### PR TITLE
fix(customize): YAML内のリソースパスからアプリ名の重複を除去

### DIFF
--- a/src/cli/commands/customize/apply.ts
+++ b/src/cli/commands/customize/apply.ts
@@ -1,4 +1,4 @@
-import { dirname, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import * as p from "@clack/prompts";
 import { define } from "gunshi";
 import {
@@ -17,12 +17,14 @@ import {
 import { handleCliError } from "../../handleError";
 import { confirmAndDeploy, printAppHeader } from "../../output";
 import { routeMultiApp, runMultiAppWithFailCheck } from "../../projectConfig";
+import { deriveFilePrefix } from "./capture";
 
 async function applyCustomizationForApp(
   config: CustomizationCliContainerConfig,
 ): Promise<CustomizationContainer> {
   const container = createCustomizationCliContainer(config);
-  const basePath = dirname(resolve(config.customizeFilePath));
+  const filePrefix = deriveFilePrefix(config.customizeFilePath);
+  const basePath = join(dirname(resolve(config.customizeFilePath)), filePrefix);
 
   const s = p.spinner();
   s.start("Applying customization...");

--- a/src/core/application/customization/__tests__/captureCustomization.test.ts
+++ b/src/core/application/customization/__tests__/captureCustomization.test.ts
@@ -52,7 +52,7 @@ describe("captureCustomization", () => {
     expect(parsed.desktop.js).toHaveLength(1);
     expect(parsed.desktop.js[0]).toEqual({
       type: "FILE",
-      path: "myapp/desktop/js/app.js",
+      path: "desktop/js/app.js",
     });
 
     expect(container.fileDownloader.callLog).toContain("download");
@@ -133,10 +133,10 @@ describe("captureCustomization", () => {
 
     const parsed = ConfigParser.parse(result.configText);
     expect(parsed.desktop.js).toEqual([
-      { type: "FILE", path: "myapp/desktop/js/desktop.js" },
+      { type: "FILE", path: "desktop/js/desktop.js" },
     ]);
     expect(parsed.mobile.js).toEqual([
-      { type: "FILE", path: "myapp/mobile/js/mobile.js" },
+      { type: "FILE", path: "mobile/js/mobile.js" },
     ]);
 
     expect(container.fileWriter.writtenFiles.size).toBe(2);
@@ -186,7 +186,7 @@ describe("captureCustomization", () => {
     expect(parsed.desktop.js).toHaveLength(2);
     expect(parsed.desktop.js[0]).toEqual({
       type: "FILE",
-      path: "myapp/desktop/js/app.js",
+      path: "desktop/js/app.js",
     });
     expect(parsed.desktop.js[1]).toEqual({
       type: "URL",
@@ -195,7 +195,7 @@ describe("captureCustomization", () => {
     expect(parsed.desktop.css).toHaveLength(1);
     expect(parsed.desktop.css[0]).toEqual({
       type: "FILE",
-      path: "myapp/desktop/css/style.css",
+      path: "desktop/css/style.css",
     });
   });
 
@@ -269,7 +269,7 @@ describe("captureCustomization", () => {
     const parsed = ConfigParser.parse(result.configText);
     expect(parsed.desktop.js[0]).toEqual({
       type: "FILE",
-      path: "myapp/desktop/js/passwd",
+      path: "desktop/js/passwd",
     });
     expect(
       container.fileWriter.writtenFiles.has(
@@ -318,11 +318,11 @@ describe("captureCustomization", () => {
     expect(parsed.desktop.js).toHaveLength(2);
     expect(parsed.desktop.js[0]).toEqual({
       type: "FILE",
-      path: "myapp/desktop/js/app.js",
+      path: "desktop/js/app.js",
     });
     expect(parsed.desktop.js[1]).toEqual({
       type: "FILE",
-      path: "myapp/desktop/js/app_1.js",
+      path: "desktop/js/app_1.js",
     });
 
     expect(container.fileWriter.writtenFiles.size).toBe(2);

--- a/src/core/application/customization/captureCustomization.ts
+++ b/src/core/application/customization/captureCustomization.ts
@@ -140,7 +140,7 @@ function planPlatform(
     args.input.filePrefix,
     platformName,
   );
-  const platformPrefix = join(args.input.filePrefix, platformName);
+  const platformPrefix = platformName;
 
   const jsPlan = planResources(
     remotePlatform.js,


### PR DESCRIPTION
## Summary

- マルチアプリ構成で `customize capture` した際、YAML内のファイルパスに冗長なアプリ名プレフィックスが含まれていた問題を修正
- capture側: YAML内の相対パスから `filePrefix`（アプリ名）を除外
- apply側: `basePath` に `filePrefix` を組み込み、ファイル解決の整合性を維持

### Before
```yaml
# customize/customer.yaml
desktop:
  js:
    - type: FILE
      path: customer/desktop/js/app.js  # "customer" が冗長
```

### After
```yaml
# customize/customer.yaml
desktop:
  js:
    - type: FILE
      path: desktop/js/app.js  # スッキリ
```

## Test plan

- [x] `pnpm typecheck` パス
- [x] `pnpm lint:fix` パス
- [x] `pnpm test` 全1678テストパス
- [ ] マルチアプリ構成で `customize capture` → `customize apply` の往復確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)