### PR TITLE
fix: display detailed error cause when kintone API calls fail

### DIFF
--- a/src/cli/__tests__/handleError.test.ts
+++ b/src/cli/__tests__/handleError.test.ts
@@ -173,7 +173,7 @@ describe("handleCliError", () => {
     expect(p.log.warn).toHaveBeenCalledWith(expect.stringContaining("Cause:"));
   });
 
-  it("cause に errors プロパティがある場合、Details が warn でログ出力される", () => {
+  it("cause に errors プロパティがある場合、エラー詳細が warn でログ出力される", () => {
     const cause = { errors: [{ message: "field1 is invalid" }] };
     const error = new SystemError(
       SystemErrorCode.ExternalApiError,
@@ -185,7 +185,7 @@ describe("handleCliError", () => {
 
     expect(p.log.warn).toHaveBeenCalledWith(expect.stringContaining("Cause:"));
     expect(p.log.warn).toHaveBeenCalledWith(
-      expect.stringContaining("Details:"),
+      expect.stringContaining("field1 is invalid"),
     );
   });
 


### PR DESCRIPTION
## Summary
- kintone SDK のエラー原因（`KintoneAllRecordsError` / `KintoneRestAPIError`）が正しく表示されるよう `logErrorDetails` を改善
- `String(error.cause)` の代わりに Error インスタンスなら `.message` を、プレーンオブジェクトなら `JSON.stringify` で表示
- `cause.errors` が配列の場合（`KintoneAllRecordsError`）、各エラーの message とフィールドレベルの詳細を個別に出力

## Test plan
- [x] 既存テスト 581 件全パス
- [x] typecheck / lint / format パス
- [ ] 実際に kintone API エラーが発生するケースで Cause 行にエラー詳細が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)