### PR TITLE
feat: change file path structure from feature/appName to appName/feature

### DIFF
--- a/src/core/application/init/__tests__/generateProjectConfig.test.ts
+++ b/src/core/application/init/__tests__/generateProjectConfig.test.ts
@@ -28,7 +28,7 @@ describe("generateProjectConfig", () => {
     const parsed = parseYaml(result);
     expect(parsed.apps.myapp).toBeDefined();
     expect(parsed.apps.myapp.appId).toBe("1");
-    expect(parsed.apps.myapp.files.schema).toBe("schemas/myapp.yaml");
+    expect(parsed.apps.myapp.files.schema).toBe("myapp/schema.yaml");
   });
 
   it("codeが空の場合、アプリ名を使用する", () => {
@@ -43,7 +43,7 @@ describe("generateProjectConfig", () => {
     expect(parsed.apps["No Code App"]).toBeDefined();
     expect(parsed.apps["No Code App"].appId).toBe("42");
     expect(parsed.apps["No Code App"].files.schema).toBe(
-      "schemas/No Code App.yaml",
+      "No Code App/schema.yaml",
     );
   });
 
@@ -58,7 +58,7 @@ describe("generateProjectConfig", () => {
     const parsed = parseYaml(result);
     expect(parsed.apps["app-42"]).toBeDefined();
     expect(parsed.apps["app-42"].appId).toBe("42");
-    expect(parsed.apps["app-42"].files.schema).toBe("schemas/app-42.yaml");
+    expect(parsed.apps["app-42"].files.schema).toBe("app-42/schema.yaml");
   });
 
   it("複数アプリの設定を生成する", () => {
@@ -90,20 +90,20 @@ describe("generateProjectConfig", () => {
 
     const parsed = parseYaml(result);
     const files = parsed.apps.myapp.files;
-    expect(files.schema).toBe("schemas/myapp.yaml");
-    expect(files.seed).toBe("seeds/myapp.yaml");
-    expect(files.customize).toBe("customize/myapp.yaml");
-    expect(files.view).toBe("view/myapp.yaml");
-    expect(files.settings).toBe("settings/myapp.yaml");
-    expect(files.notification).toBe("notification/myapp.yaml");
-    expect(files.report).toBe("report/myapp.yaml");
-    expect(files.action).toBe("action/myapp.yaml");
-    expect(files.process).toBe("process/myapp.yaml");
-    expect(files.fieldAcl).toBe("field-acl/myapp.yaml");
-    expect(files.appAcl).toBe("app-acl/myapp.yaml");
-    expect(files.recordAcl).toBe("record-acl/myapp.yaml");
-    expect(files.adminNotes).toBe("admin-notes/myapp.yaml");
-    expect(files.plugin).toBe("plugin/myapp.yaml");
+    expect(files.schema).toBe("myapp/schema.yaml");
+    expect(files.seed).toBe("myapp/seed.yaml");
+    expect(files.customize).toBe("myapp/customize.yaml");
+    expect(files.view).toBe("myapp/view.yaml");
+    expect(files.settings).toBe("myapp/settings.yaml");
+    expect(files.notification).toBe("myapp/notification.yaml");
+    expect(files.report).toBe("myapp/report.yaml");
+    expect(files.action).toBe("myapp/action.yaml");
+    expect(files.process).toBe("myapp/process.yaml");
+    expect(files.fieldAcl).toBe("myapp/field-acl.yaml");
+    expect(files.appAcl).toBe("myapp/app-acl.yaml");
+    expect(files.recordAcl).toBe("myapp/record-acl.yaml");
+    expect(files.adminNotes).toBe("myapp/admin-notes.yaml");
+    expect(files.plugin).toBe("myapp/plugin.yaml");
   });
 
   it("guestSpaceIdが指定された場合、設定に含める", () => {
@@ -147,7 +147,7 @@ describe("generateProjectConfig", () => {
     expect(parsed.apps.myapp.appId).toBe("1");
     expect(parsed.apps["myapp-2"]).toBeDefined();
     expect(parsed.apps["myapp-2"].appId).toBe("2");
-    expect(parsed.apps["myapp-2"].files.schema).toBe("schemas/myapp-2.yaml");
+    expect(parsed.apps["myapp-2"].files.schema).toBe("myapp-2/schema.yaml");
   });
 
   it("生成された設定にauthフィールドが含まれない", () => {

--- a/src/core/domain/projectConfig/__tests__/appFilePaths.test.ts
+++ b/src/core/domain/projectConfig/__tests__/appFilePaths.test.ts
@@ -8,39 +8,39 @@ describe("buildAppFilePaths", () => {
   it("returns paths without baseDir prefix when baseDir is omitted", () => {
     const paths = buildAppFilePaths(appName);
 
-    expect(paths.schema).toBe("schemas/customer.yaml");
-    expect(paths.seed).toBe("seeds/customer.yaml");
-    expect(paths.customize).toBe("customize/customer.yaml");
-    expect(paths.view).toBe("view/customer.yaml");
-    expect(paths.settings).toBe("settings/customer.yaml");
-    expect(paths.notification).toBe("notification/customer.yaml");
-    expect(paths.report).toBe("report/customer.yaml");
-    expect(paths.action).toBe("action/customer.yaml");
-    expect(paths.process).toBe("process/customer.yaml");
-    expect(paths.fieldAcl).toBe("field-acl/customer.yaml");
-    expect(paths.appAcl).toBe("app-acl/customer.yaml");
-    expect(paths.recordAcl).toBe("record-acl/customer.yaml");
-    expect(paths.adminNotes).toBe("admin-notes/customer.yaml");
-    expect(paths.plugin).toBe("plugin/customer.yaml");
+    expect(paths.schema).toBe("customer/schema.yaml");
+    expect(paths.seed).toBe("customer/seed.yaml");
+    expect(paths.customize).toBe("customer/customize.yaml");
+    expect(paths.view).toBe("customer/view.yaml");
+    expect(paths.settings).toBe("customer/settings.yaml");
+    expect(paths.notification).toBe("customer/notification.yaml");
+    expect(paths.report).toBe("customer/report.yaml");
+    expect(paths.action).toBe("customer/action.yaml");
+    expect(paths.process).toBe("customer/process.yaml");
+    expect(paths.fieldAcl).toBe("customer/field-acl.yaml");
+    expect(paths.appAcl).toBe("customer/app-acl.yaml");
+    expect(paths.recordAcl).toBe("customer/record-acl.yaml");
+    expect(paths.adminNotes).toBe("customer/admin-notes.yaml");
+    expect(paths.plugin).toBe("customer/plugin.yaml");
   });
 
   it("returns paths prefixed with baseDir when baseDir is provided", () => {
     const paths = buildAppFilePaths(appName, "output");
 
-    expect(paths.schema).toBe("output/schemas/customer.yaml");
-    expect(paths.seed).toBe("output/seeds/customer.yaml");
-    expect(paths.customize).toBe("output/customize/customer.yaml");
-    expect(paths.view).toBe("output/view/customer.yaml");
-    expect(paths.settings).toBe("output/settings/customer.yaml");
-    expect(paths.notification).toBe("output/notification/customer.yaml");
-    expect(paths.report).toBe("output/report/customer.yaml");
-    expect(paths.action).toBe("output/action/customer.yaml");
-    expect(paths.process).toBe("output/process/customer.yaml");
-    expect(paths.fieldAcl).toBe("output/field-acl/customer.yaml");
-    expect(paths.appAcl).toBe("output/app-acl/customer.yaml");
-    expect(paths.recordAcl).toBe("output/record-acl/customer.yaml");
-    expect(paths.adminNotes).toBe("output/admin-notes/customer.yaml");
-    expect(paths.plugin).toBe("output/plugin/customer.yaml");
+    expect(paths.schema).toBe("output/customer/schema.yaml");
+    expect(paths.seed).toBe("output/customer/seed.yaml");
+    expect(paths.customize).toBe("output/customer/customize.yaml");
+    expect(paths.view).toBe("output/customer/view.yaml");
+    expect(paths.settings).toBe("output/customer/settings.yaml");
+    expect(paths.notification).toBe("output/customer/notification.yaml");
+    expect(paths.report).toBe("output/customer/report.yaml");
+    expect(paths.action).toBe("output/customer/action.yaml");
+    expect(paths.process).toBe("output/customer/process.yaml");
+    expect(paths.fieldAcl).toBe("output/customer/field-acl.yaml");
+    expect(paths.appAcl).toBe("output/customer/app-acl.yaml");
+    expect(paths.recordAcl).toBe("output/customer/record-acl.yaml");
+    expect(paths.adminNotes).toBe("output/customer/admin-notes.yaml");
+    expect(paths.plugin).toBe("output/customer/plugin.yaml");
   });
 
   it("returns all 14 fields", () => {

--- a/src/core/domain/projectConfig/appFilePaths.ts
+++ b/src/core/domain/projectConfig/appFilePaths.ts
@@ -25,19 +25,19 @@ export function buildAppFilePaths(
   const prefix = (path: string): string =>
     baseDir ? join(baseDir, path) : path;
   return {
-    schema: prefix(`schemas/${appName}.yaml`),
-    seed: prefix(`seeds/${appName}.yaml`),
-    customize: prefix(`customize/${appName}.yaml`),
-    view: prefix(`view/${appName}.yaml`),
-    settings: prefix(`settings/${appName}.yaml`),
-    notification: prefix(`notification/${appName}.yaml`),
-    report: prefix(`report/${appName}.yaml`),
-    action: prefix(`action/${appName}.yaml`),
-    process: prefix(`process/${appName}.yaml`),
-    fieldAcl: prefix(`field-acl/${appName}.yaml`),
-    appAcl: prefix(`app-acl/${appName}.yaml`),
-    recordAcl: prefix(`record-acl/${appName}.yaml`),
-    adminNotes: prefix(`admin-notes/${appName}.yaml`),
-    plugin: prefix(`plugin/${appName}.yaml`),
+    schema: prefix(`${appName}/schema.yaml`),
+    seed: prefix(`${appName}/seed.yaml`),
+    customize: prefix(`${appName}/customize.yaml`),
+    view: prefix(`${appName}/view.yaml`),
+    settings: prefix(`${appName}/settings.yaml`),
+    notification: prefix(`${appName}/notification.yaml`),
+    report: prefix(`${appName}/report.yaml`),
+    action: prefix(`${appName}/action.yaml`),
+    process: prefix(`${appName}/process.yaml`),
+    fieldAcl: prefix(`${appName}/field-acl.yaml`),
+    appAcl: prefix(`${appName}/app-acl.yaml`),
+    recordAcl: prefix(`${appName}/record-acl.yaml`),
+    adminNotes: prefix(`${appName}/admin-notes.yaml`),
+    plugin: prefix(`${appName}/plugin.yaml`),
   };
 }


### PR DESCRIPTION
## Summary
- ファイルパス構造を `機能名/アプリ名.yaml`（例: `schemas/myapp.yaml`）から `アプリ名/機能名.yaml`（例: `myapp/schema.yaml`）に変更
- `buildAppFilePaths()` のパス生成ロジックを更新し、アプリ単位でファイルをグルーピングするように変更
- 関連テスト（`appFilePaths.test.ts`, `generateProjectConfig.test.ts`）の期待値を新パス構造に更新

## Test plan
- [x] `pnpm test` で全1678テストがパス
- [x] `pnpm typecheck` で型チェック通過
- [x] `pnpm lint:fix && pnpm format` でlint/format通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)