### PR TITLE
ci: add Node.js and pnpm setup to Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,6 +30,19 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
@@ -46,5 +59,4 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
-
+          claude_args: '--allowed-tools "Bash(gh pr:*),Bash(pnpm:*)"'


### PR DESCRIPTION
## Summary
- Claude GitHub Actions ワークフローに Node.js 22 と pnpm のセットアップステップを追加
- `pnpm install --frozen-lockfile` で依存関係をインストールするステップを追加
- `claude_args` に `Bash(pnpm:*)` を許可ツールとして追加し、Claude が pnpm コマンドを実行可能に

## Test plan
- [ ] GitHub Actions ワークフローが正常に実行されることを確認
- [ ] Claude Code Action が pnpm コマンドを使用できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)