### PR TITLE
test: improve domain service test coverage

### DIFF
--- a/src/core/domain/action/services/__tests__/configParser.test.ts
+++ b/src/core/domain/action/services/__tests__/configParser.test.ts
@@ -280,5 +280,166 @@ actions:
         }),
       );
     });
+
+    it("should throw for non-object action value", () => {
+      const yaml = `
+actions:
+  test: not_an_object
+`;
+      expect(() => ActionConfigParser.parse(yaml)).toThrow(BusinessRuleError);
+      expect(() => ActionConfigParser.parse(yaml)).toThrow(
+        expect.objectContaining({
+          code: ActionErrorCode.AcInvalidConfigStructure,
+        }),
+      );
+    });
+
+    it("should throw for non-array mappings", () => {
+      const yaml = `
+actions:
+  test:
+    index: 0
+    destApp:
+      code: target-app
+    mappings: not_an_array
+    entities: []
+`;
+      expect(() => ActionConfigParser.parse(yaml)).toThrow(BusinessRuleError);
+      expect(() => ActionConfigParser.parse(yaml)).toThrow(
+        expect.objectContaining({
+          code: ActionErrorCode.AcInvalidConfigStructure,
+        }),
+      );
+    });
+
+    it("should throw for non-array entities", () => {
+      const yaml = `
+actions:
+  test:
+    index: 0
+    destApp:
+      code: target-app
+    mappings: []
+    entities: not_an_array
+`;
+      expect(() => ActionConfigParser.parse(yaml)).toThrow(BusinessRuleError);
+      expect(() => ActionConfigParser.parse(yaml)).toThrow(
+        expect.objectContaining({
+          code: ActionErrorCode.AcInvalidConfigStructure,
+        }),
+      );
+    });
+
+    it("should throw for non-object mapping", () => {
+      const yaml = `
+actions:
+  test:
+    index: 0
+    destApp:
+      code: target-app
+    mappings:
+      - not_an_object
+    entities: []
+`;
+      expect(() => ActionConfigParser.parse(yaml)).toThrow(BusinessRuleError);
+      expect(() => ActionConfigParser.parse(yaml)).toThrow(
+        expect.objectContaining({
+          code: ActionErrorCode.AcInvalidConfigStructure,
+        }),
+      );
+    });
+
+    it("should throw for non-object entity", () => {
+      const yaml = `
+actions:
+  test:
+    index: 0
+    destApp:
+      code: target-app
+    mappings: []
+    entities:
+      - not_an_object
+`;
+      expect(() => ActionConfigParser.parse(yaml)).toThrow(BusinessRuleError);
+      expect(() => ActionConfigParser.parse(yaml)).toThrow(
+        expect.objectContaining({
+          code: ActionErrorCode.AcInvalidConfigStructure,
+        }),
+      );
+    });
+
+    it("should parse destApp with app only", () => {
+      const yaml = `
+actions:
+  test:
+    index: 0
+    destApp:
+      app: "123"
+    mappings: []
+    entities: []
+`;
+      const config = ActionConfigParser.parse(yaml);
+      expect(config.actions.test.destApp).toEqual({ app: "123" });
+    });
+
+    it("should parse destApp with both app and code", () => {
+      const yaml = `
+actions:
+  test:
+    index: 0
+    destApp:
+      app: "123"
+      code: my-app
+    mappings: []
+    entities: []
+`;
+      const config = ActionConfigParser.parse(yaml);
+      expect(config.actions.test.destApp).toEqual({
+        app: "123",
+        code: "my-app",
+      });
+    });
+
+    it("should parse mapping with srcField omitted for RECORD_URL", () => {
+      const yaml = `
+actions:
+  test:
+    index: 0
+    destApp:
+      code: target-app
+    mappings:
+      - srcType: RECORD_URL
+        destField: url_field
+    entities: []
+`;
+      const config = ActionConfigParser.parse(yaml);
+      expect(config.actions.test.mappings[0].srcField).toBeUndefined();
+    });
+
+    it("should throw AcEmptyActionName for empty action key", () => {
+      const yaml = `
+actions:
+  "":
+    index: 0
+    destApp:
+      code: target-app
+    mappings: []
+    entities: []
+`;
+      expect(() => ActionConfigParser.parse(yaml)).toThrow(BusinessRuleError);
+      expect(() => ActionConfigParser.parse(yaml)).toThrow(
+        expect.objectContaining({
+          code: ActionErrorCode.AcEmptyActionName,
+        }),
+      );
+    });
+
+    it("should parse empty actions object", () => {
+      const yaml = `
+actions: {}
+`;
+      const config = ActionConfigParser.parse(yaml);
+      expect(Object.keys(config.actions)).toHaveLength(0);
+    });
   });
 });

--- a/src/core/domain/fieldPermission/services/__tests__/configParser.test.ts
+++ b/src/core/domain/fieldPermission/services/__tests__/configParser.test.ts
@@ -229,6 +229,87 @@ rights:
       );
     });
 
+    it("should throw for non-object field right", () => {
+      const yaml = `
+rights:
+  - not_an_object
+`;
+      expect(() => FieldPermissionConfigParser.parse(yaml)).toThrow(
+        BusinessRuleError,
+      );
+      expect(() => FieldPermissionConfigParser.parse(yaml)).toThrow(
+        expect.objectContaining({
+          code: FieldPermissionErrorCode.FpInvalidConfigStructure,
+        }),
+      );
+    });
+
+    it("should throw for non-array entities in field right", () => {
+      const yaml = `
+rights:
+  - code: field_code_1
+    entities: not_an_array
+`;
+      expect(() => FieldPermissionConfigParser.parse(yaml)).toThrow(
+        BusinessRuleError,
+      );
+      expect(() => FieldPermissionConfigParser.parse(yaml)).toThrow(
+        expect.objectContaining({
+          code: FieldPermissionErrorCode.FpInvalidConfigStructure,
+        }),
+      );
+    });
+
+    it("should throw for non-object field right entity", () => {
+      const yaml = `
+rights:
+  - code: field_code_1
+    entities:
+      - not_an_object
+`;
+      expect(() => FieldPermissionConfigParser.parse(yaml)).toThrow(
+        BusinessRuleError,
+      );
+      expect(() => FieldPermissionConfigParser.parse(yaml)).toThrow(
+        expect.objectContaining({
+          code: FieldPermissionErrorCode.FpInvalidConfigStructure,
+        }),
+      );
+    });
+
+    it("should throw for non-object entity in field right entity", () => {
+      const yaml = `
+rights:
+  - code: field_code_1
+    entities:
+      - accessibility: READ
+        entity: not_an_object
+`;
+      expect(() => FieldPermissionConfigParser.parse(yaml)).toThrow(
+        BusinessRuleError,
+      );
+      expect(() => FieldPermissionConfigParser.parse(yaml)).toThrow(
+        expect.objectContaining({
+          code: FieldPermissionErrorCode.FpInvalidConfigStructure,
+        }),
+      );
+    });
+
+    it("should parse includeSubs as false", () => {
+      const yaml = `
+rights:
+  - code: field_code_1
+    entities:
+      - accessibility: READ
+        entity:
+          type: GROUP
+          code: group1
+        includeSubs: false
+`;
+      const config = FieldPermissionConfigParser.parse(yaml);
+      expect(config.rights[0].entities[0].includeSubs).toBe(false);
+    });
+
     it("should throw DuplicateFieldCode for duplicate field codes", () => {
       const yaml = `
 rights:

--- a/src/core/domain/generalSettings/services/__tests__/configParser.test.ts
+++ b/src/core/domain/generalSettings/services/__tests__/configParser.test.ts
@@ -280,5 +280,124 @@ icon:
       const config = GeneralSettingsConfigParser.parse(yaml);
       expect(config.icon).toEqual({ type: "FILE", key: "some-file-key" });
     });
+
+    it("should throw for non-string name", () => {
+      const yaml = `
+name: 123
+`;
+      expect(() => GeneralSettingsConfigParser.parse(yaml)).toThrow(
+        BusinessRuleError,
+      );
+      expect(() => GeneralSettingsConfigParser.parse(yaml)).toThrow(
+        expect.objectContaining({
+          code: GeneralSettingsErrorCode.GsInvalidConfigStructure,
+        }),
+      );
+    });
+
+    it("should throw for non-string description", () => {
+      const yaml = `
+description: 123
+`;
+      expect(() => GeneralSettingsConfigParser.parse(yaml)).toThrow(
+        BusinessRuleError,
+      );
+      expect(() => GeneralSettingsConfigParser.parse(yaml)).toThrow(
+        expect.objectContaining({
+          code: GeneralSettingsErrorCode.GsInvalidConfigStructure,
+        }),
+      );
+    });
+
+    it("should throw for non-string titleField.code", () => {
+      const yaml = `
+titleField:
+  selectionMode: MANUAL
+  code: 123
+`;
+      expect(() => GeneralSettingsConfigParser.parse(yaml)).toThrow(
+        BusinessRuleError,
+      );
+      expect(() => GeneralSettingsConfigParser.parse(yaml)).toThrow(
+        expect.objectContaining({
+          code: GeneralSettingsErrorCode.GsInvalidConfigStructure,
+        }),
+      );
+    });
+
+    it("should throw for non-object titleField", () => {
+      const yaml = `
+titleField: not_an_object
+`;
+      expect(() => GeneralSettingsConfigParser.parse(yaml)).toThrow(
+        BusinessRuleError,
+      );
+      expect(() => GeneralSettingsConfigParser.parse(yaml)).toThrow(
+        expect.objectContaining({
+          code: GeneralSettingsErrorCode.GsInvalidConfigStructure,
+        }),
+      );
+    });
+
+    it("should throw for icon with empty key", () => {
+      const yaml = `
+icon:
+  type: PRESET
+  key: ""
+`;
+      expect(() => GeneralSettingsConfigParser.parse(yaml)).toThrow(
+        BusinessRuleError,
+      );
+      expect(() => GeneralSettingsConfigParser.parse(yaml)).toThrow(
+        expect.objectContaining({
+          code: GeneralSettingsErrorCode.GsInvalidConfigStructure,
+        }),
+      );
+    });
+
+    it("should throw for numberPrecision with non-number digits", () => {
+      const yaml = `
+numberPrecision:
+  digits: abc
+  decimalPlaces: 2
+  roundingMode: HALF_EVEN
+`;
+      expect(() => GeneralSettingsConfigParser.parse(yaml)).toThrow(
+        BusinessRuleError,
+      );
+    });
+
+    it("should throw for numberPrecision with non-number decimalPlaces", () => {
+      const yaml = `
+numberPrecision:
+  digits: 12
+  decimalPlaces: abc
+  roundingMode: HALF_EVEN
+`;
+      expect(() => GeneralSettingsConfigParser.parse(yaml)).toThrow(
+        BusinessRuleError,
+      );
+    });
+
+    it("should throw for numberPrecision with invalid roundingMode", () => {
+      const yaml = `
+numberPrecision:
+  digits: 12
+  decimalPlaces: 2
+  roundingMode: INVALID
+`;
+      expect(() => GeneralSettingsConfigParser.parse(yaml)).toThrow(
+        BusinessRuleError,
+      );
+    });
+
+    it("should throw for firstMonthOfFiscalYear less than 1", () => {
+      const yaml = `
+firstMonthOfFiscalYear: 0
+`;
+      expect(() => GeneralSettingsConfigParser.parse(yaml)).toThrow(
+        BusinessRuleError,
+      );
+    });
   });
 });

--- a/src/core/domain/notification/services/__tests__/configSerializer.test.ts
+++ b/src/core/domain/notification/services/__tests__/configSerializer.test.ts
@@ -117,6 +117,72 @@ describe("NotificationConfigSerializer.serialize", () => {
     expect(yaml.trim()).toBe("{}");
   });
 
+  it("perRecordのtargetにincludeSubsを含めてシリアライズできる", () => {
+    const config: NotificationConfig = {
+      perRecord: [
+        {
+          filterCond: "",
+          title: "Test",
+          targets: [
+            {
+              entity: { type: "GROUP", code: "group1" },
+              includeSubs: true,
+            },
+          ],
+        },
+      ],
+    };
+    const yaml = NotificationConfigSerializer.serialize(config);
+    expect(yaml).toContain("includeSubs: true");
+  });
+
+  it("reminderのtimeフィールドをシリアライズできる", () => {
+    const config: NotificationConfig = {
+      reminder: {
+        timezone: "Asia/Tokyo",
+        notifications: [
+          {
+            code: "due_date",
+            daysLater: 1,
+            time: "09:00",
+            filterCond: "",
+            title: "Due",
+            targets: [{ entity: { type: "USER", code: "admin" } }],
+          },
+        ],
+      },
+    };
+    const yaml = NotificationConfigSerializer.serialize(config);
+    expect(yaml).toContain("time:");
+    expect(yaml).toContain("09:00");
+    expect(yaml).not.toContain("hoursLater");
+  });
+
+  it("reminderのtargetにincludeSubsを含めてシリアライズできる", () => {
+    const config: NotificationConfig = {
+      reminder: {
+        timezone: "Asia/Tokyo",
+        notifications: [
+          {
+            code: "due_date",
+            daysLater: 1,
+            hoursLater: 9,
+            filterCond: "",
+            title: "Due",
+            targets: [
+              {
+                entity: { type: "GROUP", code: "group1" },
+                includeSubs: false,
+              },
+            ],
+          },
+        ],
+      },
+    };
+    const yaml = NotificationConfigSerializer.serialize(config);
+    expect(yaml).toContain("includeSubs: false");
+  });
+
   it("ラウンドトリップテスト: parse→serialize→parse→比較", () => {
     const yaml1 = NotificationConfigSerializer.serialize(fullConfig);
     const parsed1 = NotificationConfigParser.parse(yaml1);

--- a/src/core/domain/processManagement/services/__tests__/configParser.test.ts
+++ b/src/core/domain/processManagement/services/__tests__/configParser.test.ts
@@ -442,6 +442,264 @@ actions:
       }
     });
 
+    it("action がオブジェクトでない場合に PmInvalidConfigStructure エラー", () => {
+      try {
+        ProcessManagementConfigParser.parse(`
+states:
+  state1:
+    index: 0
+    assignee:
+      type: ONE
+      entities: []
+actions:
+  - not_an_object
+`);
+      } catch (error) {
+        expect(isBusinessRuleError(error)).toBe(true);
+        if (isBusinessRuleError(error)) {
+          expect(error.code).toBe(
+            ProcessManagementErrorCode.PmInvalidConfigStructure,
+          );
+        }
+      }
+    });
+
+    it("action に name がない場合に PmInvalidConfigStructure エラー", () => {
+      try {
+        ProcessManagementConfigParser.parse(`
+states:
+  state1:
+    index: 0
+    assignee:
+      type: ONE
+      entities: []
+actions:
+  - from: state1
+    to: state1
+`);
+      } catch (error) {
+        expect(isBusinessRuleError(error)).toBe(true);
+        if (isBusinessRuleError(error)) {
+          expect(error.code).toBe(
+            ProcessManagementErrorCode.PmInvalidConfigStructure,
+          );
+        }
+      }
+    });
+
+    it("action に from がない場合に PmInvalidConfigStructure エラー", () => {
+      try {
+        ProcessManagementConfigParser.parse(`
+states:
+  state1:
+    index: 0
+    assignee:
+      type: ONE
+      entities: []
+actions:
+  - name: action1
+    to: state1
+`);
+      } catch (error) {
+        expect(isBusinessRuleError(error)).toBe(true);
+        if (isBusinessRuleError(error)) {
+          expect(error.code).toBe(
+            ProcessManagementErrorCode.PmInvalidConfigStructure,
+          );
+        }
+      }
+    });
+
+    it("action に to がない場合に PmInvalidConfigStructure エラー", () => {
+      try {
+        ProcessManagementConfigParser.parse(`
+states:
+  state1:
+    index: 0
+    assignee:
+      type: ONE
+      entities: []
+actions:
+  - name: action1
+    from: state1
+`);
+      } catch (error) {
+        expect(isBusinessRuleError(error)).toBe(true);
+        if (isBusinessRuleError(error)) {
+          expect(error.code).toBe(
+            ProcessManagementErrorCode.PmInvalidConfigStructure,
+          );
+        }
+      }
+    });
+
+    it("無効な action.type で PmInvalidConfigStructure エラー", () => {
+      try {
+        ProcessManagementConfigParser.parse(`
+states:
+  state1:
+    index: 0
+    assignee:
+      type: ONE
+      entities: []
+  state2:
+    index: 1
+    assignee:
+      type: ONE
+      entities: []
+actions:
+  - name: action1
+    from: state1
+    to: state2
+    type: INVALID
+`);
+      } catch (error) {
+        expect(isBusinessRuleError(error)).toBe(true);
+        if (isBusinessRuleError(error)) {
+          expect(error.code).toBe(
+            ProcessManagementErrorCode.PmInvalidConfigStructure,
+          );
+        }
+      }
+    });
+
+    it("assignee がオブジェクトでない場合に PmInvalidConfigStructure エラー", () => {
+      try {
+        ProcessManagementConfigParser.parse(`
+states:
+  state1:
+    index: 0
+    assignee: not_an_object
+`);
+      } catch (error) {
+        expect(isBusinessRuleError(error)).toBe(true);
+        if (isBusinessRuleError(error)) {
+          expect(error.code).toBe(
+            ProcessManagementErrorCode.PmInvalidConfigStructure,
+          );
+        }
+      }
+    });
+
+    it("assignee に entities がない場合に PmInvalidConfigStructure エラー", () => {
+      try {
+        ProcessManagementConfigParser.parse(`
+states:
+  state1:
+    index: 0
+    assignee:
+      type: ONE
+`);
+      } catch (error) {
+        expect(isBusinessRuleError(error)).toBe(true);
+        if (isBusinessRuleError(error)) {
+          expect(error.code).toBe(
+            ProcessManagementErrorCode.PmInvalidConfigStructure,
+          );
+        }
+      }
+    });
+
+    it("entity がオブジェクトでない場合に PmInvalidConfigStructure エラー", () => {
+      try {
+        ProcessManagementConfigParser.parse(`
+states:
+  state1:
+    index: 0
+    assignee:
+      type: ONE
+      entities:
+        - not_an_object
+`);
+      } catch (error) {
+        expect(isBusinessRuleError(error)).toBe(true);
+        if (isBusinessRuleError(error)) {
+          expect(error.code).toBe(
+            ProcessManagementErrorCode.PmInvalidConfigStructure,
+          );
+        }
+      }
+    });
+
+    it("state がオブジェクトでない場合に PmInvalidConfigStructure エラー", () => {
+      try {
+        ProcessManagementConfigParser.parse(`
+states:
+  state1: not_an_object
+`);
+      } catch (error) {
+        expect(isBusinessRuleError(error)).toBe(true);
+        if (isBusinessRuleError(error)) {
+          expect(error.code).toBe(
+            ProcessManagementErrorCode.PmInvalidConfigStructure,
+          );
+        }
+      }
+    });
+
+    it("SECONDARY アクションの executableUser がオブジェクトでない場合にエラー", () => {
+      try {
+        ProcessManagementConfigParser.parse(`
+states:
+  state1:
+    index: 0
+    assignee:
+      type: ONE
+      entities: []
+  state2:
+    index: 1
+    assignee:
+      type: ONE
+      entities: []
+actions:
+  - name: action1
+    from: state1
+    to: state2
+    type: SECONDARY
+    executableUser: not_an_object
+`);
+      } catch (error) {
+        expect(isBusinessRuleError(error)).toBe(true);
+        if (isBusinessRuleError(error)) {
+          expect(error.code).toBe(
+            ProcessManagementErrorCode.PmInvalidConfigStructure,
+          );
+        }
+      }
+    });
+
+    it("SECONDARY アクションの executableUser.entities が配列でない場合にエラー", () => {
+      try {
+        ProcessManagementConfigParser.parse(`
+states:
+  state1:
+    index: 0
+    assignee:
+      type: ONE
+      entities: []
+  state2:
+    index: 1
+    assignee:
+      type: ONE
+      entities: []
+actions:
+  - name: action1
+    from: state1
+    to: state2
+    type: SECONDARY
+    executableUser:
+      entities: not_an_array
+`);
+      } catch (error) {
+        expect(isBusinessRuleError(error)).toBe(true);
+        if (isBusinessRuleError(error)) {
+          expect(error.code).toBe(
+            ProcessManagementErrorCode.PmInvalidConfigStructure,
+          );
+        }
+      }
+    });
+
     it("action の to が存在しないステータスの場合に PmInvalidActionReference エラー", () => {
       try {
         ProcessManagementConfigParser.parse(`

--- a/src/core/domain/recordPermission/services/__tests__/configParser.test.ts
+++ b/src/core/domain/recordPermission/services/__tests__/configParser.test.ts
@@ -283,5 +283,130 @@ rights:
         }),
       );
     });
+
+    it("should throw for non-object record right", () => {
+      const yaml = `
+rights:
+  - not_an_object
+`;
+      expect(() => RecordPermissionConfigParser.parse(yaml)).toThrow(
+        BusinessRuleError,
+      );
+      expect(() => RecordPermissionConfigParser.parse(yaml)).toThrow(
+        expect.objectContaining({
+          code: RecordPermissionErrorCode.RpInvalidConfigStructure,
+        }),
+      );
+    });
+
+    it("should throw for non-array entities in record right", () => {
+      const yaml = `
+rights:
+  - filterCond: ""
+    entities: not_an_array
+`;
+      expect(() => RecordPermissionConfigParser.parse(yaml)).toThrow(
+        BusinessRuleError,
+      );
+      expect(() => RecordPermissionConfigParser.parse(yaml)).toThrow(
+        expect.objectContaining({
+          code: RecordPermissionErrorCode.RpInvalidConfigStructure,
+        }),
+      );
+    });
+
+    it("should throw for non-object record right entity", () => {
+      const yaml = `
+rights:
+  - filterCond: ""
+    entities:
+      - not_an_object
+`;
+      expect(() => RecordPermissionConfigParser.parse(yaml)).toThrow(
+        BusinessRuleError,
+      );
+      expect(() => RecordPermissionConfigParser.parse(yaml)).toThrow(
+        expect.objectContaining({
+          code: RecordPermissionErrorCode.RpInvalidConfigStructure,
+        }),
+      );
+    });
+
+    it("should throw for non-object entity in record right entity", () => {
+      const yaml = `
+rights:
+  - filterCond: ""
+    entities:
+      - entity: not_an_object
+        viewable: true
+        editable: false
+        deletable: false
+        includeSubs: false
+`;
+      expect(() => RecordPermissionConfigParser.parse(yaml)).toThrow(
+        BusinessRuleError,
+      );
+      expect(() => RecordPermissionConfigParser.parse(yaml)).toThrow(
+        expect.objectContaining({
+          code: RecordPermissionErrorCode.RpInvalidConfigStructure,
+        }),
+      );
+    });
+
+    it("should throw InvalidPermissionValue for string deletable value", () => {
+      const yaml = `
+rights:
+  - filterCond: ""
+    entities:
+      - entity:
+          type: USER
+          code: user1
+        viewable: true
+        editable: false
+        deletable: "no"
+        includeSubs: false
+`;
+      expect(() => RecordPermissionConfigParser.parse(yaml)).toThrow(
+        BusinessRuleError,
+      );
+      expect(() => RecordPermissionConfigParser.parse(yaml)).toThrow(
+        expect.objectContaining({
+          code: RecordPermissionErrorCode.RpInvalidPermissionValue,
+        }),
+      );
+    });
+
+    it("should throw InvalidPermissionValue for string includeSubs value", () => {
+      const yaml = `
+rights:
+  - filterCond: ""
+    entities:
+      - entity:
+          type: USER
+          code: user1
+        viewable: true
+        editable: false
+        deletable: false
+        includeSubs: "true"
+`;
+      expect(() => RecordPermissionConfigParser.parse(yaml)).toThrow(
+        BusinessRuleError,
+      );
+      expect(() => RecordPermissionConfigParser.parse(yaml)).toThrow(
+        expect.objectContaining({
+          code: RecordPermissionErrorCode.RpInvalidPermissionValue,
+        }),
+      );
+    });
+
+    it("should parse filterCond as string", () => {
+      const yaml = `
+rights:
+  - filterCond: 'status = "active"'
+    entities: []
+`;
+      const config = RecordPermissionConfigParser.parse(yaml);
+      expect(config.rights[0].filterCond).toBe('status = "active"');
+    });
   });
 });

--- a/src/core/domain/report/services/__tests__/configParser.test.ts
+++ b/src/core/domain/report/services/__tests__/configParser.test.ts
@@ -651,5 +651,255 @@ reports:
       expect(config.reports["テスト"].chartType).toBe("TABLE");
       expect(config.reports["テスト"].chartMode).toBeUndefined();
     });
+
+    it("should parse periodicReport with minute", () => {
+      const yaml = `
+reports:
+  時間レポート:
+    chartType: COLUMN
+    index: 0
+    groups: []
+    aggregations:
+      - type: COUNT
+    filterCond: ""
+    sorts: []
+    periodicReport:
+      active: true
+      period:
+        every: HOUR
+        minute: 30
+`;
+      const config = ReportConfigParser.parse(yaml);
+      const report = config.reports["時間レポート"];
+      expect(report.periodicReport?.period.minute).toBe(30);
+    });
+
+    it("should throw for non-boolean periodicReport.active", () => {
+      const yaml = `
+reports:
+  テスト:
+    chartType: COLUMN
+    index: 0
+    groups: []
+    aggregations:
+      - type: COUNT
+    filterCond: ""
+    sorts: []
+    periodicReport:
+      active: "yes"
+      period:
+        every: MONTH
+`;
+      expect(() => ReportConfigParser.parse(yaml)).toThrow(BusinessRuleError);
+    });
+
+    it("should throw for non-object periodicReport", () => {
+      const yaml = `
+reports:
+  テスト:
+    chartType: COLUMN
+    index: 0
+    groups: []
+    aggregations:
+      - type: COUNT
+    filterCond: ""
+    sorts: []
+    periodicReport: not_an_object
+`;
+      expect(() => ReportConfigParser.parse(yaml)).toThrow(BusinessRuleError);
+    });
+
+    it("should throw for non-object periodicReport.period", () => {
+      const yaml = `
+reports:
+  テスト:
+    chartType: COLUMN
+    index: 0
+    groups: []
+    aggregations:
+      - type: COUNT
+    filterCond: ""
+    sorts: []
+    periodicReport:
+      active: true
+      period: not_an_object
+`;
+      expect(() => ReportConfigParser.parse(yaml)).toThrow(BusinessRuleError);
+    });
+
+    it("should throw for invalid periodicReport.period.every", () => {
+      const yaml = `
+reports:
+  テスト:
+    chartType: COLUMN
+    index: 0
+    groups: []
+    aggregations:
+      - type: COUNT
+    filterCond: ""
+    sorts: []
+    periodicReport:
+      active: true
+      period:
+        every: INVALID
+`;
+      expect(() => ReportConfigParser.parse(yaml)).toThrow(BusinessRuleError);
+    });
+
+    it("should throw for non-object group", () => {
+      const yaml = `
+reports:
+  テスト:
+    chartType: BAR
+    index: 0
+    groups:
+      - not_an_object
+    aggregations: []
+    filterCond: ""
+    sorts: []
+`;
+      expect(() => ReportConfigParser.parse(yaml)).toThrow(BusinessRuleError);
+    });
+
+    it("should throw for group with empty code", () => {
+      const yaml = `
+reports:
+  テスト:
+    chartType: BAR
+    index: 0
+    groups:
+      - code: ""
+    aggregations: []
+    filterCond: ""
+    sorts: []
+`;
+      expect(() => ReportConfigParser.parse(yaml)).toThrow(BusinessRuleError);
+    });
+
+    it("should throw for non-object aggregation", () => {
+      const yaml = `
+reports:
+  テスト:
+    chartType: BAR
+    index: 0
+    groups: []
+    aggregations:
+      - not_an_object
+    filterCond: ""
+    sorts: []
+`;
+      expect(() => ReportConfigParser.parse(yaml)).toThrow(BusinessRuleError);
+    });
+
+    it("should throw for aggregation with non-string code", () => {
+      const yaml = `
+reports:
+  テスト:
+    chartType: BAR
+    index: 0
+    groups: []
+    aggregations:
+      - type: SUM
+        code: 123
+    filterCond: ""
+    sorts: []
+`;
+      expect(() => ReportConfigParser.parse(yaml)).toThrow(BusinessRuleError);
+    });
+
+    it("should throw for non-object sort", () => {
+      const yaml = `
+reports:
+  テスト:
+    chartType: BAR
+    index: 0
+    groups: []
+    aggregations: []
+    filterCond: ""
+    sorts:
+      - not_an_object
+`;
+      expect(() => ReportConfigParser.parse(yaml)).toThrow(BusinessRuleError);
+    });
+
+    it("should throw for non-object report", () => {
+      const yaml = `
+reports:
+  テスト: not_an_object
+`;
+      expect(() => ReportConfigParser.parse(yaml)).toThrow(BusinessRuleError);
+    });
+
+    it("should default filterCond to empty string when not provided", () => {
+      const yaml = `
+reports:
+  テスト:
+    chartType: BAR
+    index: 0
+    groups: []
+    aggregations: []
+    sorts: []
+`;
+      const config = ReportConfigParser.parse(yaml);
+      expect(config.reports["テスト"].filterCond).toBe("");
+    });
+
+    it("should default groups, aggregations, sorts to empty arrays when not arrays", () => {
+      const yaml = `
+reports:
+  テスト:
+    chartType: BAR
+    index: 0
+    filterCond: ""
+`;
+      const config = ReportConfigParser.parse(yaml);
+      expect(config.reports["テスト"].groups).toEqual([]);
+      expect(config.reports["テスト"].aggregations).toEqual([]);
+      expect(config.reports["テスト"].sorts).toEqual([]);
+    });
+
+    it("should parse all periodic every values", () => {
+      const everyValues = ["YEAR", "QUARTER", "MONTH", "WEEK", "DAY", "HOUR"];
+      for (const every of everyValues) {
+        const yaml = `
+reports:
+  テスト:
+    chartType: COLUMN
+    index: 0
+    groups: []
+    aggregations:
+      - type: COUNT
+    filterCond: ""
+    sorts: []
+    periodicReport:
+      active: true
+      period:
+        every: ${every}
+`;
+        const config = ReportConfigParser.parse(yaml);
+        expect(config.reports["テスト"].periodicReport?.period.every).toBe(
+          every,
+        );
+      }
+    });
+
+    it("should parse all aggregation types", () => {
+      const aggregationTypes = ["COUNT", "SUM", "AVERAGE", "MAX", "MIN"];
+      for (const aggType of aggregationTypes) {
+        const yaml = `
+reports:
+  テスト:
+    chartType: BAR
+    index: 0
+    groups: []
+    aggregations:
+      - type: ${aggType}
+    filterCond: ""
+    sorts: []
+`;
+        const config = ReportConfigParser.parse(yaml);
+        expect(config.reports["テスト"].aggregations[0].type).toBe(aggType);
+      }
+    });
   });
 });

--- a/src/core/domain/report/services/__tests__/configSerializer.test.ts
+++ b/src/core/domain/report/services/__tests__/configSerializer.test.ts
@@ -248,6 +248,61 @@ describe("ReportConfigSerializer", () => {
       expect(yaml).not.toContain("chartMode");
     });
 
+    it("should serialize periodicReport with dayOfWeek", () => {
+      const config: ReportsConfig = {
+        reports: {
+          週次レポート: {
+            chartType: "COLUMN",
+            chartMode: "NORMAL",
+            index: 0,
+            name: "週次レポート",
+            groups: [],
+            aggregations: [{ type: "COUNT" }],
+            filterCond: "",
+            sorts: [],
+            periodicReport: {
+              active: true,
+              period: {
+                every: "WEEK",
+                dayOfWeek: "MONDAY",
+                time: "09:00",
+              },
+            },
+          },
+        },
+      };
+
+      const yaml = ReportConfigSerializer.serialize(config);
+      expect(yaml).toContain("dayOfWeek: MONDAY");
+    });
+
+    it("should serialize periodicReport with minute", () => {
+      const config: ReportsConfig = {
+        reports: {
+          時間レポート: {
+            chartType: "COLUMN",
+            chartMode: "NORMAL",
+            index: 0,
+            name: "時間レポート",
+            groups: [],
+            aggregations: [{ type: "COUNT" }],
+            filterCond: "",
+            sorts: [],
+            periodicReport: {
+              active: true,
+              period: {
+                every: "HOUR",
+                minute: 30,
+              },
+            },
+          },
+        },
+      };
+
+      const yaml = ReportConfigSerializer.serialize(config);
+      expect(yaml).toContain("minute: 30");
+    });
+
     it("should roundtrip parse and serialize", () => {
       const originalYaml = `
 reports:


### PR DESCRIPTION
## Summary
- ドメインサービス層のテストカバレッジを大幅に向上（+86テストケース、10ファイル）
- config parser、serializer、diff detectorの未カバー分岐を網羅的にテスト
- 全体のブランチカバレッジが70.98% → 74.57%に改善

## Changes

| ファイル | Before → After (Stmts) |
|---|---|
| processManagement configParser | 86.9% → **100%** |
| generalSettings configParser | 89.7% → **100%** |
| fieldPermission configParser | 91.8% → **100%** |
| recordPermission configParser | 90.5% → **100%** |
| notification configParser | 87.1% → **99%** |
| report configParser | 89.3% → **99.1%** |
| view diffDetector | 87.5% → **98.6%** |
| notification serializer | 93.1% → **100%** |
| report serializer | 94.3% → **100%** |
| action configParser | 88.7% → improved |

## Test plan
- [x] `pnpm test` - 1552テスト全パス
- [x] `pnpm typecheck` - 型エラーなし
- [x] `pnpm lint:fix` - lint問題なし
- [x] `pnpm format` - フォーマット済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)