### PR TITLE
feat: add guest space and API token auth support

### DIFF
--- a/src/cli/commands/dump.ts
+++ b/src/cli/commands/dump.ts
@@ -16,6 +16,7 @@ export default define({
       const client = new KintoneRestAPIClient({
         baseUrl: config.baseUrl,
         auth: buildKintoneAuth(config.auth),
+        guestSpaceId: config.guestSpaceId,
       });
 
       const s = p.spinner();

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -6,6 +6,7 @@ const CliConfigSchema = v.object({
   KINTONE_USERNAME: v.optional(v.string()),
   KINTONE_PASSWORD: v.optional(v.string()),
   KINTONE_APP_ID: v.pipe(v.string(), v.nonEmpty("KINTONE_APP_ID is required")),
+  KINTONE_GUEST_SPACE_ID: v.optional(v.string()),
   SCHEMA_FILE_PATH: v.optional(v.string(), "schema.yaml"),
 });
 
@@ -15,6 +16,7 @@ export type CliConfig = {
     | { type: "apiToken"; apiToken: string | string[] }
     | { type: "password"; username: string; password: string };
   appId: string;
+  guestSpaceId?: string;
   schemaFilePath: string;
 };
 
@@ -58,6 +60,12 @@ export const kintoneArgs = {
     short: "a",
     description: "kintone app ID (overrides KINTONE_APP_ID env var)",
   },
+  "guest-space-id": {
+    type: "string" as const,
+    short: "g",
+    description:
+      "kintone guest space ID (overrides KINTONE_GUEST_SPACE_ID env var)",
+  },
   "schema-file": {
     type: "string" as const,
     short: "f",
@@ -71,6 +79,7 @@ export function resolveConfig(cliValues: {
   password?: string;
   "api-token"?: string;
   "app-id"?: string;
+  "guest-space-id"?: string;
   "schema-file"?: string;
 }): CliConfig {
   const result = v.safeParse(CliConfigSchema, {
@@ -82,6 +91,10 @@ export function resolveConfig(cliValues: {
     KINTONE_PASSWORD:
       cliValues.password ?? process.env.KINTONE_PASSWORD ?? undefined,
     KINTONE_APP_ID: cliValues["app-id"] ?? process.env.KINTONE_APP_ID ?? "",
+    KINTONE_GUEST_SPACE_ID:
+      cliValues["guest-space-id"] ??
+      process.env.KINTONE_GUEST_SPACE_ID ??
+      undefined,
     SCHEMA_FILE_PATH: cliValues["schema-file"] ?? process.env.SCHEMA_FILE_PATH,
   });
 
@@ -102,6 +115,7 @@ export function resolveConfig(cliValues: {
     baseUrl: `https://${output.KINTONE_DOMAIN}`,
     auth,
     appId: output.KINTONE_APP_ID,
+    guestSpaceId: output.KINTONE_GUEST_SPACE_ID,
     schemaFilePath: output.SCHEMA_FILE_PATH,
   };
 }

--- a/src/core/application/container/cli.ts
+++ b/src/core/application/container/cli.ts
@@ -10,6 +10,7 @@ export type CliContainerConfig = {
   baseUrl: string;
   auth: CliConfig["auth"];
   appId: string;
+  guestSpaceId?: string;
   schemaFilePath: string;
 };
 
@@ -17,6 +18,7 @@ export function createCliContainer(config: CliContainerConfig): Container {
   const client = new KintoneRestAPIClient({
     baseUrl: config.baseUrl,
     auth: buildKintoneAuth(config.auth),
+    guestSpaceId: config.guestSpaceId,
   });
 
   return {


### PR DESCRIPTION
## Summary
- Add guest space support via `--guest-space-id` / `-g` CLI option and `KINTONE_GUEST_SPACE_ID` environment variable
- Add `KINTONE_API_TOKEN` authentication support (API token takes priority over username/password when both are set)
- Update CI workflows to use latest action versions and pnpm

## Test plan
- [ ] Verify guest space app access works with `--guest-space-id` option
- [ ] Verify guest space app access works with `KINTONE_GUEST_SPACE_ID` env var
- [ ] Verify non-guest-space apps still work without the option
- [ ] Verify API token authentication with single token
- [ ] Verify API token authentication with comma-separated multiple tokens
- [ ] Verify username/password authentication still works
- [ ] Verify API token takes priority when both auth methods are configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)