### PR TITLE
feat: add --yes flag to skip confirmation prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,14 @@ Applies schema file changes to the kintone form. Displays the diff and prompts f
 ```bash
 kintone-migrator migrate
 
+# Skip confirmation prompts (for CI/CD)
+kintone-migrator migrate --yes
+kintone-migrator migrate -y
+
 # Multi-app mode
 kintone-migrator migrate --app customer
 kintone-migrator migrate --all
+kintone-migrator migrate --all --yes
 ```
 
 ### `override`
@@ -104,12 +109,17 @@ Overwrites the entire kintone form with the schema file contents. Fields not def
 ```bash
 kintone-migrator override
 
+# Skip confirmation prompts (for CI/CD)
+kintone-migrator override --yes
+kintone-migrator override -y
+
 # Reset form: delete all custom fields (no schema file needed)
 kintone-migrator override --reset
 
 # Multi-app mode
 kintone-migrator override --all
 kintone-migrator override --reset --all
+kintone-migrator override --all --yes
 ```
 
 #### Override-specific arguments
@@ -117,6 +127,7 @@ kintone-migrator override --reset --all
 | CLI Argument | Description |
 |---------|------|
 | `--reset` | Reset form by deleting all custom fields. Cannot be used with `--schema-file`. In multi-app mode (`--all`), apps are reset in reverse dependency order. |
+| `--yes`, `-y` | Skip confirmation prompts. Also available on `migrate`. |
 
 ### `capture`
 

--- a/src/cli/__tests__/output.test.ts
+++ b/src/cli/__tests__/output.test.ts
@@ -248,7 +248,7 @@ describe("promptDeploy", () => {
       appDeployer: { deploy: vi.fn().mockResolvedValue(undefined) },
     };
 
-    await promptDeploy(container);
+    await promptDeploy(container, false);
 
     expect(container.appDeployer.deploy).toHaveBeenCalled();
     expect(p.log.success).toHaveBeenCalledWith(
@@ -266,7 +266,7 @@ describe("promptDeploy", () => {
       appDeployer: { deploy: vi.fn() },
     };
 
-    await promptDeploy(container);
+    await promptDeploy(container, false);
 
     expect(container.appDeployer.deploy).not.toHaveBeenCalled();
     expect(p.log.warn).toHaveBeenCalledWith(
@@ -284,11 +284,27 @@ describe("promptDeploy", () => {
       appDeployer: { deploy: vi.fn() },
     };
 
-    await promptDeploy(container);
+    await promptDeploy(container, false);
 
     expect(container.appDeployer.deploy).not.toHaveBeenCalled();
     expect(p.log.warn).toHaveBeenCalledWith(
       expect.stringContaining("運用環境には反映されていません"),
+    );
+  });
+
+  it("skipConfirm が true の場合、確認なしで deployApp が呼ばれる", async () => {
+    const container = {
+      formConfigurator: {} as never,
+      schemaStorage: {} as never,
+      appDeployer: { deploy: vi.fn().mockResolvedValue(undefined) },
+    };
+
+    await promptDeploy(container, true);
+
+    expect(p.confirm).not.toHaveBeenCalled();
+    expect(container.appDeployer.deploy).toHaveBeenCalled();
+    expect(p.log.success).toHaveBeenCalledWith(
+      expect.stringContaining("運用環境への反映が完了しました"),
     );
   });
 });

--- a/src/cli/commands/__tests__/migrate.test.ts
+++ b/src/cli/commands/__tests__/migrate.test.ts
@@ -18,6 +18,7 @@ vi.mock("@clack/prompts", () => ({
 vi.mock("@/cli/config", () => ({
   kintoneArgs: {},
   multiAppArgs: {},
+  confirmArgs: {},
   resolveConfig: vi.fn(() => ({
     baseUrl: "https://test.cybozu.com",
     username: "user",

--- a/src/cli/commands/__tests__/override.test.ts
+++ b/src/cli/commands/__tests__/override.test.ts
@@ -17,6 +17,7 @@ vi.mock("@clack/prompts", () => ({
 vi.mock("@/cli/config", () => ({
   kintoneArgs: {},
   multiAppArgs: {},
+  confirmArgs: {},
   resolveConfig: vi.fn(() => ({
     baseUrl: "https://test.cybozu.com",
     username: "user",

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -74,6 +74,14 @@ export const kintoneArgs = {
   },
 };
 
+export const confirmArgs = {
+  yes: {
+    type: "boolean" as const,
+    short: "y",
+    description: "Skip confirmation prompts",
+  },
+};
+
 export const multiAppArgs = {
   app: {
     type: "string" as const,

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -71,14 +71,21 @@ export function printMultiAppResult(result: MultiAppResult): void {
   }
 }
 
-export async function promptDeploy(container: Container): Promise<void> {
-  const shouldDeploy = await p.confirm({
-    message: "運用環境に反映しますか？",
-  });
+export async function promptDeploy(
+  container: Container,
+  skipConfirm: boolean,
+): Promise<void> {
+  if (!skipConfirm) {
+    const shouldDeploy = await p.confirm({
+      message: "運用環境に反映しますか？",
+    });
 
-  if (p.isCancel(shouldDeploy) || !shouldDeploy) {
-    p.log.warn("テスト環境に反映済みですが、運用環境には反映されていません。");
-    return;
+    if (p.isCancel(shouldDeploy) || !shouldDeploy) {
+      p.log.warn(
+        "テスト環境に反映済みですが、運用環境には反映されていません。",
+      );
+      return;
+    }
   }
 
   const ds = p.spinner();


### PR DESCRIPTION
## Summary

- `migrate` / `override` コマンドに `--yes` (`-y`) フラグを追加し、全ての確認プロンプト (`p.confirm()`) をスキップ可能にした
- CI/CD パイプラインやスクリプトからの非対話実行に対応
- `promptDeploy` にも `skipConfirm` パラメータを追加し、デプロイ確認もスキップ可能にした

## Test plan

- [x] `pnpm typecheck` パス
- [x] `pnpm lint:fix && pnpm format` パス
- [x] `pnpm test` 全581テストパス（`skipConfirm=true` のテストケース追加済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)