### PR TITLE
refactor: CLI Config ファイル群のボイラープレート統合

### DIFF
--- a/src/cli/__tests__/createDomainConfigResolver.test.ts
+++ b/src/cli/__tests__/createDomainConfigResolver.test.ts
@@ -38,11 +38,7 @@ describe("createDomainConfigResolver", () => {
   });
 
   it("resolveFilePathがデフォルトのファイル名を返す", () => {
-    const { resolveFilePath } = createDomainConfigResolver<
-      TestContainerConfig,
-      "test-file",
-      TestCliValues
-    >({
+    const { resolveFilePath } = createDomainConfigResolver({
       fileArgKey: "test-file",
       envVar: () => undefined,
       appFileField: () => undefined,
@@ -55,11 +51,7 @@ describe("createDomainConfigResolver", () => {
   });
 
   it("resolveFilePathがCLI引数を優先する", () => {
-    const { resolveFilePath } = createDomainConfigResolver<
-      TestContainerConfig,
-      "test-file",
-      TestCliValues
-    >({
+    const { resolveFilePath } = createDomainConfigResolver({
       fileArgKey: "test-file",
       envVar: () => "env-path.yaml",
       appFileField: () => undefined,
@@ -74,11 +66,7 @@ describe("createDomainConfigResolver", () => {
   });
 
   it("resolveFilePathが環境変数をフォールバックとして使う", () => {
-    const { resolveFilePath } = createDomainConfigResolver<
-      TestContainerConfig,
-      "test-file",
-      TestCliValues
-    >({
+    const { resolveFilePath } = createDomainConfigResolver({
       fileArgKey: "test-file",
       envVar: () => "env-path.yaml",
       appFileField: () => undefined,
@@ -93,11 +81,7 @@ describe("createDomainConfigResolver", () => {
   it("resolveContainerConfigが正しいconfigオブジェクトを返す", () => {
     setupEnv();
 
-    const { resolveContainerConfig } = createDomainConfigResolver<
-      TestContainerConfig,
-      "test-file",
-      TestCliValues
-    >({
+    const { resolveContainerConfig } = createDomainConfigResolver({
       fileArgKey: "test-file",
       envVar: () => undefined,
       appFileField: () => undefined,
@@ -129,11 +113,7 @@ describe("createDomainConfigResolver", () => {
       apps: new Map([[appName, app]]),
     };
 
-    const { resolveAppContainerConfig } = createDomainConfigResolver<
-      TestContainerConfig,
-      "test-file",
-      TestCliValues
-    >({
+    const { resolveAppContainerConfig } = createDomainConfigResolver({
       fileArgKey: "test-file",
       envVar: () => undefined,
       appFileField: (a) =>
@@ -144,17 +124,16 @@ describe("createDomainConfigResolver", () => {
     });
 
     const config = resolveAppContainerConfig(app, projectConfig, baseValues);
-    expect(config.baseUrl).toBe("https://project.cybozu.com");
-    expect(config.appId).toBe("100");
-    expect(config.testFilePath).toBe("custom-test.yaml");
+    expect(config).toEqual({
+      baseUrl: "https://project.cybozu.com",
+      auth: { type: "apiToken", apiToken: "project-token" },
+      appId: "100",
+      testFilePath: "custom-test.yaml",
+    });
   });
 
   it("envVarがモジュールロード時ではなく呼び出し時に評価される", () => {
-    const { resolveFilePath } = createDomainConfigResolver<
-      TestContainerConfig,
-      "test-file",
-      TestCliValues
-    >({
+    const { resolveFilePath } = createDomainConfigResolver({
       fileArgKey: "test-file",
       envVar: () => process.env.TEST_FILE_PATH,
       appFileField: () => undefined,

--- a/src/cli/actionConfig.ts
+++ b/src/cli/actionConfig.ts
@@ -20,17 +20,16 @@ const {
   resolveFilePath: resolveActionFilePath,
   resolveContainerConfig: resolveActionContainerConfig,
   resolveAppContainerConfig: resolveActionAppContainerConfig,
-} = createDomainConfigResolver<
-  ActionCliContainerConfig,
-  "action-file",
-  ActionCliValues
->({
+} = createDomainConfigResolver({
   fileArgKey: "action-file",
   envVar: () => process.env.ACTION_FILE_PATH,
   appFileField: (a) => a.actionFile,
   defaultDir: "action",
   defaultFileName: "actions.yaml",
-  buildConfig: (base, filePath) => ({ ...base, actionFilePath: filePath }),
+  buildConfig: (base, filePath): ActionCliContainerConfig => ({
+    ...base,
+    actionFilePath: filePath,
+  }),
 });
 
 export {

--- a/src/cli/adminNotesConfig.ts
+++ b/src/cli/adminNotesConfig.ts
@@ -20,17 +20,13 @@ const {
   resolveFilePath: resolveAdminNotesFilePath,
   resolveContainerConfig: resolveAdminNotesContainerConfig,
   resolveAppContainerConfig: resolveAdminNotesAppContainerConfig,
-} = createDomainConfigResolver<
-  AdminNotesCliContainerConfig,
-  "admin-notes-file",
-  AdminNotesCliValues
->({
+} = createDomainConfigResolver({
   fileArgKey: "admin-notes-file",
   envVar: () => process.env.ADMIN_NOTES_FILE_PATH,
   appFileField: (a) => a.adminNotesFile,
   defaultDir: "admin-notes",
   defaultFileName: "admin-notes.yaml",
-  buildConfig: (base, filePath) => ({
+  buildConfig: (base, filePath): AdminNotesCliContainerConfig => ({
     ...base,
     adminNotesFilePath: filePath,
   }),

--- a/src/cli/appAclConfig.ts
+++ b/src/cli/appAclConfig.ts
@@ -20,17 +20,16 @@ const {
   resolveFilePath: resolveAppAclFilePath,
   resolveContainerConfig: resolveAppAclContainerConfig,
   resolveAppContainerConfig: resolveAppAclAppContainerConfig,
-} = createDomainConfigResolver<
-  AppPermissionCliContainerConfig,
-  "app-acl-file",
-  AppAclCliValues
->({
+} = createDomainConfigResolver({
   fileArgKey: "app-acl-file",
   envVar: () => process.env.APP_ACL_FILE_PATH,
   appFileField: (a) => a.appAclFile,
   defaultDir: "app-acl",
   defaultFileName: "app-acl.yaml",
-  buildConfig: (base, filePath) => ({ ...base, appAclFilePath: filePath }),
+  buildConfig: (base, filePath): AppPermissionCliContainerConfig => ({
+    ...base,
+    appAclFilePath: filePath,
+  }),
 });
 
 export {

--- a/src/cli/commands/seed/config.ts
+++ b/src/cli/commands/seed/config.ts
@@ -13,17 +13,16 @@ const {
   resolveFilePath: resolveSeedFilePath,
   resolveContainerConfig: resolveSeedConfig,
   resolveAppContainerConfig: resolveSeedAppConfig,
-} = createDomainConfigResolver<
-  SeedCliContainerConfig,
-  "seed-file",
-  SeedCliValues
->({
+} = createDomainConfigResolver({
   fileArgKey: "seed-file",
   envVar: () => process.env.SEED_FILE_PATH,
   appFileField: (a) => a.seedFile,
   defaultDir: "seeds",
   defaultFileName: "seed.yaml",
-  buildConfig: (base, filePath) => ({ ...base, seedFilePath: filePath }),
+  buildConfig: (base, filePath): SeedCliContainerConfig => ({
+    ...base,
+    seedFilePath: filePath,
+  }),
 });
 
 export { resolveSeedFilePath, resolveSeedConfig, resolveSeedAppConfig };

--- a/src/cli/customizeConfig.ts
+++ b/src/cli/customizeConfig.ts
@@ -20,17 +20,13 @@ const {
   resolveFilePath: resolveCustomizeFilePath,
   resolveContainerConfig: resolveCustomizeConfig,
   resolveAppContainerConfig: resolveCustomizeAppConfig,
-} = createDomainConfigResolver<
-  CustomizationCliContainerConfig,
-  "customize-file",
-  CustomizeCliValues
->({
+} = createDomainConfigResolver({
   fileArgKey: "customize-file",
   envVar: () => process.env.CUSTOMIZE_FILE_PATH,
   appFileField: (a) => a.customizeFile,
   defaultDir: "customize",
   defaultFileName: "customize.yaml",
-  buildConfig: (base, filePath) => ({
+  buildConfig: (base, filePath): CustomizationCliContainerConfig => ({
     ...base,
     customizeFilePath: filePath,
   }),

--- a/src/cli/fieldAclConfig.ts
+++ b/src/cli/fieldAclConfig.ts
@@ -20,17 +20,13 @@ const {
   resolveFilePath: resolveFieldAclFilePath,
   resolveContainerConfig: resolveFieldAclContainerConfig,
   resolveAppContainerConfig: resolveFieldAclAppContainerConfig,
-} = createDomainConfigResolver<
-  FieldPermissionCliContainerConfig,
-  "field-acl-file",
-  FieldAclCliValues
->({
+} = createDomainConfigResolver({
   fileArgKey: "field-acl-file",
   envVar: () => process.env.FIELD_ACL_FILE_PATH,
   appFileField: (a) => a.fieldAclFile,
   defaultDir: "field-acl",
   defaultFileName: "field-acl.yaml",
-  buildConfig: (base, filePath) => ({
+  buildConfig: (base, filePath): FieldPermissionCliContainerConfig => ({
     ...base,
     fieldAclFilePath: filePath,
   }),

--- a/src/cli/notificationConfig.ts
+++ b/src/cli/notificationConfig.ts
@@ -20,17 +20,13 @@ const {
   resolveFilePath: resolveNotificationFilePath,
   resolveContainerConfig: resolveNotificationContainerConfig,
   resolveAppContainerConfig: resolveNotificationAppContainerConfig,
-} = createDomainConfigResolver<
-  NotificationCliContainerConfig,
-  "notification-file",
-  NotificationCliValues
->({
+} = createDomainConfigResolver({
   fileArgKey: "notification-file",
   envVar: () => process.env.NOTIFICATION_FILE_PATH,
   appFileField: (a) => a.notificationFile,
   defaultDir: "notification",
   defaultFileName: "notification.yaml",
-  buildConfig: (base, filePath) => ({
+  buildConfig: (base, filePath): NotificationCliContainerConfig => ({
     ...base,
     notificationFilePath: filePath,
   }),

--- a/src/cli/pluginConfig.ts
+++ b/src/cli/pluginConfig.ts
@@ -20,17 +20,16 @@ const {
   resolveFilePath: resolvePluginFilePath,
   resolveContainerConfig: resolvePluginContainerConfig,
   resolveAppContainerConfig: resolvePluginAppContainerConfig,
-} = createDomainConfigResolver<
-  PluginCliContainerConfig,
-  "plugin-file",
-  PluginCliValues
->({
+} = createDomainConfigResolver({
   fileArgKey: "plugin-file",
   envVar: () => process.env.PLUGIN_FILE_PATH,
   appFileField: (a) => a.pluginFile,
   defaultDir: "plugin",
   defaultFileName: "plugins.yaml",
-  buildConfig: (base, filePath) => ({ ...base, pluginFilePath: filePath }),
+  buildConfig: (base, filePath): PluginCliContainerConfig => ({
+    ...base,
+    pluginFilePath: filePath,
+  }),
 });
 
 export {

--- a/src/cli/processConfig.ts
+++ b/src/cli/processConfig.ts
@@ -20,17 +20,13 @@ const {
   resolveFilePath: resolveProcessFilePath,
   resolveContainerConfig: resolveProcessContainerConfig,
   resolveAppContainerConfig: resolveProcessAppContainerConfig,
-} = createDomainConfigResolver<
-  ProcessManagementCliContainerConfig,
-  "process-file",
-  ProcessCliValues
->({
+} = createDomainConfigResolver({
   fileArgKey: "process-file",
   envVar: () => process.env.PROCESS_FILE_PATH,
   appFileField: (a) => a.processFile,
   defaultDir: "process",
   defaultFileName: "process.yaml",
-  buildConfig: (base, filePath) => ({
+  buildConfig: (base, filePath): ProcessManagementCliContainerConfig => ({
     ...base,
     processFilePath: filePath,
   }),

--- a/src/cli/recordAclConfig.ts
+++ b/src/cli/recordAclConfig.ts
@@ -20,17 +20,13 @@ const {
   resolveFilePath: resolveRecordAclFilePath,
   resolveContainerConfig: resolveRecordAclContainerConfig,
   resolveAppContainerConfig: resolveRecordAclAppContainerConfig,
-} = createDomainConfigResolver<
-  RecordPermissionCliContainerConfig,
-  "record-acl-file",
-  RecordAclCliValues
->({
+} = createDomainConfigResolver({
   fileArgKey: "record-acl-file",
   envVar: () => process.env.RECORD_ACL_FILE_PATH,
   appFileField: (a) => a.recordAclFile,
   defaultDir: "record-acl",
   defaultFileName: "record-acl.yaml",
-  buildConfig: (base, filePath) => ({
+  buildConfig: (base, filePath): RecordPermissionCliContainerConfig => ({
     ...base,
     recordAclFilePath: filePath,
   }),

--- a/src/cli/reportConfig.ts
+++ b/src/cli/reportConfig.ts
@@ -20,17 +20,16 @@ const {
   resolveFilePath: resolveReportFilePath,
   resolveContainerConfig: resolveReportContainerConfig,
   resolveAppContainerConfig: resolveReportAppContainerConfig,
-} = createDomainConfigResolver<
-  ReportCliContainerConfig,
-  "report-file",
-  ReportCliValues
->({
+} = createDomainConfigResolver({
   fileArgKey: "report-file",
   envVar: () => process.env.REPORT_FILE_PATH,
   appFileField: (a) => a.reportFile,
   defaultDir: "report",
   defaultFileName: "reports.yaml",
-  buildConfig: (base, filePath) => ({ ...base, reportFilePath: filePath }),
+  buildConfig: (base, filePath): ReportCliContainerConfig => ({
+    ...base,
+    reportFilePath: filePath,
+  }),
 });
 
 export {

--- a/src/cli/settingsConfig.ts
+++ b/src/cli/settingsConfig.ts
@@ -20,17 +20,13 @@ const {
   resolveFilePath: resolveSettingsFilePath,
   resolveContainerConfig: resolveSettingsContainerConfig,
   resolveAppContainerConfig: resolveSettingsAppContainerConfig,
-} = createDomainConfigResolver<
-  GeneralSettingsCliContainerConfig,
-  "settings-file",
-  SettingsCliValues
->({
+} = createDomainConfigResolver({
   fileArgKey: "settings-file",
   envVar: () => process.env.SETTINGS_FILE_PATH,
   appFileField: (a) => a.settingsFile,
   defaultDir: "settings",
   defaultFileName: "settings.yaml",
-  buildConfig: (base, filePath) => ({
+  buildConfig: (base, filePath): GeneralSettingsCliContainerConfig => ({
     ...base,
     settingsFilePath: filePath,
   }),

--- a/src/cli/viewConfig.ts
+++ b/src/cli/viewConfig.ts
@@ -20,17 +20,16 @@ const {
   resolveFilePath: resolveViewFilePath,
   resolveContainerConfig: resolveViewContainerConfig,
   resolveAppContainerConfig: resolveViewAppContainerConfig,
-} = createDomainConfigResolver<
-  ViewCliContainerConfig,
-  "view-file",
-  ViewCliValues
->({
+} = createDomainConfigResolver({
   fileArgKey: "view-file",
   envVar: () => process.env.VIEW_FILE_PATH,
   appFileField: (a) => a.viewFile,
   defaultDir: "view",
   defaultFileName: "views.yaml",
-  buildConfig: (base, filePath) => ({ ...base, viewFilePath: filePath }),
+  buildConfig: (base, filePath): ViewCliContainerConfig => ({
+    ...base,
+    viewFilePath: filePath,
+  }),
 });
 
 export {


### PR DESCRIPTION
Closes #57

## Summary

- `createDomainConfigResolver` ファクトリ関数を `src/cli/createDomainConfigResolver.ts` に新規作成
- CLI層の 13ファイル (`*Config.ts`) が持つ同一パターンをファクトリ呼び出しに置換
- 627行削除・372行追加で正味255行削減

## Test plan

- [x] `pnpm typecheck` 通過
- [x] `pnpm lint:fix` 通過
- [x] `pnpm test` 172テストファイル・1702ケース全通過

Generated with [Claude Code](https://claude.ai/code)