### PR TITLE
feat: add --clean option to seed command

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,12 +178,17 @@ Applies seed data (records) to a kintone app using upsert (insert or update base
 kintone-migrator seed
 kintone-migrator seed -s my-seed.yaml
 
+# Clean apply: delete all existing records, then apply seed data
+kintone-migrator seed --clean
+kintone-migrator seed --clean --yes
+
 # Capture records from a kintone app
 kintone-migrator seed --capture --key-field customer_code
 kintone-migrator seed --capture --key-field customer_code -s seeds/customer.yaml
 
 # Multi-app mode
 kintone-migrator seed --all
+kintone-migrator seed --clean --all --yes
 kintone-migrator seed --capture --key-field code --all
 kintone-migrator seed --app customer
 ```
@@ -193,8 +198,10 @@ kintone-migrator seed --app customer
 | CLI Argument | Description |
 |---------|------|
 | `--capture` | Capture mode: fetch records from kintone and save to seed file |
+| `--clean` | Delete all existing records before applying seed data. Cannot be used with `--capture`. Prompts for confirmation unless `--yes` is specified. |
 | `--key-field`, `-k` | Key field code for upsert (required for `--capture`) |
 | `--seed-file`, `-s` | Seed file path (default: `seed.yaml`) |
+| `--yes`, `-y` | Skip confirmation prompts (for `--clean` mode) |
 
 ### `customize`
 

--- a/spec/seed.md
+++ b/spec/seed.md
@@ -36,6 +36,27 @@ records:
     priority: "low"
 ```
 
+### Cleanモード
+
+CLIで `--clean` フラグを付けて実行すると、既存レコードをすべて削除してからシードデータを適用する。Upsert計画はスキップされ、全レコードがInsert（追加）として処理される。`key` の有無に関わらず動作する。
+
+```bash
+kintone-migrator seed --clean
+kintone-migrator seed --clean --yes   # 確認プロンプトをスキップ
+```
+
+#### Cleanモードのフロー
+
+1. `recordManager.deleteAllRecords()` で既存レコードを全削除
+2. シードファイルの全レコードを `recordManager.addRecords()` で追加
+3. `UpsertSeedOutput` を返却（`deleted` に削除件数が含まれる）
+
+#### 注意事項
+
+- `--clean` と `--capture` は排他的であり、同時に指定した場合は `ValidationError` となる
+- 破壊的操作のため、デフォルトで確認プロンプトが表示される（`--yes` でスキップ可能）
+- Multi-Appモード（`--all`）では、1回の確認プロンプトで全アプリの実行を開始する
+
 ## フィールド定義
 
 | フィールド | 型 | 必須 | 説明 |

--- a/spec/usecases/seedData.md
+++ b/spec/usecases/seedData.md
@@ -2,9 +2,17 @@
 
 ## upsertSeed
 
-シードファイルのデータをkintoneアプリにUpsert（存在すれば更新、なければ追加）する。
+シードファイルのデータをkintoneアプリにUpsert（存在すれば更新、なければ追加）する。`clean` オプションを指定すると、既存レコードを全削除してからシードデータを全追加する。
 
-### フロー
+### 入力
+
+```typescript
+type UpsertSeedInput = {
+  clean?: boolean;
+};
+```
+
+### フロー（通常モード）
 
 1. `seedStorage.get()` でシードファイルを読み込む
 2. `SeedParser.parse()` でパース・バリデーション
@@ -14,7 +22,16 @@
 6. `RecordConverter.toKintoneRecord()` でシードレコードをkintone形式に変換
 7. `recordManager.addRecords()` で新規レコードを追加
 8. `recordManager.updateRecords()` で既存レコードを更新
-9. `UpsertSeedOutput` を返却
+9. `UpsertSeedOutput` を返却（`deleted: 0`）
+
+### フロー（cleanモード: `input.clean === true`）
+
+1. `seedStorage.get()` でシードファイルを読み込む
+2. `SeedParser.parse()` でパース・バリデーション
+3. `recordManager.deleteAllRecords()` で既存レコードを全削除
+4. `RecordConverter.toKintoneRecord()` でシードレコードをkintone形式に変換
+5. `recordManager.addRecords()` で全レコードを追加（Upsert計画はスキップ）
+6. `UpsertSeedOutput` を返却（`deleted` に削除件数が含まれる）
 
 ### 出力
 
@@ -23,6 +40,7 @@ type UpsertSeedOutput = {
   added: number;
   updated: number;
   unchanged: number;
+  deleted: number;
   total: number;
 };
 ```

--- a/src/core/adapters/empty/recordManager.ts
+++ b/src/core/adapters/empty/recordManager.ts
@@ -35,4 +35,11 @@ export class EmptyRecordManager implements RecordManager {
       "EmptyRecordManager.updateRecords not implemented",
     );
   }
+
+  async deleteAllRecords(): Promise<{ deletedCount: number }> {
+    throw new SystemError(
+      SystemErrorCode.InternalServerError,
+      "EmptyRecordManager.deleteAllRecords not implemented",
+    );
+  }
 }

--- a/src/core/application/__tests__/helpers.ts
+++ b/src/core/application/__tests__/helpers.ts
@@ -483,6 +483,14 @@ export class InMemoryRecordManager implements RecordManager {
     }
   }
 
+  async deleteAllRecords(): Promise<{ deletedCount: number }> {
+    this.callLog.push("deleteAllRecords");
+    this.checkFail("deleteAllRecords");
+    const deletedCount = this.records.length;
+    this.records = [];
+    return { deletedCount };
+  }
+
   setRecords(records: KintoneRecordForResponse[]): void {
     this.records = [...records];
   }

--- a/src/core/application/seedData/dto.ts
+++ b/src/core/application/seedData/dto.ts
@@ -2,6 +2,7 @@ export type UpsertSeedOutput = {
   readonly added: number;
   readonly updated: number;
   readonly unchanged: number;
+  readonly deleted: number;
   readonly total: number;
 };
 

--- a/src/core/domain/seedData/ports/recordManager.ts
+++ b/src/core/domain/seedData/ports/recordManager.ts
@@ -16,4 +16,5 @@ export interface RecordManager {
   updateRecords(
     records: readonly { id: string; record: KintoneRecordForParameter }[],
   ): Promise<void>;
+  deleteAllRecords(): Promise<{ deletedCount: number }>;
 }


### PR DESCRIPTION
## Summary
- `seed`コマンドに`--clean`オプションを追加。既存レコードを全削除してからシードデータを適用するclean applyモードを実装
- 破壊的操作のため確認プロンプトを表示（`--yes`フラグでスキップ可能）
- `RecordManager`ポートに`deleteAllRecords()`メソッドを追加し、kintone/emptyアダプターに実装
- `UpsertSeedOutput`に`deleted`フィールドを追加
- cleanモードのテストケース（5件）を追加

## Test plan
- [x] `pnpm typecheck` パス
- [x] `pnpm lint:fix` パス
- [x] `pnpm format` パス
- [x] `pnpm test` パス（全663テスト通過）
- [ ] `kintone-migrator seed --clean` で既存レコード削除→シード適用を確認
- [ ] `kintone-migrator seed --clean --yes` で確認プロンプトがスキップされることを確認
- [ ] `kintone-migrator seed --clean --all --yes` でマルチアプリモードの動作確認
- [ ] `--capture`と`--clean`の同時指定でValidationErrorを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)