### PR TITLE
fix: display KintoneAllRecordsError inner API error details

### DIFF
--- a/src/cli/handleError.ts
+++ b/src/cli/handleError.ts
@@ -60,25 +60,56 @@ function formatErrorForDisplay(error: unknown): string {
 function logErrorDetails(error: Error): void {
   if (error.cause) {
     p.log.warn(`Cause: ${formatErrorForDisplay(error.cause)}`);
-    const cause = error.cause as Record<string, unknown>;
-    if (Array.isArray(cause.errors)) {
-      for (const e of cause.errors) {
-        if (e instanceof Error) {
-          p.log.warn(`  - ${e.message}`);
-          const inner = e as unknown as Record<string, unknown>;
-          if (inner.errors && typeof inner.errors === "object") {
-            p.log.warn(`    ${JSON.stringify(inner.errors, null, 2)}`);
-          }
-        } else {
-          p.log.warn(`  - ${JSON.stringify(e, null, 2)}`);
-        }
-      }
-    } else if (cause.errors && typeof cause.errors === "object") {
-      p.log.warn(`Details: ${JSON.stringify(cause.errors, null, 2)}`);
-    }
+    logNestedErrorProperties(error.cause);
   }
   if (error.stack) {
     p.log.warn(`Stack: ${error.stack}`);
+  }
+}
+
+function logNestedErrorProperties(target: unknown): void {
+  if (typeof target !== "object" || target === null) {
+    return;
+  }
+
+  const record = target as Record<string, unknown>;
+
+  // Handle `.error` (singular) property - e.g. KintoneAllRecordsError wraps KintoneRestAPIError
+  if (record.error instanceof Error) {
+    p.log.warn(`  Error: ${record.error.message}`);
+    const innerRecord = record.error as unknown as Record<string, unknown>;
+    if (innerRecord.errors && typeof innerRecord.errors === "object") {
+      p.log.warn(`  Details: ${JSON.stringify(innerRecord.errors, null, 2)}`);
+    }
+  }
+
+  // Handle `.errors` (plural) array - e.g. array of Error objects
+  if (Array.isArray(record.errors)) {
+    for (const e of record.errors) {
+      if (e instanceof Error) {
+        p.log.warn(`  - ${e.message}`);
+        const inner = e as unknown as Record<string, unknown>;
+        if (inner.errors && typeof inner.errors === "object") {
+          p.log.warn(`    ${JSON.stringify(inner.errors, null, 2)}`);
+        }
+      } else {
+        p.log.warn(`  - ${JSON.stringify(e, null, 2)}`);
+      }
+    }
+  } else if (
+    record.errors &&
+    typeof record.errors === "object" &&
+    !("error" in record)
+  ) {
+    // Handle `.errors` (plural) object - e.g. KintoneRestAPIError field-level details
+    // Skip if `.error` was already handled above to avoid duplicate output
+    p.log.warn(`Details: ${JSON.stringify(record.errors, null, 2)}`);
+  }
+
+  // Recursively follow the cause chain
+  if (target instanceof Error && target.cause) {
+    p.log.warn(`  Caused by: ${formatErrorForDisplay(target.cause)}`);
+    logNestedErrorProperties(target.cause);
   }
 }
 


### PR DESCRIPTION
## Summary
- `KintoneAllRecordsError`が`.error`（単数）プロパティで`KintoneRestAPIError`をラップしているが、`logErrorDetails`が`.errors`（複数）しかチェックしていなかったため、seedデータ反映時のAPIエラー詳細（ステータスコード、フィールドレベルのバリデーションエラー等）が表示されていなかった
- `.error`（単数）プロパティの探索と、causeチェーンの再帰的な追跡を追加
- 対応するテストケースを追加

## Test plan
- [x] `pnpm test` 全431件パス
- [x] `pnpm typecheck` パス
- [x] `pnpm lint:fix` パス
- [x] `pnpm format` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)