### PR TITLE
fix: handle null periodicReport from kintone API

### DIFF
--- a/src/core/adapters/kintone/reportConfigurator.ts
+++ b/src/core/adapters/kintone/reportConfigurator.ts
@@ -119,7 +119,7 @@ type KintoneReportConfig = {
   aggregations: KintoneReportAggregation[];
   filterCond: string;
   sorts: KintoneReportSort[];
-  periodicReport?: KintonePeriodicReport;
+  periodicReport?: KintonePeriodicReport | null;
 };
 
 function fromKintoneGroup(raw: KintoneReportGroup): ReportGroup {
@@ -270,7 +270,7 @@ function fromKintoneReportConfig(raw: KintoneReportConfig): ReportConfig {
     sorts: raw.sorts.map(fromKintoneSort),
   };
 
-  if (raw.periodicReport !== undefined) {
+  if (raw.periodicReport != null) {
     return {
       ...result,
       periodicReport: fromKintonePeriodicReport(raw.periodicReport),


### PR DESCRIPTION
## Summary

- kintone APIが `periodicReport: null` を返すケースで `Cannot read properties of null (reading 'active')` エラーが発生していたのを修正
- `fromKintoneReportConfig` の null チェックを `!== undefined` から `!= null` に変更し、`null` と `undefined` の両方をガード
- `KintoneReportConfig` 型の `periodicReport` フィールドに `| null` を追加してAPIの実態に合わせた

## Test plan

- [x] `pnpm typecheck` パス
- [x] `pnpm lint:fix` パス
- [x] `pnpm test` 全1671テストパス
- [ ] `periodicReport: null` を返すkintoneアプリに対して `schema capture` を実行し、エラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)