### PR TITLE
fix: display error stack traces during init capture failures

### DIFF
--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -14,7 +14,11 @@ import { generateProjectConfig } from "@/core/application/init/generateProjectCo
 import { buildAppFilePaths } from "@/core/domain/projectConfig/appFilePaths";
 import { resolveAppName } from "@/core/domain/space/entity";
 import { kintoneArgs, resolveAuth, validateKintoneDomain } from "../config";
-import { formatErrorForDisplay, handleCliError } from "../handleError";
+import {
+  formatErrorForDisplay,
+  handleCliError,
+  logError,
+} from "../handleError";
 import { DEFAULT_CONFIG_PATH } from "../projectConfig";
 
 const initArgs = {
@@ -66,6 +70,7 @@ function printCaptureResults(results: readonly CaptureResult[]): void {
       p.log.error(
         `  ${pc.red("\u2717")} ${result.domain}: ${pc.dim(formatErrorForDisplay(result.error))}`,
       );
+      logError(result.error);
     }
   }
 }


### PR DESCRIPTION
## Summary
- `init`コマンドでドメインキャプチャが失敗した際、`printCaptureResults`がエラーメッセージのみ表示しスタックトレースやcauseチェーンが省略されていた問題を修正
- 失敗時に`logError`を呼び出すことで、他コマンドと同じ詳細なエラー出力（エラータイプ・スタックトレース・causeチェーン）を表示するように変更

Closes #47

## Test plan
- [ ] `init`コマンドを無効な認証情報で実行し、スタックトレースが表示されることを確認
- [ ] `init`コマンドで一部ドメインキャプチャが失敗するケースで、失敗したドメインのエラー詳細が表示されることを確認
- [ ] 既存テストが全て通ることを確認（`pnpm test` — 171 files, 1669 tests passed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)