### PR TITLE
fix: align customize capture download paths with config-stored paths

### DIFF
--- a/src/cli/commands/customize/__tests__/capture.test.ts
+++ b/src/cli/commands/customize/__tests__/capture.test.ts
@@ -1,16 +1,21 @@
-import { basename, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { deriveFilePrefix } from "../capture";
 
 describe("deriveFilePrefix", () => {
-  it("customize.yaml はカレントディレクトリ名を返す", () => {
-    // resolve("customize.yaml") → /cwd/customize.yaml → parentDir = cwd's basename
-    const expected = basename(resolve("."));
-    expect(deriveFilePrefix("customize.yaml")).toBe(expected);
+  it("customize.yaml は空文字を返す", () => {
+    expect(deriveFilePrefix("customize.yaml")).toBe("");
   });
 
-  it("ディレクトリ内の customize.yaml は親ディレクトリ名を返す", () => {
-    expect(deriveFilePrefix("myapp/customize.yaml")).toBe("myapp");
+  it("ディレクトリ内の customize.yaml は空文字を返す", () => {
+    expect(deriveFilePrefix("myapp/customize.yaml")).toBe("");
+  });
+
+  it("深いパスの customize.yaml は空文字を返す", () => {
+    expect(deriveFilePrefix("path/to/customer/customize.yaml")).toBe("");
+  });
+
+  it("絶対パスの customize.yaml は空文字を返す", () => {
+    expect(deriveFilePrefix("/project/apps/myapp/customize.yaml")).toBe("");
   });
 
   it("customize以外のファイル名はそのファイル名を返す", () => {
@@ -21,16 +26,8 @@ describe("deriveFilePrefix", () => {
     expect(deriveFilePrefix("some-dir/my-config.yaml")).toBe("my-config");
   });
 
-  it("深いパスの customize.yaml は直近の親ディレクトリ名を返す", () => {
-    expect(deriveFilePrefix("path/to/customer/customize.yaml")).toBe(
-      "customer",
-    );
-  });
-
-  it("絶対パスの customize.yaml は親ディレクトリ名を返す", () => {
-    expect(deriveFilePrefix("/project/apps/myapp/customize.yaml")).toBe(
-      "myapp",
-    );
+  it("マルチアプリ形式のパスはアプリ名を返す", () => {
+    expect(deriveFilePrefix("customize/customer.yaml")).toBe("customer");
   });
 
   it(".yml 拡張子のファイルも正しくファイル名を返す", () => {

--- a/src/cli/commands/customize/capture.ts
+++ b/src/cli/commands/customize/capture.ts
@@ -20,19 +20,16 @@ import { routeMultiApp, runMultiAppWithFailCheck } from "../../projectConfig";
 
 export function deriveFilePrefix(customizeFilePath: string): string {
   const resolved = resolve(customizeFilePath);
-  const dir = dirname(resolved);
-  const parentDir = basename(dir);
   const fileName = basename(resolved, extname(resolved));
 
-  // parentDir is "" when the file is at the filesystem root (e.g. /customize.yaml)
-  if (parentDir === "") {
-    return fileName;
-  }
-
+  // When the file is named "customize" (e.g. myapp/customize.yaml), basePath
+  // already points to the app-specific directory, so no extra prefix is needed.
   if (fileName === "customize") {
-    return parentDir;
+    return "";
   }
 
+  // Otherwise the filename identifies the app (e.g. customize/customer.yaml in
+  // a multi-app layout). Use it as prefix to isolate downloaded files per app.
   return fileName;
 }
 

--- a/src/core/application/customization/__tests__/captureCustomization.test.ts
+++ b/src/core/application/customization/__tests__/captureCustomization.test.ts
@@ -11,7 +11,7 @@ describe("captureCustomization", () => {
   let container: TestCustomizationContainer;
 
   const basePath = "/project/customize";
-  const filePrefix = "customize";
+  const filePrefix = "myapp";
 
   function setup(): void {
     container = getContainer();
@@ -52,14 +52,14 @@ describe("captureCustomization", () => {
     expect(parsed.desktop.js).toHaveLength(1);
     expect(parsed.desktop.js[0]).toEqual({
       type: "FILE",
-      path: "customize/desktop/js/app.js",
+      path: "myapp/desktop/js/app.js",
     });
 
     expect(container.fileDownloader.callLog).toContain("download");
     expect(container.fileWriter.writtenFiles.size).toBe(1);
     expect(
       container.fileWriter.writtenFiles.has(
-        "/project/customize/desktop/js/app.js",
+        "/project/customize/myapp/desktop/js/app.js",
       ),
     ).toBe(true);
   });
@@ -133,10 +133,10 @@ describe("captureCustomization", () => {
 
     const parsed = ConfigParser.parse(result.configText);
     expect(parsed.desktop.js).toEqual([
-      { type: "FILE", path: "customize/desktop/js/desktop.js" },
+      { type: "FILE", path: "myapp/desktop/js/desktop.js" },
     ]);
     expect(parsed.mobile.js).toEqual([
-      { type: "FILE", path: "customize/mobile/js/mobile.js" },
+      { type: "FILE", path: "myapp/mobile/js/mobile.js" },
     ]);
 
     expect(container.fileWriter.writtenFiles.size).toBe(2);
@@ -186,7 +186,7 @@ describe("captureCustomization", () => {
     expect(parsed.desktop.js).toHaveLength(2);
     expect(parsed.desktop.js[0]).toEqual({
       type: "FILE",
-      path: "customize/desktop/js/app.js",
+      path: "myapp/desktop/js/app.js",
     });
     expect(parsed.desktop.js[1]).toEqual({
       type: "URL",
@@ -195,7 +195,7 @@ describe("captureCustomization", () => {
     expect(parsed.desktop.css).toHaveLength(1);
     expect(parsed.desktop.css[0]).toEqual({
       type: "FILE",
-      path: "customize/desktop/css/style.css",
+      path: "myapp/desktop/css/style.css",
     });
   });
 
@@ -269,11 +269,11 @@ describe("captureCustomization", () => {
     const parsed = ConfigParser.parse(result.configText);
     expect(parsed.desktop.js[0]).toEqual({
       type: "FILE",
-      path: "customize/desktop/js/passwd",
+      path: "myapp/desktop/js/passwd",
     });
     expect(
       container.fileWriter.writtenFiles.has(
-        "/project/customize/desktop/js/passwd",
+        "/project/customize/myapp/desktop/js/passwd",
       ),
     ).toBe(true);
   });
@@ -318,11 +318,11 @@ describe("captureCustomization", () => {
     expect(parsed.desktop.js).toHaveLength(2);
     expect(parsed.desktop.js[0]).toEqual({
       type: "FILE",
-      path: "customize/desktop/js/app.js",
+      path: "myapp/desktop/js/app.js",
     });
     expect(parsed.desktop.js[1]).toEqual({
       type: "FILE",
-      path: "customize/desktop/js/app_1.js",
+      path: "myapp/desktop/js/app_1.js",
     });
 
     expect(container.fileWriter.writtenFiles.size).toBe(2);
@@ -400,5 +400,43 @@ describe("captureCustomization", () => {
         input: { basePath, filePrefix },
       }),
     ).rejects.toThrow("getCustomization failed");
+  });
+
+  it("should download files directly under basePath when filePrefix is empty", async () => {
+    setup();
+    container.customizationConfigurator.setCustomization({
+      scope: "ALL",
+      desktop: {
+        js: [
+          {
+            type: "FILE",
+            file: {
+              fileKey: "fk-1",
+              name: "app.js",
+              contentType: "text/javascript",
+              size: "100",
+            },
+          },
+        ],
+        css: [],
+      },
+      mobile: { js: [], css: [] },
+      revision: "1",
+    });
+
+    const result = await captureCustomization({
+      container,
+      input: { basePath: "/project/myapp", filePrefix: "" },
+    });
+
+    const parsed = ConfigParser.parse(result.configText);
+    expect(parsed.desktop.js[0]).toEqual({
+      type: "FILE",
+      path: "desktop/js/app.js",
+    });
+
+    expect(
+      container.fileWriter.writtenFiles.has("/project/myapp/desktop/js/app.js"),
+    ).toBe(true);
   });
 });

--- a/src/core/application/customization/captureCustomization.ts
+++ b/src/core/application/customization/captureCustomization.ts
@@ -135,7 +135,11 @@ function planPlatform(
   filesToDownload: readonly PlannedFile[];
   fileCount: number;
 } {
-  const platformDir = join(args.input.basePath, platformName);
+  const platformDir = join(
+    args.input.basePath,
+    args.input.filePrefix,
+    platformName,
+  );
   const platformPrefix = join(args.input.filePrefix, platformName);
 
   const jsPlan = planResources(


### PR DESCRIPTION
## Summary
- `captureCustomization` の `platformDir`（ダウンロード先）に `filePrefix` を含めるよう修正。config YAMLに保存される相対パスと実際のダウンロード先が一致するようになり、`customize apply` が正しくファイルを見つけられるようになった
- `deriveFilePrefix` を簡素化：`customize.yaml` という名前のファイルの場合は空文字を返す（basePath が既にアプリ固有ディレクトリ）。それ以外はファイル名をprefixとして返す（マルチアプリでのファイル衝突回避）
- 空prefix（単一アプリ）のテストケースを追加

## Test plan
- [x] `pnpm test` — 171ファイル、1671テスト全パス
- [x] `pnpm typecheck` — 型エラーなし
- [x] `pnpm lint:fix && pnpm format` — コード品質OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)