### PR TITLE
fix: grant write permissions to Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,9 +19,9 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Summary
- Claude GitHub Actions workflow の permissions を `read` → `write` に変更
  - `contents: write`
  - `pull-requests: write`
  - `issues: write`

## Test plan
- [ ] Claude がPR/issueに対してコメントや操作を行えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)