### PR TITLE
fix: always place config file at project root regardless of --output

### DIFF
--- a/src/cli/commands/__tests__/init.test.ts
+++ b/src/cli/commands/__tests__/init.test.ts
@@ -255,7 +255,7 @@ describe("init コマンド", () => {
     expect(handleCliError).not.toHaveBeenCalled();
     expect(createInitCliContainer).toHaveBeenCalledWith(
       expect.objectContaining({
-        configFilePath: "mydir/kintone-migrator.yaml",
+        configFilePath: "kintone-migrator.yaml",
       }),
     );
     expect(generateProjectConfig).toHaveBeenCalledWith(

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -1,4 +1,4 @@
-import { dirname, join, resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import * as p from "@clack/prompts";
 import { define } from "gunshi";
 import pc from "picocolors";
@@ -108,9 +108,7 @@ export default define({
       const guestSpaceId =
         values["guest-space-id"] ?? process.env.KINTONE_GUEST_SPACE_ID;
       const output = values.output;
-      const configPath = output
-        ? join(output, DEFAULT_CONFIG_PATH)
-        : DEFAULT_CONFIG_PATH;
+      const configPath = DEFAULT_CONFIG_PATH;
       const skipConfirm = values.yes ?? false;
       const dryRun = values["dry-run"] ?? false;
 


### PR DESCRIPTION
## Summary
- `init --output mydir` 指定時に `kintone-migrator.yaml` が `mydir/` 配下に作られてしまい、後続コマンド（`schema capture`, `customize apply` 等）がCWDの設定ファイルを見つけられない問題を修正
- 設定ファイルは常にCWDルートに配置し、YAML内のファイルパスで出力ディレクトリを参照するように変更

## Test plan
- [x] `pnpm test` — 全1678テストパス
- [x] `pnpm typecheck` — エラーなし
- [x] `pnpm lint:fix && pnpm format` — 問題なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)