### PR TITLE
feat: use actual app name instead of app-{appId} in init command

### DIFF
--- a/src/core/adapters/empty/reportStorage.ts
+++ b/src/core/adapters/empty/reportStorage.ts
@@ -1,6 +1,6 @@
 import { SystemError, SystemErrorCode } from "@/core/application/error";
-import type { ReportStorage } from "@/core/domain/report/ports/reportStorage";
 import type { StorageResult } from "@/core/domain/ports/storageResult";
+import type { ReportStorage } from "@/core/domain/report/ports/reportStorage";
 
 export class EmptyReportStorage implements ReportStorage {
   async get(): Promise<StorageResult> {

--- a/src/core/adapters/empty/seedStorage.ts
+++ b/src/core/adapters/empty/seedStorage.ts
@@ -1,6 +1,6 @@
 import { SystemError, SystemErrorCode } from "@/core/application/error";
-import type { SeedStorage } from "@/core/domain/seedData/ports/seedStorage";
 import type { StorageResult } from "@/core/domain/ports/storageResult";
+import type { SeedStorage } from "@/core/domain/seedData/ports/seedStorage";
 
 export class EmptySeedStorage implements SeedStorage {
   async get(): Promise<StorageResult> {

--- a/src/core/adapters/empty/viewStorage.ts
+++ b/src/core/adapters/empty/viewStorage.ts
@@ -1,6 +1,6 @@
 import { SystemError, SystemErrorCode } from "@/core/application/error";
-import type { ViewStorage } from "@/core/domain/view/ports/viewStorage";
 import type { StorageResult } from "@/core/domain/ports/storageResult";
+import type { ViewStorage } from "@/core/domain/view/ports/viewStorage";
 
 export class EmptyViewStorage implements ViewStorage {
   async get(): Promise<StorageResult> {

--- a/src/core/adapters/local/processManagementStorage.ts
+++ b/src/core/adapters/local/processManagementStorage.ts
@@ -1,8 +1,8 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { SystemError, SystemErrorCode } from "@/core/application/error";
-import type { ProcessManagementStorage } from "@/core/domain/processManagement/ports/processManagementStorage";
 import type { StorageResult } from "@/core/domain/ports/storageResult";
+import type { ProcessManagementStorage } from "@/core/domain/processManagement/ports/processManagementStorage";
 import { isNodeError } from "@/lib/nodeError";
 
 export class LocalFileProcessManagementStorage

--- a/src/core/adapters/local/projectConfigStorage.ts
+++ b/src/core/adapters/local/projectConfigStorage.ts
@@ -1,8 +1,8 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { SystemError, SystemErrorCode } from "@/core/application/error";
-import type { ProjectConfigStorage } from "@/core/domain/projectConfig/ports/projectConfigStorage";
 import type { StorageResult } from "@/core/domain/ports/storageResult";
+import type { ProjectConfigStorage } from "@/core/domain/projectConfig/ports/projectConfigStorage";
 import { isNodeError } from "@/lib/nodeError";
 
 export class LocalFileProjectConfigStorage implements ProjectConfigStorage {

--- a/src/core/adapters/local/reportStorage.ts
+++ b/src/core/adapters/local/reportStorage.ts
@@ -1,8 +1,8 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { SystemError, SystemErrorCode } from "@/core/application/error";
-import type { ReportStorage } from "@/core/domain/report/ports/reportStorage";
 import type { StorageResult } from "@/core/domain/ports/storageResult";
+import type { ReportStorage } from "@/core/domain/report/ports/reportStorage";
 import { isNodeError } from "@/lib/nodeError";
 
 export class LocalFileReportStorage implements ReportStorage {

--- a/src/core/adapters/local/seedStorage.ts
+++ b/src/core/adapters/local/seedStorage.ts
@@ -1,8 +1,8 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { SystemError, SystemErrorCode } from "@/core/application/error";
-import type { SeedStorage } from "@/core/domain/seedData/ports/seedStorage";
 import type { StorageResult } from "@/core/domain/ports/storageResult";
+import type { SeedStorage } from "@/core/domain/seedData/ports/seedStorage";
 import { isNodeError } from "@/lib/nodeError";
 
 export class LocalFileSeedStorage implements SeedStorage {

--- a/src/core/adapters/local/viewStorage.ts
+++ b/src/core/adapters/local/viewStorage.ts
@@ -1,8 +1,8 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { SystemError, SystemErrorCode } from "@/core/application/error";
-import type { ViewStorage } from "@/core/domain/view/ports/viewStorage";
 import type { StorageResult } from "@/core/domain/ports/storageResult";
+import type { ViewStorage } from "@/core/domain/view/ports/viewStorage";
 import { isNodeError } from "@/lib/nodeError";
 
 export class LocalFileViewStorage implements ViewStorage {

--- a/src/core/application/init/__tests__/generateProjectConfig.test.ts
+++ b/src/core/application/init/__tests__/generateProjectConfig.test.ts
@@ -31,8 +31,24 @@ describe("generateProjectConfig", () => {
     expect(parsed.apps.myapp.files.schema).toBe("schemas/myapp.yaml");
   });
 
-  it("codeが空の場合、app-{appId}をアプリ名として使用する", () => {
+  it("codeが空の場合、アプリ名を使用する", () => {
     const apps: SpaceApp[] = [{ appId: "42", code: "", name: "No Code App" }];
+
+    const result = generateProjectConfig({
+      apps,
+      domain: "example.cybozu.com",
+    });
+
+    const parsed = parseYaml(result);
+    expect(parsed.apps["No Code App"]).toBeDefined();
+    expect(parsed.apps["No Code App"].appId).toBe("42");
+    expect(parsed.apps["No Code App"].files.schema).toBe(
+      "schemas/No Code App.yaml",
+    );
+  });
+
+  it("codeとnameが両方空の場合、app-{appId}をフォールバックとして使用する", () => {
+    const apps: SpaceApp[] = [{ appId: "42", code: "", name: "" }];
 
     const result = generateProjectConfig({
       apps,
@@ -61,7 +77,7 @@ describe("generateProjectConfig", () => {
     expect(Object.keys(parsed.apps)).toHaveLength(3);
     expect(parsed.apps.app1).toBeDefined();
     expect(parsed.apps.app2).toBeDefined();
-    expect(parsed.apps["app-3"]).toBeDefined();
+    expect(parsed.apps["App 3"]).toBeDefined();
   });
 
   it("filesオブジェクトに全ドメインのファイルパスを含む", () => {

--- a/src/core/domain/space/__tests__/entity.test.ts
+++ b/src/core/domain/space/__tests__/entity.test.ts
@@ -7,8 +7,13 @@ describe("resolveAppName", () => {
     expect(resolveAppName(app)).toBe("myapp");
   });
 
-  it("codeが空文字の場合、app-{appId}を返す", () => {
+  it("codeが空文字の場合、アプリ名を返す", () => {
     const app: SpaceApp = { appId: "42", code: "", name: "My App" };
+    expect(resolveAppName(app)).toBe("My App");
+  });
+
+  it("codeとnameが両方空の場合、app-{appId}を返す", () => {
+    const app: SpaceApp = { appId: "42", code: "", name: "" };
     expect(resolveAppName(app)).toBe("app-42");
   });
 

--- a/src/core/domain/space/entity.ts
+++ b/src/core/domain/space/entity.ts
@@ -15,6 +15,11 @@ function sanitizeForFileSystem(name: string): string {
 }
 
 export function resolveAppName(app: SpaceApp): AppName {
-  const raw = app.code !== "" ? app.code : `app-${app.appId}`;
+  const raw =
+    app.code !== ""
+      ? app.code
+      : app.name !== ""
+        ? app.name
+        : `app-${app.appId}`;
   return AppName.create(sanitizeForFileSystem(raw));
 }


### PR DESCRIPTION
## Summary
- `resolveAppName` のフォールバックロジックを変更し、`code` が空の場合に `app-{appId}` ではなく kintone の実際のアプリ名を使用するように修正
- 優先順位: `code` > `name` > `app-{appId}`（`code` と `name` が両方空の場合のみ最終フォールバック）
- ドメイン層・アプリケーション層のテストを更新・追加

## Test plan
- [x] `pnpm test` 全テストパス (1678 tests)
- [x] `pnpm typecheck` 型チェック通過
- [x] `pnpm lint:fix && pnpm format` lint/format通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)