### PR TITLE
fix: normalize defaultValue type for single-select fields

### DIFF
--- a/spec/domains/formSchema.md
+++ b/spec/domains/formSchema.md
@@ -204,9 +204,9 @@ type SelectionOption = Readonly<{
   index: string;
 }>;
 
-type SelectionFieldDefinition = FieldDefinitionBase &
+type MultiValueSelectionFieldDefinition = FieldDefinitionBase &
   Readonly<{
-    type: "CHECK_BOX" | "RADIO_BUTTON" | "MULTI_SELECT" | "DROP_DOWN";
+    type: "CHECK_BOX" | "MULTI_SELECT";
     properties: Readonly<{
       required?: boolean;
       defaultValue?: readonly string[];
@@ -214,7 +214,25 @@ type SelectionFieldDefinition = FieldDefinitionBase &
       align?: "HORIZONTAL" | "VERTICAL";
     }>;
   }>;
+
+type SingleValueSelectionFieldDefinition = FieldDefinitionBase &
+  Readonly<{
+    type: "RADIO_BUTTON" | "DROP_DOWN";
+    properties: Readonly<{
+      required?: boolean;
+      defaultValue?: string;
+      options: Readonly<Record<string, SelectionOption>>;
+      align?: "HORIZONTAL" | "VERTICAL";
+    }>;
+  }>;
+
+type SelectionFieldDefinition =
+  | MultiValueSelectionFieldDefinition
+  | SingleValueSelectionFieldDefinition;
 ```
+
+- **CHECK_BOX / MULTI_SELECT**（複数選択）: `defaultValue` は文字列の配列
+- **RADIO_BUTTON / DROP_DOWN**（単一選択）: `defaultValue` は文字列
 
 #### 日時系フィールド
 

--- a/spec/sample_schema.json
+++ b/spec/sample_schema.json
@@ -182,7 +182,7 @@
       "label": "優先度",
       "properties": {
         "required": true,
-        "defaultValue": ["中"],
+        "defaultValue": "中",
         "options": {
           "高": { "label": "高", "index": "0" },
           "中": { "label": "中", "index": "1" },
@@ -223,7 +223,7 @@
       "label": "ステータス",
       "properties": {
         "required": true,
-        "defaultValue": ["未着手"],
+        "defaultValue": "未着手",
         "options": {
           "未着手": { "label": "未着手", "index": "0" },
           "進行中": { "label": "進行中", "index": "1" },

--- a/spec/sample_schema.yaml
+++ b/spec/sample_schema.yaml
@@ -193,8 +193,7 @@ layout:
         label: 優先度
         size: { width: "200" }
         required: true
-        defaultValue:
-          - 中
+        defaultValue: 中
         options:
           高: { label: 高, index: "0" }
           中: { label: 中, index: "1" }
@@ -232,8 +231,7 @@ layout:
         label: ステータス
         size: { width: "200" }
         required: true
-        defaultValue:
-          - 未着手
+        defaultValue: 未着手
         options:
           未着手: { label: 未着手, index: "0" }
           進行中: { label: 進行中, index: "1" }

--- a/spec/schema.md
+++ b/spec/schema.md
@@ -244,13 +244,11 @@ size:
 | `HOUR_MINUTE` | 時間:分 |
 | `DAY_HOUR_MINUTE` | 日 時間:分 |
 
-### CHECK_BOX / RADIO_BUTTON / MULTI_SELECT / DROP_DOWN（選択系）
-
-4つの選択系フィールドは同じプロパティ構造を持つ。
+### CHECK_BOX / MULTI_SELECT（複数選択系）
 
 ```yaml
 - code: field_code
-  type: CHECK_BOX      # または RADIO_BUTTON / MULTI_SELECT / DROP_DOWN
+  type: CHECK_BOX      # または MULTI_SELECT
   label: ラベル
   size: { width: "300" }
   required: true
@@ -269,6 +267,31 @@ size:
 | `defaultValue` | string[] | No | デフォルト選択値の配列 |
 | `options` | Record<string, SelectionOption> | Yes | 選択肢の定義 |
 | `align` | `"HORIZONTAL"` \| `"VERTICAL"` | No | 選択肢の配置方向 |
+
+### RADIO_BUTTON / DROP_DOWN（単一選択系）
+
+```yaml
+- code: field_code
+  type: RADIO_BUTTON   # または DROP_DOWN
+  label: ラベル
+  size: { width: "300" }
+  required: true
+  defaultValue: 選択肢A
+  options:
+    選択肢A: { label: 選択肢A, index: "0" }
+    選択肢B: { label: 選択肢B, index: "1" }
+    選択肢C: { label: 選択肢C, index: "2" }
+  align: HORIZONTAL
+```
+
+| プロパティ | 型 | 必須 | 説明 |
+| --- | --- | --- | --- |
+| `required` | boolean | No | 必須フィールド |
+| `defaultValue` | string | No | デフォルト選択値（文字列） |
+| `options` | Record<string, SelectionOption> | Yes | 選択肢の定義 |
+| `align` | `"HORIZONTAL"` \| `"VERTICAL"` | No | 選択肢の配置方向 |
+
+> **注意**: YAML で配列構文（`- value`）を使用した場合でも、パーサーが自動的に文字列に正規化します。
 
 **SelectionOption**:
 

--- a/src/core/adapters/kintone/__tests__/formConfigurator.test.ts
+++ b/src/core/adapters/kintone/__tests__/formConfigurator.test.ts
@@ -213,6 +213,66 @@ describe("KintoneFormConfigurator", () => {
       );
     });
 
+    it("RADIO_BUTTON フィールドを取得すると defaultValue が文字列として保持される", async () => {
+      const client = createMockClient({
+        getFormFields: () =>
+          Promise.resolve({
+            properties: {
+              priority: {
+                type: "RADIO_BUTTON",
+                code: "priority",
+                label: "優先度",
+                required: true,
+                defaultValue: "中",
+                options: {
+                  高: { label: "高", index: "0" },
+                  中: { label: "中", index: "1" },
+                  低: { label: "低", index: "2" },
+                },
+                align: "HORIZONTAL",
+              },
+            },
+          }),
+      });
+      const adapter = new KintoneFormConfigurator(client, APP_ID);
+      const fields = await adapter.getFields();
+
+      const field = fields.get("priority" as FieldCode);
+      expect(field?.type).toBe("RADIO_BUTTON");
+      if (field?.type === "RADIO_BUTTON") {
+        expect(field.properties.defaultValue).toBe("中");
+        expect(field.properties.required).toBe(true);
+        expect(field.properties.align).toBe("HORIZONTAL");
+      }
+    });
+
+    it("RADIO_BUTTON の defaultValue が配列で返された場合、文字列に正規化される", async () => {
+      const client = createMockClient({
+        getFormFields: () =>
+          Promise.resolve({
+            properties: {
+              priority: {
+                type: "RADIO_BUTTON",
+                code: "priority",
+                label: "優先度",
+                defaultValue: ["中"],
+                options: {
+                  高: { label: "高", index: "0" },
+                  中: { label: "中", index: "1" },
+                },
+              },
+            },
+          }),
+      });
+      const adapter = new KintoneFormConfigurator(client, APP_ID);
+      const fields = await adapter.getFields();
+
+      const field = fields.get("priority" as FieldCode);
+      if (field?.type === "RADIO_BUTTON") {
+        expect(field.properties.defaultValue).toBe("中");
+      }
+    });
+
     it("USER_SELECT フィールドを取得すると defaultValue と entities が保持される", async () => {
       const client = createMockClient({
         getFormFields: () =>

--- a/src/core/adapters/kintone/formConfigurator.ts
+++ b/src/core/adapters/kintone/formConfigurator.ts
@@ -141,6 +141,21 @@ function fromKintoneProperty(prop: KintoneFieldProperty): FieldDefinition {
     );
   }
 
+  // Normalize defaultValue for selection fields
+  if (type === "RADIO_BUTTON" || type === "DROP_DOWN") {
+    if (rest.defaultValue !== undefined && Array.isArray(rest.defaultValue)) {
+      const arr = rest.defaultValue as string[];
+      rest.defaultValue = arr.length > 0 ? String(arr[0]) : "";
+    }
+  } else if (type === "CHECK_BOX" || type === "MULTI_SELECT") {
+    if (
+      rest.defaultValue !== undefined &&
+      typeof rest.defaultValue === "string"
+    ) {
+      rest.defaultValue = rest.defaultValue === "" ? [] : [rest.defaultValue];
+    }
+  }
+
   return { ...base, type, properties: rest } as FieldDefinition;
 }
 

--- a/src/core/domain/formSchema/services/__tests__/diffDetector.test.ts
+++ b/src/core/domain/formSchema/services/__tests__/diffDetector.test.ts
@@ -444,6 +444,40 @@ describe("DiffDetector", () => {
       expect(diff.summary.modified).toBe(1);
     });
 
+    it("RADIO_BUTTON の defaultValue 文字列が異なる場合、modified として検出される", () => {
+      const before = makeField("f", "RADIO_BUTTON", "RB", {
+        defaultValue: "A",
+        options: {
+          A: { label: "A", index: "0" },
+          B: { label: "B", index: "1" },
+        },
+      });
+      const after = makeField("f", "RADIO_BUTTON", "RB", {
+        defaultValue: "B",
+        options: {
+          A: { label: "A", index: "0" },
+          B: { label: "B", index: "1" },
+        },
+      });
+      const schema = makeSchema([after]);
+      const current = makeFieldMap([before]);
+
+      const diff = DiffDetector.detect(schema, current);
+      expect(diff.summary.modified).toBe(1);
+    });
+
+    it("RADIO_BUTTON の defaultValue が同一文字列の場合、差分なしとなる", () => {
+      const field = makeField("f", "RADIO_BUTTON", "RB", {
+        defaultValue: "A",
+        options: { A: { label: "A", index: "0" } },
+      });
+      const schema = makeSchema([field]);
+      const current = makeFieldMap([field]);
+
+      const diff = DiffDetector.detect(schema, current);
+      expect(diff.isEmpty).toBe(true);
+    });
+
     it("配列プロパティが異なる長さの場合、modified として検出される", () => {
       const before = makeField("f", "CHECK_BOX", "CB", {
         defaultValue: ["A"],

--- a/src/core/domain/formSchema/services/__tests__/schemaParser.test.ts
+++ b/src/core/domain/formSchema/services/__tests__/schemaParser.test.ts
@@ -1011,9 +1011,50 @@ layout:
       expect(field?.type).toBe("RADIO_BUTTON");
       if (field?.type === "RADIO_BUTTON") {
         expect(field.properties.required).toBe(true);
-        expect(field.properties.defaultValue).toEqual(["中"]);
+        expect(field.properties.defaultValue).toBe("中");
         expect(field.properties.align).toBe("VERTICAL");
         expect(Object.keys(field.properties.options)).toHaveLength(3);
+      }
+    });
+
+    it("RADIO_BUTTON の defaultValue を文字列で指定するとそのまま保持される", () => {
+      const yaml = `
+layout:
+  - type: ROW
+    fields:
+      - code: priority
+        type: RADIO_BUTTON
+        label: 優先度
+        defaultValue: 中
+        options:
+          高: { label: 高, index: "0" }
+          中: { label: 中, index: "1" }
+          低: { label: 低, index: "2" }
+`;
+      const schema = SchemaParser.parse(yaml);
+      const field = schema.fields.get("priority" as FieldCode);
+      expect(field?.type).toBe("RADIO_BUTTON");
+      if (field?.type === "RADIO_BUTTON") {
+        expect(field.properties.defaultValue).toBe("中");
+      }
+    });
+
+    it("RADIO_BUTTON の defaultValue が空配列の場合は空文字列に正規化される", () => {
+      const yaml = `
+layout:
+  - type: ROW
+    fields:
+      - code: priority
+        type: RADIO_BUTTON
+        label: 優先度
+        defaultValue: []
+        options:
+          高: { label: 高, index: "0" }
+`;
+      const schema = SchemaParser.parse(yaml);
+      const field = schema.fields.get("priority" as FieldCode);
+      if (field?.type === "RADIO_BUTTON") {
+        expect(field.properties.defaultValue).toBe("");
       }
     });
 
@@ -1061,11 +1102,31 @@ layout:
       expect(field?.type).toBe("DROP_DOWN");
       if (field?.type === "DROP_DOWN") {
         expect(field.properties.required).toBe(true);
-        expect(field.properties.defaultValue).toEqual(["未着手"]);
+        expect(field.properties.defaultValue).toBe("未着手");
         expect(field.properties.options).toEqual({
           未着手: { label: "未着手", index: "0" },
           完了: { label: "完了", index: "1" },
         });
+      }
+    });
+
+    it("DROP_DOWN の defaultValue を文字列で指定するとそのまま保持される", () => {
+      const yaml = `
+layout:
+  - type: ROW
+    fields:
+      - code: status
+        type: DROP_DOWN
+        label: ステータス
+        defaultValue: 未着手
+        options:
+          未着手: { label: 未着手, index: "0" }
+          完了: { label: 完了, index: "1" }
+`;
+      const schema = SchemaParser.parse(yaml);
+      const field = schema.fields.get("status" as FieldCode);
+      if (field?.type === "DROP_DOWN") {
+        expect(field.properties.defaultValue).toBe("未着手");
       }
     });
 

--- a/src/core/domain/formSchema/services/schemaParser.ts
+++ b/src/core/domain/formSchema/services/schemaParser.ts
@@ -236,15 +236,38 @@ function buildFieldDefinition(
         type: fieldType,
         properties: properties as FieldPropsOf<"CALC">,
       };
-    case "CHECK_BOX":
     case "RADIO_BUTTON":
-    case "MULTI_SELECT":
-    case "DROP_DOWN":
+    case "DROP_DOWN": {
+      const props = { ...properties };
+      if (
+        props.defaultValue !== undefined &&
+        Array.isArray(props.defaultValue)
+      ) {
+        const arr = props.defaultValue as string[];
+        props.defaultValue = arr.length > 0 ? String(arr[0]) : "";
+      }
       return {
         ...base,
         type: fieldType,
-        properties: properties as FieldPropsOf<"CHECK_BOX">,
+        properties: props as FieldPropsOf<"RADIO_BUTTON">,
       };
+    }
+    case "CHECK_BOX":
+    case "MULTI_SELECT": {
+      const props = { ...properties };
+      if (
+        props.defaultValue !== undefined &&
+        typeof props.defaultValue === "string"
+      ) {
+        props.defaultValue =
+          props.defaultValue === "" ? [] : [props.defaultValue];
+      }
+      return {
+        ...base,
+        type: fieldType,
+        properties: props as FieldPropsOf<"CHECK_BOX">,
+      };
+    }
     case "DATE":
       return {
         ...base,

--- a/src/core/domain/formSchema/valueObject.ts
+++ b/src/core/domain/formSchema/valueObject.ts
@@ -153,9 +153,9 @@ export type CalcFieldDefinition = FieldDefinitionBase &
   }>;
 
 // Selection fields
-export type SelectionFieldDefinition = FieldDefinitionBase &
+export type MultiValueSelectionFieldDefinition = FieldDefinitionBase &
   Readonly<{
-    type: "CHECK_BOX" | "RADIO_BUTTON" | "MULTI_SELECT" | "DROP_DOWN";
+    type: "CHECK_BOX" | "MULTI_SELECT";
     properties: Readonly<{
       required?: boolean;
       defaultValue?: readonly string[];
@@ -163,6 +163,21 @@ export type SelectionFieldDefinition = FieldDefinitionBase &
       align?: "HORIZONTAL" | "VERTICAL";
     }>;
   }>;
+
+export type SingleValueSelectionFieldDefinition = FieldDefinitionBase &
+  Readonly<{
+    type: "RADIO_BUTTON" | "DROP_DOWN";
+    properties: Readonly<{
+      required?: boolean;
+      defaultValue?: string;
+      options: Readonly<Record<string, SelectionOption>>;
+      align?: "HORIZONTAL" | "VERTICAL";
+    }>;
+  }>;
+
+export type SelectionFieldDefinition =
+  | MultiValueSelectionFieldDefinition
+  | SingleValueSelectionFieldDefinition;
 
 // Date/Time fields
 export type DateFieldDefinition = FieldDefinitionBase &
@@ -275,7 +290,8 @@ export type FieldDefinition =
   | RichTextFieldDefinition
   | NumberFieldDefinition
   | CalcFieldDefinition
-  | SelectionFieldDefinition
+  | MultiValueSelectionFieldDefinition
+  | SingleValueSelectionFieldDefinition
   | DateFieldDefinition
   | TimeFieldDefinition
   | DateTimeFieldDefinition


### PR DESCRIPTION
## Summary
- **RADIO_BUTTON / DROP_DOWN** の `defaultValue` 型を `string[]` から `string` に修正し、kintone API の `CB_IJ01` エラーを解消
- `SelectionFieldDefinition` を `MultiValueSelectionFieldDefinition`（CHECK_BOX / MULTI_SELECT）と `SingleValueSelectionFieldDefinition`（RADIO_BUTTON / DROP_DOWN）に分割
- スキーマパーサーと API アダプターの両方で `defaultValue` の型を自動正規化（YAML で配列構文を使っても正しく動作）

## Test plan
- [x] `pnpm typecheck` パス
- [x] `pnpm lint:fix` パス
- [x] `pnpm test` 全441テストパス
- [ ] RADIO_BUTTON / DROP_DOWN の `defaultValue` を配列構文で書いた YAML で `migrate` / `override` が成功することを確認
- [ ] CHECK_BOX / MULTI_SELECT の `defaultValue` が従来通り配列で動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)