### PR TITLE
fix: log error details and stack traces in multi-app batch execution

### DIFF
--- a/src/cli/handleError.ts
+++ b/src/cli/handleError.ts
@@ -6,43 +6,42 @@ import {
 } from "@/core/application/error";
 import { isBusinessRuleError } from "@/core/domain/error";
 
-export function handleCliError(error: unknown): never {
+export function logError(error: unknown): void {
   if (isBusinessRuleError(error)) {
     p.log.error(`[BusinessRuleError] ${error.code}: ${error.message}`);
     logErrorDetails(error);
-    p.outro("Failed.");
-    process.exit(1);
+    return;
   }
 
   if (isValidationError(error)) {
     p.log.error(`[ValidationError] ${error.message}`);
     logErrorDetails(error);
-    p.outro("Failed.");
-    process.exit(1);
+    return;
   }
 
   if (isSystemError(error)) {
     p.log.error(`[SystemError] ${error.code}: ${error.message}`);
     logErrorDetails(error);
-    p.outro("Failed.");
-    process.exit(1);
+    return;
   }
 
   if (isApplicationError(error)) {
     p.log.error(`[${error.name}] ${error.code}: ${error.message}`);
     logErrorDetails(error);
-    p.outro("Failed.");
-    process.exit(1);
+    return;
   }
 
   if (error instanceof Error) {
     p.log.error(`[Error] ${error.message}`);
     logErrorDetails(error);
-    p.outro("Failed.");
-    process.exit(1);
+    return;
   }
 
   p.log.error(`[Error] 予期しないエラーが発生しました: ${String(error)}`);
+}
+
+export function handleCliError(error: unknown): never {
+  logError(error);
   p.outro("Failed.");
   process.exit(1);
 }

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -4,6 +4,7 @@ import type { Container } from "@/core/application/container";
 import { deployApp } from "@/core/application/formSchema/deployApp";
 import type { DetectDiffOutput } from "@/core/application/formSchema/dto";
 import type { MultiAppResult } from "@/core/domain/projectConfig/entity";
+import { logError } from "./handleError";
 
 export function printDiffResult(result: DetectDiffOutput): void {
   const { summary } = result;
@@ -56,6 +57,9 @@ export function printMultiAppResult(result: MultiAppResult): void {
         break;
       case "failed":
         p.log.error(`  ${pc.red("\u2717")} Failed: ${r.name}`);
+        if (r.error) {
+          logError(r.error);
+        }
         break;
       case "skipped":
         p.log.warn(`  ${pc.dim("-")} Skipped: ${r.name}`);


### PR DESCRIPTION
## Summary
- マルチアプリ一括実行（`--all`）時に、失敗したアプリのエラー詳細・cause chain・スタックトレースが出力されずに握り潰されていた問題を修正
- `handleCliError` からエラーログ出力ロジックを `logError` として切り出し、`printMultiAppResult` でも再利用できるようにした
- 失敗時に「`✗ Failed: app-name`」だけでなく、エラーの種類・メッセージ・原因・スタックトレースが表示されるように

## Test plan
- [ ] `pnpm typecheck` パス確認済み
- [ ] `pnpm lint` パス確認済み
- [ ] `pnpm test` 574件全パス確認済み
- [ ] マルチアプリ実行でアプリが失敗した際にエラー詳細とスタックトレースが出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)