### PR TITLE
fix: add deploy step to field-acl command

### DIFF
--- a/src/cli/commands/__tests__/fieldAcl.test.ts
+++ b/src/cli/commands/__tests__/fieldAcl.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+const mockDeploy = vi.fn();
+
 vi.mock("@clack/prompts", () => ({
   spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn() })),
   log: {
@@ -8,7 +10,9 @@ vi.mock("@clack/prompts", () => ({
     warn: vi.fn(),
     error: vi.fn(),
   },
+  confirm: vi.fn(() => true),
   outro: vi.fn(),
+  isCancel: vi.fn(() => false),
 }));
 
 vi.mock("@/cli/fieldAclConfig", () => ({
@@ -38,8 +42,14 @@ vi.mock("@/cli/output", () => ({
   printAppHeader: vi.fn(),
 }));
 
+vi.mock("@/cli/config", () => ({
+  confirmArgs: {},
+}));
+
 vi.mock("@/core/application/container/cli", () => ({
-  createFieldPermissionCliContainer: vi.fn(() => ({})),
+  createFieldPermissionCliContainer: vi.fn(() => ({
+    appDeployer: { deploy: mockDeploy },
+  })),
 }));
 
 vi.mock("@/core/application/fieldPermission/applyFieldPermission");
@@ -67,6 +77,37 @@ describe("field-acl コマンド", () => {
     expect(p.log.success).toHaveBeenCalledWith(
       expect.stringContaining("successfully"),
     );
+  });
+
+  it("適用後にデプロイの確認が行われる", async () => {
+    vi.mocked(applyFieldPermission).mockResolvedValue(undefined);
+    vi.mocked(p.confirm).mockResolvedValue(true);
+
+    await command.run({ values: {} } as never);
+
+    expect(p.confirm).toHaveBeenCalled();
+    expect(mockDeploy).toHaveBeenCalled();
+  });
+
+  it("デプロイをキャンセルした場合、警告メッセージが表示される", async () => {
+    vi.mocked(applyFieldPermission).mockResolvedValue(undefined);
+    vi.mocked(p.confirm).mockResolvedValue(false);
+
+    await command.run({ values: {} } as never);
+
+    expect(mockDeploy).not.toHaveBeenCalled();
+    expect(p.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("運用環境には反映されていません"),
+    );
+  });
+
+  it("--yes フラグで確認をスキップしてデプロイされる", async () => {
+    vi.mocked(applyFieldPermission).mockResolvedValue(undefined);
+
+    await command.run({ values: { yes: true } } as never);
+
+    expect(p.confirm).not.toHaveBeenCalled();
+    expect(mockDeploy).toHaveBeenCalled();
   });
 
   it("エラー発生時にhandleCliErrorで処理される", async () => {

--- a/src/core/application/__tests__/helpers.ts
+++ b/src/core/application/__tests__/helpers.ts
@@ -593,12 +593,14 @@ export function setupTestSeedContainer(): () => TestSeedContainer {
 export type TestFieldPermissionContainer = FieldPermissionContainer & {
   fieldPermissionConfigurator: InMemoryFieldPermissionConfigurator;
   fieldPermissionStorage: InMemoryFieldPermissionStorage;
+  appDeployer: InMemoryAppDeployer;
 };
 
 export function createTestFieldPermissionContainer(): TestFieldPermissionContainer {
   return {
     fieldPermissionConfigurator: new InMemoryFieldPermissionConfigurator(),
     fieldPermissionStorage: new InMemoryFieldPermissionStorage(),
+    appDeployer: new InMemoryAppDeployer(),
   };
 }
 

--- a/src/core/application/container/cli.ts
+++ b/src/core/application/container/cli.ts
@@ -102,6 +102,7 @@ export function createFieldPermissionCliContainer(
     fieldPermissionStorage: new LocalFileFieldPermissionStorage(
       config.fieldAclFilePath,
     ),
+    appDeployer: new KintoneAppDeployer(client, config.appId),
   };
 }
 

--- a/src/core/application/container/fieldPermission.ts
+++ b/src/core/application/container/fieldPermission.ts
@@ -1,9 +1,11 @@
 import type { FieldPermissionConfigurator } from "@/core/domain/fieldPermission/ports/fieldPermissionConfigurator";
 import type { FieldPermissionStorage } from "@/core/domain/fieldPermission/ports/fieldPermissionStorage";
+import type { AppDeployer } from "@/core/domain/ports/appDeployer";
 
 export type FieldPermissionContainer = {
   fieldPermissionConfigurator: FieldPermissionConfigurator;
   fieldPermissionStorage: FieldPermissionStorage;
+  appDeployer: AppDeployer;
 };
 
 export type FieldPermissionServiceArgs<T = undefined> = T extends undefined


### PR DESCRIPTION
## Summary
- `field-acl` コマンドでフィールドアクセス権を更新した後、運用環境へのデプロイが行われていなかった問題を修正
- `FieldPermissionContainer` に `appDeployer` を追加し、`customize` コマンドと同じパターンで `confirmAndDeploy` フローを実装
- `--yes` フラグによる確認スキップにも対応

## Test plan
- [x] 既存テスト全780件パス
- [x] デプロイ確認・実行のテスト追加
- [x] デプロイキャンセル時の警告メッセージ表示テスト追加
- [x] `--yes` フラグでの確認スキップテスト追加
- [x] typecheck / lint / format 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)