### PR TITLE
fix: サブテーブル行内の配列フィールドが文字列に変換される問題を修正

### DIFF
--- a/src/core/domain/seedData/services/__tests__/seedParser.test.ts
+++ b/src/core/domain/seedData/services/__tests__/seedParser.test.ts
@@ -68,6 +68,27 @@ records:
     expect(items[0].price).toBe("1000");
   });
 
+  it("サブテーブル行内の配列フィールドをパースする", () => {
+    const yaml = `
+key: code
+records:
+  - code: "001"
+    items:
+      - product: "商品A"
+        options:
+          - "オプション1"
+          - "オプション2"
+`;
+    const result = SeedParser.parse(yaml);
+    const items = result.records[0].items as readonly Record<
+      string,
+      string | readonly string[]
+    >[];
+    expect(items).toHaveLength(1);
+    expect(items[0].product).toBe("商品A");
+    expect(items[0].options).toEqual(["オプション1", "オプション2"]);
+  });
+
   it("数値を文字列に変換する", () => {
     const yaml = `
 key: code

--- a/src/core/domain/seedData/services/seedParser.ts
+++ b/src/core/domain/seedData/services/seedParser.ts
@@ -40,12 +40,16 @@ function normalizeValue(value: unknown): RecordFieldValue {
     }
     // Subtable rows
     return value.filter(isRecord).map((row) => {
-      const normalized: Record<string, string> = {};
+      const normalized: Record<string, string | readonly string[]> = {};
       for (const [k, v] of Object.entries(row)) {
-        normalized[k] = v === null || v === undefined ? "" : String(v);
+        if (Array.isArray(v)) {
+          normalized[k] = v.map(String) as readonly string[];
+        } else {
+          normalized[k] = v === null || v === undefined ? "" : String(v);
+        }
       }
       return normalized;
-    }) as readonly Record<string, string>[];
+    }) as readonly Record<string, string | readonly string[]>[];
   }
   return String(value);
 }


### PR DESCRIPTION
## Summary

- `seedParser` の `normalizeValue` でサブテーブル行を処理する際、行内のフィールド値が配列（チェックボックス等）の場合も `String()` で文字列化されていたバグを修正
- 配列フィールドは `string[]` として保持するよう変更
- 対応するテストケースを追加

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (172 test files / 1702 tests)
- [x] 新規テスト「サブテーブル行内の配列フィールドをパースする」が追加済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)