### PR TITLE
feat: make domain optional in project config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ A project config file (`kintone-migrator.yaml`) enables managing multiple kinton
 
 ```yaml
 # Shared connection settings (can be overridden per app)
+# domain can also be set via KINTONE_DOMAIN env var or --domain CLI arg
 domain: example.cybozu.com
 auth:
   apiToken: "shared-token"

--- a/spec/domains/projectConfig.md
+++ b/spec/domains/projectConfig.md
@@ -95,7 +95,8 @@ YAML形式のプロジェクト設定をパースし、バリデーションを�
 バリデーション:
 - `apps` は必須で空でないオブジェクト
 - 各アプリに `appId` が必須
-- `domain` と `auth` はトップレベルまたはアプリ単位で最低1つ必要
+- `auth` はトップレベルまたはアプリ単位で最低1つ必要
+- `domain` はCLI引数・環境変数・設定ファイルのいずれかで実行時に解決される（設定ファイル内では任意）
 
 ## エラーコード
 
@@ -105,5 +106,4 @@ YAML形式のプロジェクト設定をパースし、バリデーションを�
 | UNKNOWN_DEPENDENCY | 存在しないアプリへの依存参照 |
 | EMPTY_APPS | apps が空 |
 | EMPTY_APP_ID | appId が空 |
-| MISSING_DOMAIN | domain が未設定 |
 | MISSING_AUTH | auth が未設定 |

--- a/spec/projectConfig.md
+++ b/spec/projectConfig.md
@@ -36,7 +36,7 @@ apps:
 
 | フィールド | 型 | 必須 | 説明 |
 | --- | --- | --- | --- |
-| `domain` | string | 条件付き | kintoneドメイン。トップレベルまたは各アプリで最低1つ必要 |
+| `domain` | string | - | kintoneドメイン。CLI引数・環境変数・設定ファイルのいずれかで指定 |
 | `auth` | object | 条件付き | 認証設定。トップレベルまたは各アプリで最低1つ必要 |
 | `auth.apiToken` | string | - | APIトークン認証 |
 | `auth.username` | string | - | パスワード認証のユーザー名 |
@@ -62,7 +62,7 @@ apps:
 - 各アプリに `appId`（非空文字列）が必須
 - `schemaFile` 省略時は `schemas/<appName>.yaml` がデフォルト値
 - `dependsOn` の参照先は同一設定ファイル内のアプリ名であること
-- `domain` はトップレベルまたはアプリ単位で最低1つ必要
+- `domain` はCLI引数（`--domain`）、環境変数（`KINTONE_DOMAIN`）、または設定ファイル（トップレベル/アプリ単位）のいずれかで解決される
 - `auth` はトップレベルまたはアプリ単位で最低1つ必要
 - 循環依存は `--all` による実行順序解決時に検出してエラー
 
@@ -107,5 +107,5 @@ Kahn's algorithm（BFSトポロジカルソート）で実行順序を決定す�
 | 存在しない依存先参照 | BusinessRuleError | UNKNOWN_DEPENDENCY |
 | `apps` が空 | BusinessRuleError | EMPTY_APPS |
 | `appId` が空 | BusinessRuleError | EMPTY_APP_ID |
-| `domain` が未設定 | BusinessRuleError | MISSING_DOMAIN |
 | `auth` が未設定 | BusinessRuleError | MISSING_AUTH |
+| `domain` が未設定（実行時） | ValidationError | INVALID_INPUT |

--- a/src/core/domain/projectConfig/errorCode.ts
+++ b/src/core/domain/projectConfig/errorCode.ts
@@ -4,7 +4,6 @@ export const ProjectConfigErrorCode = {
   EmptyApps: "EMPTY_APPS",
   EmptyAppId: "EMPTY_APP_ID",
   EmptyAppName: "EMPTY_APP_NAME",
-  MissingDomain: "MISSING_DOMAIN",
   MissingAuth: "MISSING_AUTH",
 } as const;
 

--- a/src/core/domain/projectConfig/services/__tests__/configParser.test.ts
+++ b/src/core/domain/projectConfig/services/__tests__/configParser.test.ts
@@ -178,19 +178,16 @@ describe("parseProjectConfig", () => {
     }
   });
 
-  it("throws MissingDomain when no domain is available", () => {
-    try {
-      parseProjectConfig({
-        auth: { apiToken: "t" },
-        apps: { app1: { appId: "1" } },
-      });
-      expect.fail("Should have thrown");
-    } catch (error) {
-      expect(isBusinessRuleError(error)).toBe(true);
-      if (isBusinessRuleError(error)) {
-        expect(error.code).toBe(ProjectConfigErrorCode.MissingDomain);
-      }
-    }
+  it("parses config without domain (domain can be resolved via env vars later)", () => {
+    const config = parseProjectConfig({
+      auth: { apiToken: "t" },
+      apps: { app1: { appId: "1" } },
+    });
+
+    expect(config.domain).toBeUndefined();
+    const app1 = config.apps.get(AppName.create("app1"));
+    expect(app1?.domain).toBeUndefined();
+    expect(app1?.appId).toBe("1");
   });
 
   it("throws MissingAuth when no auth is available", () => {

--- a/src/core/domain/projectConfig/services/configParser.ts
+++ b/src/core/domain/projectConfig/services/configParser.ts
@@ -60,15 +60,7 @@ export function parseProjectConfig(raw: unknown): ProjectConfig {
       isRecord(rawAppValue.auth) ? rawAppValue.auth : undefined,
     );
     const appDomain = asOptionalString(rawAppValue.domain);
-    const resolvedDomain = appDomain ?? topLevelDomain;
     const resolvedAuth = appAuth ?? topLevelAuth;
-
-    if (!resolvedDomain) {
-      throw new BusinessRuleError(
-        ProjectConfigErrorCode.MissingDomain,
-        `App "${name}" has no domain configured (set at top-level or per-app)`,
-      );
-    }
 
     if (!resolvedAuth) {
       throw new BusinessRuleError(


### PR DESCRIPTION
## Summary
- プロジェクト設定ファイル（`kintone-migrator.yaml`）で `domain` を必須から任意に変更
- `domain` は CLI引数（`--domain`）、環境変数（`KINTONE_DOMAIN`）、設定ファイルのいずれからでも解決可能に
- `auth` のバリデーションは従来通り設定ファイル内で必須のまま

## Test plan
- [x] `pnpm typecheck` パス
- [x] `pnpm lint:fix` パス
- [x] `pnpm test` 全574テストパス
- [ ] `domain` なしの設定ファイルで `KINTONE_DOMAIN` 環境変数から動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)