### PR TITLE
fix: Application Layer レビュー対応

### DIFF
--- a/src/core/application/action/applyAction.ts
+++ b/src/core/application/action/applyAction.ts
@@ -1,23 +1,20 @@
+import { applyFromConfig } from "../applyFromConfigBase";
 import type { ActionServiceArgs } from "../container/action";
-import { ValidationError, ValidationErrorCode } from "../error";
 import { parseActionConfigText } from "./parseConfig";
 
 export async function applyAction({
   container,
 }: ActionServiceArgs): Promise<void> {
-  const result = await container.actionStorage.get();
-  if (!result.exists) {
-    throw new ValidationError(
-      ValidationErrorCode.InvalidInput,
-      "Action config file not found",
-    );
-  }
-  const config = parseActionConfigText(result.content);
-
-  const current = await container.actionConfigurator.getActions();
-
-  await container.actionConfigurator.updateActions({
-    actions: config.actions,
-    revision: current.revision,
+  await applyFromConfig({
+    getStorage: () => container.actionStorage.get(),
+    parseConfig: parseActionConfigText,
+    fetchRemote: () => container.actionConfigurator.getActions(),
+    update: async (config, current) => {
+      await container.actionConfigurator.updateActions({
+        actions: config.actions,
+        revision: current.revision,
+      });
+    },
+    notFoundMessage: "Action config file not found",
   });
 }

--- a/src/core/application/action/captureAction.ts
+++ b/src/core/application/action/captureAction.ts
@@ -1,21 +1,18 @@
 import { ActionConfigSerializer } from "@/core/domain/action/services/configSerializer";
+import {
+  type CaptureOutput,
+  captureFromConfig,
+} from "../captureFromConfigBase";
 import type { ActionServiceArgs } from "../container/action";
 
-export type CaptureActionOutput = {
-  readonly configText: string;
-  readonly hasExistingConfig: boolean;
-};
+export type CaptureActionOutput = CaptureOutput;
 
 export async function captureAction({
   container,
 }: ActionServiceArgs): Promise<CaptureActionOutput> {
-  const { actions } = await container.actionConfigurator.getActions();
-
-  const configText = ActionConfigSerializer.serialize({ actions });
-  const existing = await container.actionStorage.get();
-
-  return {
-    configText,
-    hasExistingConfig: existing.exists,
-  };
+  return captureFromConfig({
+    fetchRemote: () => container.actionConfigurator.getActions(),
+    serialize: ({ actions }) => ActionConfigSerializer.serialize({ actions }),
+    getStorage: () => container.actionStorage.get(),
+  });
 }

--- a/src/core/application/adminNotes/applyAdminNotes.ts
+++ b/src/core/application/adminNotes/applyAdminNotes.ts
@@ -1,23 +1,20 @@
+import { applyFromConfig } from "../applyFromConfigBase";
 import type { AdminNotesServiceArgs } from "../container/adminNotes";
-import { ValidationError, ValidationErrorCode } from "../error";
 import { parseAdminNotesConfigText } from "./parseConfig";
 
 export async function applyAdminNotes({
   container,
 }: AdminNotesServiceArgs): Promise<void> {
-  const result = await container.adminNotesStorage.get();
-  if (!result.exists) {
-    throw new ValidationError(
-      ValidationErrorCode.InvalidInput,
-      "Admin notes config file not found",
-    );
-  }
-  const config = parseAdminNotesConfigText(result.content);
-
-  const current = await container.adminNotesConfigurator.getAdminNotes();
-
-  await container.adminNotesConfigurator.updateAdminNotes({
-    config,
-    revision: current.revision,
+  await applyFromConfig({
+    getStorage: () => container.adminNotesStorage.get(),
+    parseConfig: parseAdminNotesConfigText,
+    fetchRemote: () => container.adminNotesConfigurator.getAdminNotes(),
+    update: async (config, current) => {
+      await container.adminNotesConfigurator.updateAdminNotes({
+        config,
+        revision: current.revision,
+      });
+    },
+    notFoundMessage: "Admin notes config file not found",
   });
 }

--- a/src/core/application/adminNotes/captureAdminNotes.ts
+++ b/src/core/application/adminNotes/captureAdminNotes.ts
@@ -1,21 +1,18 @@
 import { AdminNotesConfigSerializer } from "@/core/domain/adminNotes/services/configSerializer";
+import {
+  type CaptureOutput,
+  captureFromConfig,
+} from "../captureFromConfigBase";
 import type { AdminNotesServiceArgs } from "../container/adminNotes";
 
-export type CaptureAdminNotesOutput = {
-  readonly configText: string;
-  readonly hasExistingConfig: boolean;
-};
+export type CaptureAdminNotesOutput = CaptureOutput;
 
 export async function captureAdminNotes({
   container,
 }: AdminNotesServiceArgs): Promise<CaptureAdminNotesOutput> {
-  const { config } = await container.adminNotesConfigurator.getAdminNotes();
-
-  const configText = AdminNotesConfigSerializer.serialize(config);
-  const existing = await container.adminNotesStorage.get();
-
-  return {
-    configText,
-    hasExistingConfig: existing.exists,
-  };
+  return captureFromConfig({
+    fetchRemote: () => container.adminNotesConfigurator.getAdminNotes(),
+    serialize: ({ config }) => AdminNotesConfigSerializer.serialize(config),
+    getStorage: () => container.adminNotesStorage.get(),
+  });
 }

--- a/src/core/application/appPermission/applyAppPermission.ts
+++ b/src/core/application/appPermission/applyAppPermission.ts
@@ -1,23 +1,20 @@
+import { applyFromConfig } from "../applyFromConfigBase";
 import type { AppPermissionServiceArgs } from "../container/appPermission";
-import { ValidationError, ValidationErrorCode } from "../error";
 import { parseAppPermissionConfigText } from "./parseConfig";
 
 export async function applyAppPermission({
   container,
 }: AppPermissionServiceArgs): Promise<void> {
-  const result = await container.appPermissionStorage.get();
-  if (!result.exists) {
-    throw new ValidationError(
-      ValidationErrorCode.InvalidInput,
-      "App permission config file not found",
-    );
-  }
-  const config = parseAppPermissionConfigText(result.content);
-
-  const current = await container.appPermissionConfigurator.getAppPermissions();
-
-  await container.appPermissionConfigurator.updateAppPermissions({
-    rights: config.rights,
-    revision: current.revision,
+  await applyFromConfig({
+    getStorage: () => container.appPermissionStorage.get(),
+    parseConfig: parseAppPermissionConfigText,
+    fetchRemote: () => container.appPermissionConfigurator.getAppPermissions(),
+    update: async (config, current) => {
+      await container.appPermissionConfigurator.updateAppPermissions({
+        rights: config.rights,
+        revision: current.revision,
+      });
+    },
+    notFoundMessage: "App permission config file not found",
   });
 }

--- a/src/core/application/appPermission/captureAppPermission.ts
+++ b/src/core/application/appPermission/captureAppPermission.ts
@@ -1,22 +1,19 @@
 import { AppPermissionConfigSerializer } from "@/core/domain/appPermission/services/configSerializer";
+import {
+  type CaptureOutput,
+  captureFromConfig,
+} from "../captureFromConfigBase";
 import type { AppPermissionServiceArgs } from "../container/appPermission";
 
-export type CaptureAppPermissionOutput = {
-  readonly configText: string;
-  readonly hasExistingConfig: boolean;
-};
+export type CaptureAppPermissionOutput = CaptureOutput;
 
 export async function captureAppPermission({
   container,
 }: AppPermissionServiceArgs): Promise<CaptureAppPermissionOutput> {
-  const { rights } =
-    await container.appPermissionConfigurator.getAppPermissions();
-
-  const configText = AppPermissionConfigSerializer.serialize({ rights });
-  const existing = await container.appPermissionStorage.get();
-
-  return {
-    configText,
-    hasExistingConfig: existing.exists,
-  };
+  return captureFromConfig({
+    fetchRemote: () => container.appPermissionConfigurator.getAppPermissions(),
+    serialize: ({ rights }) =>
+      AppPermissionConfigSerializer.serialize({ rights }),
+    getStorage: () => container.appPermissionStorage.get(),
+  });
 }

--- a/src/core/application/applyFromConfigBase.ts
+++ b/src/core/application/applyFromConfigBase.ts
@@ -1,0 +1,25 @@
+import type { StorageResult } from "@/core/domain/ports/storageResult";
+import { ValidationError, ValidationErrorCode } from "./error";
+
+type ApplyFromConfigParams<TParsed, TRemote> = {
+  readonly getStorage: () => Promise<StorageResult>;
+  readonly parseConfig: (content: string) => TParsed;
+  readonly fetchRemote: () => Promise<TRemote>;
+  readonly update: (parsed: TParsed, remote: TRemote) => Promise<void>;
+  readonly notFoundMessage: string;
+};
+
+export async function applyFromConfig<TParsed, TRemote>(
+  config: ApplyFromConfigParams<TParsed, TRemote>,
+): Promise<void> {
+  const result = await config.getStorage();
+  if (!result.exists) {
+    throw new ValidationError(
+      ValidationErrorCode.InvalidInput,
+      config.notFoundMessage,
+    );
+  }
+  const parsed = config.parseConfig(result.content);
+  const remote = await config.fetchRemote();
+  await config.update(parsed, remote);
+}

--- a/src/core/application/captureFromConfigBase.ts
+++ b/src/core/application/captureFromConfigBase.ts
@@ -1,0 +1,25 @@
+import type { StorageResult } from "@/core/domain/ports/storageResult";
+
+export type CaptureOutput = {
+  readonly configText: string;
+  readonly hasExistingConfig: boolean;
+};
+
+type CaptureFromConfigParams<TRemote> = {
+  readonly fetchRemote: () => Promise<TRemote>;
+  readonly serialize: (remote: TRemote) => string;
+  readonly getStorage: () => Promise<StorageResult>;
+};
+
+export async function captureFromConfig<TRemote>(
+  config: CaptureFromConfigParams<TRemote>,
+): Promise<CaptureOutput> {
+  const remote = await config.fetchRemote();
+  const configText = config.serialize(remote);
+  const existing = await config.getStorage();
+
+  return {
+    configText,
+    hasExistingConfig: existing.exists,
+  };
+}

--- a/src/core/application/container/actionCli.ts
+++ b/src/core/application/container/actionCli.ts
@@ -1,12 +1,10 @@
-import { KintoneRestAPIClient } from "@kintone/rest-api-client";
+import type { KintoneRestAPIClient } from "@kintone/rest-api-client";
 import { KintoneActionConfigurator } from "@/core/adapters/kintone/actionConfigurator";
 import { KintoneAppDeployer } from "@/core/adapters/kintone/appDeployer";
 import { createLocalFileActionStorage } from "@/core/adapters/local/actionStorage";
 import type { ActionContainer } from "@/core/application/container/action";
-import {
-  buildKintoneAuth,
-  type KintoneAuth,
-} from "@/core/application/container/cli";
+import type { KintoneAuth } from "@/core/application/container/cli";
+import { createKintoneClient } from "./kintoneClient";
 
 export type ActionCliContainerConfig = {
   baseUrl: string;
@@ -14,16 +12,13 @@ export type ActionCliContainerConfig = {
   appId: string;
   guestSpaceId?: string;
   actionFilePath: string;
+  client?: KintoneRestAPIClient;
 };
 
 export function createActionCliContainer(
   config: ActionCliContainerConfig,
 ): ActionContainer {
-  const client = new KintoneRestAPIClient({
-    baseUrl: config.baseUrl,
-    auth: buildKintoneAuth(config.auth),
-    guestSpaceId: config.guestSpaceId,
-  });
+  const client = config.client ?? createKintoneClient(config);
 
   return {
     actionConfigurator: new KintoneActionConfigurator(client, config.appId),

--- a/src/core/application/container/adminNotesCli.ts
+++ b/src/core/application/container/adminNotesCli.ts
@@ -1,12 +1,10 @@
-import { KintoneRestAPIClient } from "@kintone/rest-api-client";
+import type { KintoneRestAPIClient } from "@kintone/rest-api-client";
 import { KintoneAdminNotesConfigurator } from "@/core/adapters/kintone/adminNotesConfigurator";
 import { KintoneAppDeployer } from "@/core/adapters/kintone/appDeployer";
 import { createLocalFileAdminNotesStorage } from "@/core/adapters/local/adminNotesStorage";
 import type { AdminNotesContainer } from "@/core/application/container/adminNotes";
-import {
-  buildKintoneAuth,
-  type KintoneAuth,
-} from "@/core/application/container/cli";
+import type { KintoneAuth } from "@/core/application/container/cli";
+import { createKintoneClient } from "./kintoneClient";
 
 export type AdminNotesCliContainerConfig = {
   baseUrl: string;
@@ -14,16 +12,13 @@ export type AdminNotesCliContainerConfig = {
   appId: string;
   guestSpaceId?: string;
   adminNotesFilePath: string;
+  client?: KintoneRestAPIClient;
 };
 
 export function createAdminNotesCliContainer(
   config: AdminNotesCliContainerConfig,
 ): AdminNotesContainer {
-  const client = new KintoneRestAPIClient({
-    baseUrl: config.baseUrl,
-    auth: buildKintoneAuth(config.auth),
-    guestSpaceId: config.guestSpaceId,
-  });
+  const client = config.client ?? createKintoneClient(config);
 
   return {
     adminNotesConfigurator: new KintoneAdminNotesConfigurator(

--- a/src/core/application/container/appPermissionCli.ts
+++ b/src/core/application/container/appPermissionCli.ts
@@ -1,10 +1,10 @@
-import { KintoneRestAPIClient } from "@kintone/rest-api-client";
+import type { KintoneRestAPIClient } from "@kintone/rest-api-client";
 import { KintoneAppDeployer } from "@/core/adapters/kintone/appDeployer";
 import { KintoneAppPermissionConfigurator } from "@/core/adapters/kintone/appPermissionConfigurator";
 import { createLocalFileAppPermissionStorage } from "@/core/adapters/local/appPermissionStorage";
 import type { AppPermissionContainer } from "@/core/application/container/appPermission";
 import type { KintoneAuth } from "@/core/application/container/cli";
-import { buildKintoneAuth } from "@/core/application/container/cli";
+import { createKintoneClient } from "./kintoneClient";
 
 export type AppPermissionCliContainerConfig = {
   baseUrl: string;
@@ -12,16 +12,13 @@ export type AppPermissionCliContainerConfig = {
   appId: string;
   guestSpaceId?: string;
   appAclFilePath: string;
+  client?: KintoneRestAPIClient;
 };
 
 export function createAppPermissionCliContainer(
   config: AppPermissionCliContainerConfig,
 ): AppPermissionContainer {
-  const client = new KintoneRestAPIClient({
-    baseUrl: config.baseUrl,
-    auth: buildKintoneAuth(config.auth),
-    guestSpaceId: config.guestSpaceId,
-  });
+  const client = config.client ?? createKintoneClient(config);
 
   return {
     appPermissionConfigurator: new KintoneAppPermissionConfigurator(

--- a/src/core/application/container/captureAllCli.ts
+++ b/src/core/application/container/captureAllCli.ts
@@ -15,6 +15,7 @@ import {
 } from "./cli";
 import { createFieldPermissionCliContainer } from "./fieldPermissionCli";
 import { createGeneralSettingsCliContainer } from "./generalSettingsCli";
+import { createKintoneClient } from "./kintoneClient";
 import { createNotificationCliContainer } from "./notificationCli";
 import { createPluginCliContainer } from "./pluginCli";
 import { createProcessManagementCliContainer } from "./processManagementCli";
@@ -39,11 +40,13 @@ export type CreateCaptureContainersResult = Readonly<{
 export function createCliCaptureContainers(
   input: CreateCaptureContainersInput,
 ): CreateCaptureContainersResult {
+  const client = createKintoneClient(input);
   const base = {
     baseUrl: input.baseUrl,
     auth: input.auth,
     appId: input.appId,
     guestSpaceId: input.guestSpaceId,
+    client,
   };
   const paths = buildAppFilePaths(input.appName, input.baseDir);
 

--- a/src/core/application/container/cli.ts
+++ b/src/core/application/container/cli.ts
@@ -1,4 +1,4 @@
-import { KintoneRestAPIClient } from "@kintone/rest-api-client";
+import type { KintoneRestAPIClient } from "@kintone/rest-api-client";
 import { KintoneAppDeployer } from "@/core/adapters/kintone/appDeployer";
 import { KintoneCustomizationConfigurator } from "@/core/adapters/kintone/customizationConfigurator";
 import { KintoneFileDownloader } from "@/core/adapters/kintone/fileDownloader";
@@ -12,6 +12,7 @@ import { createLocalFileSeedStorage } from "@/core/adapters/local/seedStorage";
 import type { CustomizationContainer } from "@/core/application/container/customization";
 import type { FormSchemaContainer } from "@/core/application/container/formSchema";
 import type { SeedContainer } from "@/core/application/container/seed";
+import { createKintoneClient } from "./kintoneClient";
 
 export type KintoneAuth =
   | { type: "apiToken"; apiToken: string | string[] }
@@ -37,6 +38,7 @@ export type CliContainerConfig = {
   appId: string;
   guestSpaceId?: string;
   schemaFilePath: string;
+  client?: KintoneRestAPIClient;
 };
 
 export type SeedCliContainerConfig = {
@@ -45,16 +47,13 @@ export type SeedCliContainerConfig = {
   appId: string;
   guestSpaceId?: string;
   seedFilePath: string;
+  client?: KintoneRestAPIClient;
 };
 
 export function createCliContainer(
   config: CliContainerConfig,
 ): FormSchemaContainer {
-  const client = new KintoneRestAPIClient({
-    baseUrl: config.baseUrl,
-    auth: buildKintoneAuth(config.auth),
-    guestSpaceId: config.guestSpaceId,
-  });
+  const client = config.client ?? createKintoneClient(config);
 
   return {
     formConfigurator: new KintoneFormConfigurator(client, config.appId),
@@ -66,11 +65,7 @@ export function createCliContainer(
 export function createSeedCliContainer(
   config: SeedCliContainerConfig,
 ): SeedContainer {
-  const client = new KintoneRestAPIClient({
-    baseUrl: config.baseUrl,
-    auth: buildKintoneAuth(config.auth),
-    guestSpaceId: config.guestSpaceId,
-  });
+  const client = config.client ?? createKintoneClient(config);
 
   return {
     recordManager: new KintoneRecordManager(client, config.appId),
@@ -84,16 +79,13 @@ export type CustomizationCliContainerConfig = {
   appId: string;
   guestSpaceId?: string;
   customizeFilePath: string;
+  client?: KintoneRestAPIClient;
 };
 
 export function createCustomizationCliContainer(
   config: CustomizationCliContainerConfig,
 ): CustomizationContainer {
-  const client = new KintoneRestAPIClient({
-    baseUrl: config.baseUrl,
-    auth: buildKintoneAuth(config.auth),
-    guestSpaceId: config.guestSpaceId,
-  });
+  const client = config.client ?? createKintoneClient(config);
 
   return {
     customizationConfigurator: new KintoneCustomizationConfigurator(

--- a/src/core/application/container/customization.ts
+++ b/src/core/application/container/customization.ts
@@ -37,6 +37,11 @@ export type CustomizationApplyServiceArgs<T = undefined> = ServiceArgs<
   T
 >;
 
+export type CustomizationCaptureServiceArgs<T = undefined> = ServiceArgs<
+  CustomizationCaptureContainer,
+  T
+>;
+
 export type CustomizationDiffServiceArgs<T = undefined> = ServiceArgs<
   CustomizationDiffContainer,
   T

--- a/src/core/application/container/dumpCli.ts
+++ b/src/core/application/container/dumpCli.ts
@@ -1,8 +1,9 @@
-import { KintoneRestAPIClient } from "@kintone/rest-api-client";
+import type { KintoneRestAPIClient } from "@kintone/rest-api-client";
 import { KintoneFormDumpReader } from "@/core/adapters/kintone/formDumpReader";
 import { LocalFileDumpStorage } from "@/core/adapters/local/dumpStorage";
 import type { DumpContainer } from "@/core/application/container/dump";
-import { buildKintoneAuth, type KintoneAuth } from "./cli";
+import type { KintoneAuth } from "./cli";
+import { createKintoneClient } from "./kintoneClient";
 
 export type DumpCliContainerConfig = {
   baseUrl: string;
@@ -10,16 +11,13 @@ export type DumpCliContainerConfig = {
   appId: string;
   guestSpaceId?: string;
   filePrefix: string;
+  client?: KintoneRestAPIClient;
 };
 
 export function createDumpCliContainer(
   config: DumpCliContainerConfig,
 ): DumpContainer {
-  const client = new KintoneRestAPIClient({
-    baseUrl: config.baseUrl,
-    auth: buildKintoneAuth(config.auth),
-    guestSpaceId: config.guestSpaceId,
-  });
+  const client = config.client ?? createKintoneClient(config);
 
   return {
     formDumpReader: new KintoneFormDumpReader(client, config.appId),

--- a/src/core/application/container/fieldPermissionCli.ts
+++ b/src/core/application/container/fieldPermissionCli.ts
@@ -1,10 +1,10 @@
-import { KintoneRestAPIClient } from "@kintone/rest-api-client";
+import type { KintoneRestAPIClient } from "@kintone/rest-api-client";
 import { KintoneAppDeployer } from "@/core/adapters/kintone/appDeployer";
 import { KintoneFieldPermissionConfigurator } from "@/core/adapters/kintone/fieldPermissionConfigurator";
 import { createLocalFileFieldPermissionStorage } from "@/core/adapters/local/fieldPermissionStorage";
 import type { KintoneAuth } from "@/core/application/container/cli";
-import { buildKintoneAuth } from "@/core/application/container/cli";
 import type { FieldPermissionContainer } from "@/core/application/container/fieldPermission";
+import { createKintoneClient } from "./kintoneClient";
 
 export type FieldPermissionCliContainerConfig = {
   baseUrl: string;
@@ -12,16 +12,13 @@ export type FieldPermissionCliContainerConfig = {
   appId: string;
   guestSpaceId?: string;
   fieldAclFilePath: string;
+  client?: KintoneRestAPIClient;
 };
 
 export function createFieldPermissionCliContainer(
   config: FieldPermissionCliContainerConfig,
 ): FieldPermissionContainer {
-  const client = new KintoneRestAPIClient({
-    baseUrl: config.baseUrl,
-    auth: buildKintoneAuth(config.auth),
-    guestSpaceId: config.guestSpaceId,
-  });
+  const client = config.client ?? createKintoneClient(config);
 
   return {
     fieldPermissionConfigurator: new KintoneFieldPermissionConfigurator(

--- a/src/core/application/container/generalSettingsCli.ts
+++ b/src/core/application/container/generalSettingsCli.ts
@@ -1,9 +1,10 @@
-import { KintoneRestAPIClient } from "@kintone/rest-api-client";
+import type { KintoneRestAPIClient } from "@kintone/rest-api-client";
 import { KintoneAppDeployer } from "@/core/adapters/kintone/appDeployer";
 import { KintoneGeneralSettingsConfigurator } from "@/core/adapters/kintone/generalSettingsConfigurator";
 import { createLocalFileGeneralSettingsStorage } from "@/core/adapters/local/generalSettingsStorage";
-import { buildKintoneAuth, type KintoneAuth } from "./cli";
+import type { KintoneAuth } from "./cli";
 import type { GeneralSettingsContainer } from "./generalSettings";
+import { createKintoneClient } from "./kintoneClient";
 
 export type GeneralSettingsCliContainerConfig = {
   baseUrl: string;
@@ -11,16 +12,13 @@ export type GeneralSettingsCliContainerConfig = {
   appId: string;
   guestSpaceId?: string;
   settingsFilePath: string;
+  client?: KintoneRestAPIClient;
 };
 
 export function createGeneralSettingsCliContainer(
   config: GeneralSettingsCliContainerConfig,
 ): GeneralSettingsContainer {
-  const client = new KintoneRestAPIClient({
-    baseUrl: config.baseUrl,
-    auth: buildKintoneAuth(config.auth),
-    guestSpaceId: config.guestSpaceId,
-  });
+  const client = config.client ?? createKintoneClient(config);
 
   return {
     generalSettingsConfigurator: new KintoneGeneralSettingsConfigurator(

--- a/src/core/application/container/initCli.ts
+++ b/src/core/application/container/initCli.ts
@@ -1,24 +1,22 @@
-import { KintoneRestAPIClient } from "@kintone/rest-api-client";
+import type { KintoneRestAPIClient } from "@kintone/rest-api-client";
 import { KintoneSpaceReader } from "@/core/adapters/kintone/spaceReader";
 import { createLocalFileProjectConfigStorage } from "@/core/adapters/local/projectConfigStorage";
-import { buildKintoneAuth, type KintoneAuth } from "./cli";
+import type { KintoneAuth } from "./cli";
 import type { InitContainer } from "./init";
+import { createKintoneClient } from "./kintoneClient";
 
 export type InitCliContainerConfig = {
   baseUrl: string;
   auth: KintoneAuth;
   guestSpaceId?: string;
   configFilePath: string;
+  client?: KintoneRestAPIClient;
 };
 
 export function createInitCliContainer(
   config: InitCliContainerConfig,
 ): InitContainer {
-  const client = new KintoneRestAPIClient({
-    baseUrl: config.baseUrl,
-    auth: buildKintoneAuth(config.auth),
-    guestSpaceId: config.guestSpaceId,
-  });
+  const client = config.client ?? createKintoneClient(config);
 
   return {
     spaceReader: new KintoneSpaceReader(client),

--- a/src/core/application/container/kintoneClient.ts
+++ b/src/core/application/container/kintoneClient.ts
@@ -1,0 +1,18 @@
+import { KintoneRestAPIClient } from "@kintone/rest-api-client";
+import { buildKintoneAuth, type KintoneAuth } from "./cli";
+
+export type KintoneClientConfig = {
+  baseUrl: string;
+  auth: KintoneAuth;
+  guestSpaceId?: string;
+};
+
+export function createKintoneClient(
+  config: KintoneClientConfig,
+): KintoneRestAPIClient {
+  return new KintoneRestAPIClient({
+    baseUrl: config.baseUrl,
+    auth: buildKintoneAuth(config.auth),
+    guestSpaceId: config.guestSpaceId,
+  });
+}

--- a/src/core/application/container/notificationCli.ts
+++ b/src/core/application/container/notificationCli.ts
@@ -1,12 +1,10 @@
-import { KintoneRestAPIClient } from "@kintone/rest-api-client";
+import type { KintoneRestAPIClient } from "@kintone/rest-api-client";
 import { KintoneAppDeployer } from "@/core/adapters/kintone/appDeployer";
 import { KintoneNotificationConfigurator } from "@/core/adapters/kintone/notificationConfigurator";
 import { createLocalFileNotificationStorage } from "@/core/adapters/local/notificationStorage";
-import {
-  buildKintoneAuth,
-  type KintoneAuth,
-} from "@/core/application/container/cli";
+import type { KintoneAuth } from "@/core/application/container/cli";
 import type { NotificationContainer } from "@/core/application/container/notification";
+import { createKintoneClient } from "./kintoneClient";
 
 export type NotificationCliContainerConfig = {
   baseUrl: string;
@@ -14,16 +12,13 @@ export type NotificationCliContainerConfig = {
   appId: string;
   guestSpaceId?: string;
   notificationFilePath: string;
+  client?: KintoneRestAPIClient;
 };
 
 export function createNotificationCliContainer(
   config: NotificationCliContainerConfig,
 ): NotificationContainer {
-  const client = new KintoneRestAPIClient({
-    baseUrl: config.baseUrl,
-    auth: buildKintoneAuth(config.auth),
-    guestSpaceId: config.guestSpaceId,
-  });
+  const client = config.client ?? createKintoneClient(config);
 
   return {
     notificationConfigurator: new KintoneNotificationConfigurator(

--- a/src/core/application/container/pluginCli.ts
+++ b/src/core/application/container/pluginCli.ts
@@ -1,8 +1,9 @@
-import { KintoneRestAPIClient } from "@kintone/rest-api-client";
+import type { KintoneRestAPIClient } from "@kintone/rest-api-client";
 import { KintoneAppDeployer } from "@/core/adapters/kintone/appDeployer";
 import { KintonePluginConfigurator } from "@/core/adapters/kintone/pluginConfigurator";
 import { createLocalFilePluginStorage } from "@/core/adapters/local/pluginStorage";
-import { buildKintoneAuth, type KintoneAuth } from "./cli";
+import type { KintoneAuth } from "./cli";
+import { createKintoneClient } from "./kintoneClient";
 import type { PluginContainer } from "./plugin";
 
 export type PluginCliContainerConfig = {
@@ -11,16 +12,13 @@ export type PluginCliContainerConfig = {
   appId: string;
   guestSpaceId?: string;
   pluginFilePath: string;
+  client?: KintoneRestAPIClient;
 };
 
 export function createPluginCliContainer(
   config: PluginCliContainerConfig,
 ): PluginContainer {
-  const client = new KintoneRestAPIClient({
-    baseUrl: config.baseUrl,
-    auth: buildKintoneAuth(config.auth),
-    guestSpaceId: config.guestSpaceId,
-  });
+  const client = config.client ?? createKintoneClient(config);
 
   return {
     pluginConfigurator: new KintonePluginConfigurator(client, config.appId),

--- a/src/core/application/container/processManagementCli.ts
+++ b/src/core/application/container/processManagementCli.ts
@@ -1,8 +1,9 @@
-import { KintoneRestAPIClient } from "@kintone/rest-api-client";
+import type { KintoneRestAPIClient } from "@kintone/rest-api-client";
 import { KintoneAppDeployer } from "@/core/adapters/kintone/appDeployer";
 import { KintoneProcessManagementConfigurator } from "@/core/adapters/kintone/processManagementConfigurator";
 import { createLocalFileProcessManagementStorage } from "@/core/adapters/local/processManagementStorage";
-import { buildKintoneAuth, type KintoneAuth } from "./cli";
+import type { KintoneAuth } from "./cli";
+import { createKintoneClient } from "./kintoneClient";
 import type { ProcessManagementContainer } from "./processManagement";
 
 export type ProcessManagementCliContainerConfig = {
@@ -11,16 +12,13 @@ export type ProcessManagementCliContainerConfig = {
   appId: string;
   guestSpaceId?: string;
   processFilePath: string;
+  client?: KintoneRestAPIClient;
 };
 
 export function createProcessManagementCliContainer(
   config: ProcessManagementCliContainerConfig,
 ): ProcessManagementContainer {
-  const client = new KintoneRestAPIClient({
-    baseUrl: config.baseUrl,
-    auth: buildKintoneAuth(config.auth),
-    guestSpaceId: config.guestSpaceId,
-  });
+  const client = config.client ?? createKintoneClient(config);
 
   return {
     processManagementConfigurator: new KintoneProcessManagementConfigurator(

--- a/src/core/application/container/recordPermissionCli.ts
+++ b/src/core/application/container/recordPermissionCli.ts
@@ -1,9 +1,10 @@
-import { KintoneRestAPIClient } from "@kintone/rest-api-client";
+import type { KintoneRestAPIClient } from "@kintone/rest-api-client";
 import { KintoneAppDeployer } from "@/core/adapters/kintone/appDeployer";
 import { KintoneRecordPermissionConfigurator } from "@/core/adapters/kintone/recordPermissionConfigurator";
 import { createLocalFileRecordPermissionStorage } from "@/core/adapters/local/recordPermissionStorage";
 import type { RecordPermissionContainer } from "@/core/application/container/recordPermission";
-import { buildKintoneAuth, type KintoneAuth } from "./cli";
+import type { KintoneAuth } from "./cli";
+import { createKintoneClient } from "./kintoneClient";
 
 export type RecordPermissionCliContainerConfig = {
   baseUrl: string;
@@ -11,16 +12,13 @@ export type RecordPermissionCliContainerConfig = {
   appId: string;
   guestSpaceId?: string;
   recordAclFilePath: string;
+  client?: KintoneRestAPIClient;
 };
 
 export function createRecordPermissionCliContainer(
   config: RecordPermissionCliContainerConfig,
 ): RecordPermissionContainer {
-  const client = new KintoneRestAPIClient({
-    baseUrl: config.baseUrl,
-    auth: buildKintoneAuth(config.auth),
-    guestSpaceId: config.guestSpaceId,
-  });
+  const client = config.client ?? createKintoneClient(config);
 
   return {
     recordPermissionConfigurator: new KintoneRecordPermissionConfigurator(

--- a/src/core/application/container/reportCli.ts
+++ b/src/core/application/container/reportCli.ts
@@ -1,8 +1,9 @@
-import { KintoneRestAPIClient } from "@kintone/rest-api-client";
+import type { KintoneRestAPIClient } from "@kintone/rest-api-client";
 import { KintoneAppDeployer } from "@/core/adapters/kintone/appDeployer";
 import { KintoneReportConfigurator } from "@/core/adapters/kintone/reportConfigurator";
 import { createLocalFileReportStorage } from "@/core/adapters/local/reportStorage";
-import { buildKintoneAuth, type KintoneAuth } from "./cli";
+import type { KintoneAuth } from "./cli";
+import { createKintoneClient } from "./kintoneClient";
 import type { ReportContainer } from "./report";
 
 export type ReportCliContainerConfig = {
@@ -11,16 +12,13 @@ export type ReportCliContainerConfig = {
   appId: string;
   guestSpaceId?: string;
   reportFilePath: string;
+  client?: KintoneRestAPIClient;
 };
 
 export function createReportCliContainer(
   config: ReportCliContainerConfig,
 ): ReportContainer {
-  const client = new KintoneRestAPIClient({
-    baseUrl: config.baseUrl,
-    auth: buildKintoneAuth(config.auth),
-    guestSpaceId: config.guestSpaceId,
-  });
+  const client = config.client ?? createKintoneClient(config);
 
   return {
     reportConfigurator: new KintoneReportConfigurator(client, config.appId),

--- a/src/core/application/container/viewCli.ts
+++ b/src/core/application/container/viewCli.ts
@@ -1,9 +1,10 @@
-import { KintoneRestAPIClient } from "@kintone/rest-api-client";
+import type { KintoneRestAPIClient } from "@kintone/rest-api-client";
 import { KintoneAppDeployer } from "@/core/adapters/kintone/appDeployer";
 import { KintoneViewConfigurator } from "@/core/adapters/kintone/viewConfigurator";
 import { createLocalFileViewStorage } from "@/core/adapters/local/viewStorage";
 import type { ViewContainer } from "@/core/application/container/view";
-import { buildKintoneAuth, type KintoneAuth } from "./cli";
+import type { KintoneAuth } from "./cli";
+import { createKintoneClient } from "./kintoneClient";
 
 export type ViewCliContainerConfig = {
   baseUrl: string;
@@ -11,16 +12,13 @@ export type ViewCliContainerConfig = {
   appId: string;
   guestSpaceId?: string;
   viewFilePath: string;
+  client?: KintoneRestAPIClient;
 };
 
 export function createViewCliContainer(
   config: ViewCliContainerConfig,
 ): ViewContainer {
-  const client = new KintoneRestAPIClient({
-    baseUrl: config.baseUrl,
-    auth: buildKintoneAuth(config.auth),
-    guestSpaceId: config.guestSpaceId,
-  });
+  const client = config.client ?? createKintoneClient(config);
 
   return {
     viewConfigurator: new KintoneViewConfigurator(client, config.appId),

--- a/src/core/application/customization/__tests__/saveCustomization.test.ts
+++ b/src/core/application/customization/__tests__/saveCustomization.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert";
+import { describe, expect, it } from "vitest";
+import {
+  setupTestCustomizationContainer,
+  type TestCustomizationContainer,
+} from "../../__tests__/helpers";
+import { saveCustomization } from "../saveCustomization";
+
+const getContainer = setupTestCustomizationContainer();
+
+describe("saveCustomization", () => {
+  it("カスタマイズ設定テキストをストレージに保存する", async () => {
+    const container: TestCustomizationContainer = getContainer();
+    const configText = `
+scope: ALL
+desktop:
+  js: []
+  css: []
+mobile:
+  js: []
+  css: []
+`;
+    await saveCustomization({ container, input: { configText } });
+
+    expect(container.customizationStorage.callLog).toContain("update");
+    const stored = await container.customizationStorage.get();
+    assert(stored.exists);
+    expect(stored.content).toBe(configText);
+  });
+
+  it("既存の設定を上書き保存する", async () => {
+    const container: TestCustomizationContainer = getContainer();
+    container.customizationStorage.setContent("old config");
+
+    await saveCustomization({
+      container,
+      input: { configText: "new config" },
+    });
+
+    const stored = await container.customizationStorage.get();
+    assert(stored.exists);
+    expect(stored.content).toBe("new config");
+  });
+
+  it("ストレージの書き込み失敗時にエラーが伝播する", async () => {
+    const container: TestCustomizationContainer = getContainer();
+    container.customizationStorage.setFailOn("update");
+
+    await expect(
+      saveCustomization({ container, input: { configText: "test" } }),
+    ).rejects.toThrow();
+  });
+});

--- a/src/core/application/customization/captureCustomization.ts
+++ b/src/core/application/customization/captureCustomization.ts
@@ -8,7 +8,10 @@ import type {
   RemoteResource,
 } from "@/core/domain/customization/valueObject";
 import { deduplicateName } from "@/lib/deduplicateName";
-import type { CustomizationCaptureContainer } from "../container/customization";
+import type {
+  CustomizationCaptureContainer,
+  CustomizationCaptureServiceArgs,
+} from "../container/customization";
 
 export type CaptureCustomizationInput = {
   readonly basePath: string;
@@ -19,11 +22,6 @@ export type CaptureCustomizationOutput = {
   readonly configText: string;
   readonly hasExistingConfig: boolean;
   readonly fileResourceCount: number;
-};
-
-type CaptureCustomizationArgs = {
-  container: CustomizationCaptureContainer;
-  input: CaptureCustomizationInput;
 };
 
 // biome-ignore lint/suspicious/noControlCharactersInRegex: intentional control character match for file name sanitization
@@ -129,17 +127,14 @@ function planResources(
 function planPlatform(
   remotePlatform: RemotePlatform,
   platformName: string,
-  args: CaptureCustomizationArgs,
+  basePath: string,
+  filePrefix: string,
 ): {
   platform: CustomizationPlatform;
   filesToDownload: readonly PlannedFile[];
   fileCount: number;
 } {
-  const platformDir = join(
-    args.input.basePath,
-    args.input.filePrefix,
-    platformName,
-  );
+  const platformDir = join(basePath, filePrefix, platformName);
   const platformPrefix = platformName;
 
   const jsPlan = planResources(
@@ -186,18 +181,29 @@ async function downloadFiles(
   );
 }
 
-export async function captureCustomization(
-  args: CaptureCustomizationArgs,
-): Promise<CaptureCustomizationOutput> {
+export async function captureCustomization({
+  container,
+  input,
+}: CustomizationCaptureServiceArgs<CaptureCustomizationInput>): Promise<CaptureCustomizationOutput> {
   // Check existing config *before* downloading files so callers can act on it early
-  const existing = await args.container.customizationStorage.get();
+  const existing = await container.customizationStorage.get();
 
   const { scope, desktop, mobile } =
-    await args.container.customizationConfigurator.getCustomization();
+    await container.customizationConfigurator.getCustomization();
 
   // Phase 1: Plan file paths and build config (no I/O yet)
-  const desktopPlan = planPlatform(desktop, "desktop", args);
-  const mobilePlan = planPlatform(mobile, "mobile", args);
+  const desktopPlan = planPlatform(
+    desktop,
+    "desktop",
+    input.basePath,
+    input.filePrefix,
+  );
+  const mobilePlan = planPlatform(
+    mobile,
+    "mobile",
+    input.basePath,
+    input.filePrefix,
+  );
 
   const config: CustomizationConfig = {
     scope,
@@ -212,7 +218,7 @@ export async function captureCustomization(
     ...desktopPlan.filesToDownload,
     ...mobilePlan.filesToDownload,
   ];
-  await downloadFiles(allFiles, args.container);
+  await downloadFiles(allFiles, container);
 
   return {
     configText,

--- a/src/core/application/customization/saveCustomization.ts
+++ b/src/core/application/customization/saveCustomization.ts
@@ -1,4 +1,4 @@
-import type { CustomizationCaptureContainer } from "../container/customization";
+import type { CustomizationCaptureServiceArgs } from "../container/customization";
 
 export type SaveCustomizationInput = {
   readonly configText: string;
@@ -7,9 +7,6 @@ export type SaveCustomizationInput = {
 export async function saveCustomization({
   container,
   input,
-}: {
-  container: Pick<CustomizationCaptureContainer, "customizationStorage">;
-  input: SaveCustomizationInput;
-}): Promise<void> {
+}: CustomizationCaptureServiceArgs<SaveCustomizationInput>): Promise<void> {
   await container.customizationStorage.update(input.configText);
 }

--- a/src/core/application/fieldPermission/applyFieldPermission.ts
+++ b/src/core/application/fieldPermission/applyFieldPermission.ts
@@ -1,24 +1,21 @@
+import { applyFromConfig } from "../applyFromConfigBase";
 import type { FieldPermissionServiceArgs } from "../container/fieldPermission";
-import { ValidationError, ValidationErrorCode } from "../error";
 import { parseFieldPermissionConfigText } from "./parseConfig";
 
 export async function applyFieldPermission({
   container,
 }: FieldPermissionServiceArgs): Promise<void> {
-  const result = await container.fieldPermissionStorage.get();
-  if (!result.exists) {
-    throw new ValidationError(
-      ValidationErrorCode.InvalidInput,
-      "Field permission config file not found",
-    );
-  }
-  const config = parseFieldPermissionConfigText(result.content);
-
-  const current =
-    await container.fieldPermissionConfigurator.getFieldPermissions();
-
-  await container.fieldPermissionConfigurator.updateFieldPermissions({
-    rights: config.rights,
-    revision: current.revision,
+  await applyFromConfig({
+    getStorage: () => container.fieldPermissionStorage.get(),
+    parseConfig: parseFieldPermissionConfigText,
+    fetchRemote: () =>
+      container.fieldPermissionConfigurator.getFieldPermissions(),
+    update: async (config, current) => {
+      await container.fieldPermissionConfigurator.updateFieldPermissions({
+        rights: config.rights,
+        revision: current.revision,
+      });
+    },
+    notFoundMessage: "Field permission config file not found",
   });
 }

--- a/src/core/application/fieldPermission/captureFieldPermission.ts
+++ b/src/core/application/fieldPermission/captureFieldPermission.ts
@@ -1,22 +1,20 @@
 import { FieldPermissionConfigSerializer } from "@/core/domain/fieldPermission/services/configSerializer";
+import {
+  type CaptureOutput,
+  captureFromConfig,
+} from "../captureFromConfigBase";
 import type { FieldPermissionServiceArgs } from "../container/fieldPermission";
 
-export type CaptureFieldPermissionOutput = {
-  readonly configText: string;
-  readonly hasExistingConfig: boolean;
-};
+export type CaptureFieldPermissionOutput = CaptureOutput;
 
 export async function captureFieldPermission({
   container,
 }: FieldPermissionServiceArgs): Promise<CaptureFieldPermissionOutput> {
-  const { rights } =
-    await container.fieldPermissionConfigurator.getFieldPermissions();
-
-  const configText = FieldPermissionConfigSerializer.serialize({ rights });
-  const existing = await container.fieldPermissionStorage.get();
-
-  return {
-    configText,
-    hasExistingConfig: existing.exists,
-  };
+  return captureFromConfig({
+    fetchRemote: () =>
+      container.fieldPermissionConfigurator.getFieldPermissions(),
+    serialize: ({ rights }) =>
+      FieldPermissionConfigSerializer.serialize({ rights }),
+    getStorage: () => container.fieldPermissionStorage.get(),
+  });
 }

--- a/src/core/application/formSchema/detectDiff.ts
+++ b/src/core/application/formSchema/detectDiff.ts
@@ -9,12 +9,28 @@ import type { FormSchemaDiffServiceArgs } from "../container/formSchema";
 import type { DetectDiffOutput, DiffEntryDto, SchemaFieldDto } from "./dto";
 import { parseSchemaText } from "./parseSchema";
 
+function fieldPropertiesToDto(field: FieldDefinition): Record<string, unknown> {
+  if (field.type === "SUBTABLE") {
+    const innerFields: Record<string, unknown> = {};
+    for (const [code, def] of field.properties.fields) {
+      innerFields[code] = {
+        code: def.code,
+        type: def.type,
+        label: def.label,
+        properties: def.properties,
+      };
+    }
+    return { fields: innerFields };
+  }
+  return { ...field.properties };
+}
+
 function toFieldDto(field: FieldDefinition): DiffEntryDto["before"] {
   return {
     code: field.code,
     type: field.type,
     label: field.label,
-    properties: field.properties as Record<string, unknown>,
+    properties: fieldPropertiesToDto(field),
   };
 }
 

--- a/src/core/application/formSchema/executeMigration.ts
+++ b/src/core/application/formSchema/executeMigration.ts
@@ -4,10 +4,8 @@ import {
   collectSubtableInnerFieldCodes,
   enrichLayoutWithFields,
 } from "@/core/domain/formSchema/services/layoutEnricher";
-import type {
-  FieldCode,
-  FieldDefinition,
-} from "@/core/domain/formSchema/valueObject";
+import { splitSubtableInnerFields } from "@/core/domain/formSchema/services/subtableFieldSplitter";
+import type { FieldDefinition } from "@/core/domain/formSchema/valueObject";
 import type { FormSchemaServiceArgs } from "../container/formSchema";
 import { assertSchemaValid } from "./assertSchemaValid";
 import { parseSchemaText } from "./parseSchema";
@@ -70,16 +68,10 @@ export async function executeMigration({
       before !== undefined &&
       before.type === "SUBTABLE"
     ) {
-      const newInnerFields = new Map<FieldCode, FieldDefinition>();
-      const existingInnerFields = new Map<FieldCode, FieldDefinition>();
-
-      for (const [code, def] of after.properties.fields) {
-        if (before.properties.fields.has(code)) {
-          existingInnerFields.set(code, def);
-        } else {
-          newInnerFields.set(code, def);
-        }
-      }
+      const { newInnerFields, existingInnerFields } = splitSubtableInnerFields(
+        after,
+        before,
+      );
 
       if (newInnerFields.size > 0) {
         fieldsToAdd.push({

--- a/src/core/application/formSchema/forceOverrideForm.ts
+++ b/src/core/application/formSchema/forceOverrideForm.ts
@@ -1,5 +1,6 @@
 import { ValidationError, ValidationErrorCode } from "@/core/application/error";
 import { collectSubtableInnerFieldCodes } from "@/core/domain/formSchema/services/layoutEnricher";
+import { splitSubtableInnerFields } from "@/core/domain/formSchema/services/subtableFieldSplitter";
 import type {
   FieldCode,
   FieldDefinition,
@@ -35,16 +36,8 @@ export async function forceOverrideForm({
       if (schemaDef.type === "SUBTABLE") {
         const currentDef = currentFields.get(fieldCode);
         if (currentDef !== undefined && currentDef.type === "SUBTABLE") {
-          const newInnerFields = new Map<FieldCode, FieldDefinition>();
-          const existingInnerFields = new Map<FieldCode, FieldDefinition>();
-
-          for (const [code, def] of schemaDef.properties.fields) {
-            if (currentDef.properties.fields.has(code)) {
-              existingInnerFields.set(code, def);
-            } else {
-              newInnerFields.set(code, def);
-            }
-          }
+          const { newInnerFields, existingInnerFields } =
+            splitSubtableInnerFields(schemaDef, currentDef);
 
           if (newInnerFields.size > 0) {
             toAdd.push({

--- a/src/core/application/formSchema/validateSchema.ts
+++ b/src/core/application/formSchema/validateSchema.ts
@@ -1,12 +1,15 @@
-import { isBusinessRuleError } from "@/core/domain/error";
 import type { Schema } from "@/core/domain/formSchema/entity";
-import { SchemaParser } from "@/core/domain/formSchema/services/schemaParser";
 import {
   SchemaValidator,
   type ValidationResult,
 } from "@/core/domain/formSchema/services/schemaValidator";
 import type { ValidateServiceArgs } from "../container/validate";
-import { ValidationError, ValidationErrorCode } from "../error";
+import {
+  isValidationError,
+  ValidationError,
+  ValidationErrorCode,
+} from "../error";
+import { parseSchemaText } from "./parseSchema";
 
 export type ValidateSchemaOutput = Readonly<{
   parseError?: string;
@@ -25,11 +28,14 @@ export async function validateSchema({
     );
   }
 
+  // try-catch is intentional here: parse errors are returned as a value
+  // (parseError field) instead of being thrown, so the caller can display
+  // both parse errors and validation results in a unified report.
   let schema: Schema;
   try {
-    schema = SchemaParser.parse(result.content);
+    schema = parseSchemaText(result.content);
   } catch (error) {
-    if (isBusinessRuleError(error)) {
+    if (isValidationError(error)) {
       return {
         parseError: error.message,
         fieldCount: 0,

--- a/src/core/application/generalSettings/applyGeneralSettings.ts
+++ b/src/core/application/generalSettings/applyGeneralSettings.ts
@@ -1,24 +1,21 @@
+import { applyFromConfig } from "../applyFromConfigBase";
 import type { GeneralSettingsServiceArgs } from "../container/generalSettings";
-import { ValidationError, ValidationErrorCode } from "../error";
 import { parseGeneralSettingsConfigText } from "./parseConfig";
 
 export async function applyGeneralSettings({
   container,
 }: GeneralSettingsServiceArgs): Promise<void> {
-  const result = await container.generalSettingsStorage.get();
-  if (!result.exists) {
-    throw new ValidationError(
-      ValidationErrorCode.InvalidInput,
-      "General settings config file not found",
-    );
-  }
-  const config = parseGeneralSettingsConfigText(result.content);
-
-  const current =
-    await container.generalSettingsConfigurator.getGeneralSettings();
-
-  await container.generalSettingsConfigurator.updateGeneralSettings({
-    config,
-    revision: current.revision,
+  await applyFromConfig({
+    getStorage: () => container.generalSettingsStorage.get(),
+    parseConfig: parseGeneralSettingsConfigText,
+    fetchRemote: () =>
+      container.generalSettingsConfigurator.getGeneralSettings(),
+    update: async (config, current) => {
+      await container.generalSettingsConfigurator.updateGeneralSettings({
+        config,
+        revision: current.revision,
+      });
+    },
+    notFoundMessage: "General settings config file not found",
   });
 }

--- a/src/core/application/generalSettings/captureGeneralSettings.ts
+++ b/src/core/application/generalSettings/captureGeneralSettings.ts
@@ -1,22 +1,20 @@
 import { GeneralSettingsConfigSerializer } from "@/core/domain/generalSettings/services/configSerializer";
+import {
+  type CaptureOutput,
+  captureFromConfig,
+} from "../captureFromConfigBase";
 import type { GeneralSettingsServiceArgs } from "../container/generalSettings";
 
-export type CaptureGeneralSettingsOutput = {
-  readonly configText: string;
-  readonly hasExistingConfig: boolean;
-};
+export type CaptureGeneralSettingsOutput = CaptureOutput;
 
 export async function captureGeneralSettings({
   container,
 }: GeneralSettingsServiceArgs): Promise<CaptureGeneralSettingsOutput> {
-  const { config } =
-    await container.generalSettingsConfigurator.getGeneralSettings();
-
-  const configText = GeneralSettingsConfigSerializer.serialize(config);
-  const existing = await container.generalSettingsStorage.get();
-
-  return {
-    configText,
-    hasExistingConfig: existing.exists,
-  };
+  return captureFromConfig({
+    fetchRemote: () =>
+      container.generalSettingsConfigurator.getGeneralSettings(),
+    serialize: ({ config }) =>
+      GeneralSettingsConfigSerializer.serialize(config),
+    getStorage: () => container.generalSettingsStorage.get(),
+  });
 }

--- a/src/core/application/init/generateProjectConfig.ts
+++ b/src/core/application/init/generateProjectConfig.ts
@@ -38,18 +38,13 @@ export function generateProjectConfig(
 
   // auth is intentionally omitted from the generated config to avoid writing
   // credentials to disk. The CLI prompts the user to add auth settings manually.
-  const config: {
-    domain: string;
-    guestSpaceId?: string;
-    apps: Record<string, { appId: string; files: Record<string, string> }>;
-  } = {
+  const config = {
     domain: input.domain,
+    ...(input.guestSpaceId !== undefined
+      ? { guestSpaceId: input.guestSpaceId }
+      : {}),
     apps,
   };
-
-  if (input.guestSpaceId !== undefined) {
-    config.guestSpaceId = input.guestSpaceId;
-  }
 
   return stringifyYaml(config, { lineWidth: 0 });
 }

--- a/src/core/application/notification/applyNotification.ts
+++ b/src/core/application/notification/applyNotification.ts
@@ -2,6 +2,15 @@ import type { NotificationServiceArgs } from "../container/notification";
 import { ValidationError, ValidationErrorCode } from "../error";
 import { parseNotificationConfigText } from "./parseConfig";
 
+/**
+ * Apply notification settings to kintone.
+ *
+ * Each notification section (general, perRecord, reminder) is updated
+ * independently via separate API calls. If one section fails after others
+ * have already been applied, the app will be in a partially-updated state.
+ * This is a kintone API limitation — there is no transactional update
+ * across notification types. Re-running the command is safe and idempotent.
+ */
 export async function applyNotification({
   container,
 }: NotificationServiceArgs): Promise<void> {

--- a/src/core/application/notification/captureNotification.ts
+++ b/src/core/application/notification/captureNotification.ts
@@ -10,12 +10,11 @@ export type CaptureNotificationOutput = {
 export async function captureNotification({
   container,
 }: NotificationServiceArgs): Promise<CaptureNotificationOutput> {
-  const general =
-    await container.notificationConfigurator.getGeneralNotifications();
-  const perRecord =
-    await container.notificationConfigurator.getPerRecordNotifications();
-  const reminder =
-    await container.notificationConfigurator.getReminderNotifications();
+  const [general, perRecord, reminder] = await Promise.all([
+    container.notificationConfigurator.getGeneralNotifications(),
+    container.notificationConfigurator.getPerRecordNotifications(),
+    container.notificationConfigurator.getReminderNotifications(),
+  ]);
 
   const config: NotificationConfig = {
     general: {

--- a/src/core/application/plugin/capturePlugin.ts
+++ b/src/core/application/plugin/capturePlugin.ts
@@ -1,21 +1,18 @@
 import { PluginConfigSerializer } from "@/core/domain/plugin/services/configSerializer";
+import {
+  type CaptureOutput,
+  captureFromConfig,
+} from "../captureFromConfigBase";
 import type { PluginServiceArgs } from "../container/plugin";
 
-export type CapturePluginOutput = {
-  readonly configText: string;
-  readonly hasExistingConfig: boolean;
-};
+export type CapturePluginOutput = CaptureOutput;
 
 export async function capturePlugin({
   container,
 }: PluginServiceArgs): Promise<CapturePluginOutput> {
-  const { plugins } = await container.pluginConfigurator.getPlugins();
-
-  const configText = PluginConfigSerializer.serialize({ plugins });
-  const existing = await container.pluginStorage.get();
-
-  return {
-    configText,
-    hasExistingConfig: existing.exists,
-  };
+  return captureFromConfig({
+    fetchRemote: () => container.pluginConfigurator.getPlugins(),
+    serialize: ({ plugins }) => PluginConfigSerializer.serialize({ plugins }),
+    getStorage: () => container.pluginStorage.get(),
+  });
 }

--- a/src/core/application/processManagement/captureProcessManagement.ts
+++ b/src/core/application/processManagement/captureProcessManagement.ts
@@ -1,22 +1,20 @@
 import { ProcessManagementConfigSerializer } from "@/core/domain/processManagement/services/configSerializer";
+import {
+  type CaptureOutput,
+  captureFromConfig,
+} from "../captureFromConfigBase";
 import type { ProcessManagementServiceArgs } from "../container/processManagement";
 
-export type CaptureProcessManagementOutput = {
-  readonly configText: string;
-  readonly hasExistingConfig: boolean;
-};
+export type CaptureProcessManagementOutput = CaptureOutput;
 
 export async function captureProcessManagement({
   container,
 }: ProcessManagementServiceArgs): Promise<CaptureProcessManagementOutput> {
-  const { config } =
-    await container.processManagementConfigurator.getProcessManagement();
-
-  const configText = ProcessManagementConfigSerializer.serialize(config);
-  const existing = await container.processManagementStorage.get();
-
-  return {
-    configText,
-    hasExistingConfig: existing.exists,
-  };
+  return captureFromConfig({
+    fetchRemote: () =>
+      container.processManagementConfigurator.getProcessManagement(),
+    serialize: ({ config }) =>
+      ProcessManagementConfigSerializer.serialize(config),
+    getStorage: () => container.processManagementStorage.get(),
+  });
 }

--- a/src/core/application/projectConfig/loadProjectConfig.ts
+++ b/src/core/application/projectConfig/loadProjectConfig.ts
@@ -15,6 +15,9 @@ export type LoadProjectConfigInput = Readonly<{
 export function loadProjectConfig(
   input: LoadProjectConfigInput,
 ): ProjectConfig {
+  // try-catch converts external library (yaml) exceptions into application-layer
+  // ValidationError. wrapBusinessRuleError is not applicable here because
+  // parseYaml throws its own error types, not BusinessRuleError.
   let raw: unknown;
   try {
     raw = parseYaml(input.content);

--- a/src/core/application/recordPermission/applyRecordPermission.ts
+++ b/src/core/application/recordPermission/applyRecordPermission.ts
@@ -1,24 +1,21 @@
+import { applyFromConfig } from "../applyFromConfigBase";
 import type { RecordPermissionServiceArgs } from "../container/recordPermission";
-import { ValidationError, ValidationErrorCode } from "../error";
 import { parseRecordPermissionConfigText } from "./parseConfig";
 
 export async function applyRecordPermission({
   container,
 }: RecordPermissionServiceArgs): Promise<void> {
-  const result = await container.recordPermissionStorage.get();
-  if (!result.exists) {
-    throw new ValidationError(
-      ValidationErrorCode.InvalidInput,
-      "Record permission config file not found",
-    );
-  }
-  const config = parseRecordPermissionConfigText(result.content);
-
-  const current =
-    await container.recordPermissionConfigurator.getRecordPermissions();
-
-  await container.recordPermissionConfigurator.updateRecordPermissions({
-    rights: config.rights,
-    revision: current.revision,
+  await applyFromConfig({
+    getStorage: () => container.recordPermissionStorage.get(),
+    parseConfig: parseRecordPermissionConfigText,
+    fetchRemote: () =>
+      container.recordPermissionConfigurator.getRecordPermissions(),
+    update: async (config, current) => {
+      await container.recordPermissionConfigurator.updateRecordPermissions({
+        rights: config.rights,
+        revision: current.revision,
+      });
+    },
+    notFoundMessage: "Record permission config file not found",
   });
 }

--- a/src/core/application/recordPermission/captureRecordPermission.ts
+++ b/src/core/application/recordPermission/captureRecordPermission.ts
@@ -1,22 +1,20 @@
 import { RecordPermissionConfigSerializer } from "@/core/domain/recordPermission/services/configSerializer";
+import {
+  type CaptureOutput,
+  captureFromConfig,
+} from "../captureFromConfigBase";
 import type { RecordPermissionServiceArgs } from "../container/recordPermission";
 
-export type CaptureRecordPermissionOutput = {
-  readonly configText: string;
-  readonly hasExistingConfig: boolean;
-};
+export type CaptureRecordPermissionOutput = CaptureOutput;
 
 export async function captureRecordPermission({
   container,
 }: RecordPermissionServiceArgs): Promise<CaptureRecordPermissionOutput> {
-  const { rights } =
-    await container.recordPermissionConfigurator.getRecordPermissions();
-
-  const configText = RecordPermissionConfigSerializer.serialize({ rights });
-  const existing = await container.recordPermissionStorage.get();
-
-  return {
-    configText,
-    hasExistingConfig: existing.exists,
-  };
+  return captureFromConfig({
+    fetchRemote: () =>
+      container.recordPermissionConfigurator.getRecordPermissions(),
+    serialize: ({ rights }) =>
+      RecordPermissionConfigSerializer.serialize({ rights }),
+    getStorage: () => container.recordPermissionStorage.get(),
+  });
 }

--- a/src/core/application/report/applyReport.ts
+++ b/src/core/application/report/applyReport.ts
@@ -1,23 +1,20 @@
+import { applyFromConfig } from "../applyFromConfigBase";
 import type { ReportServiceArgs } from "../container/report";
-import { ValidationError, ValidationErrorCode } from "../error";
 import { parseReportConfigText } from "./parseConfig";
 
 export async function applyReport({
   container,
 }: ReportServiceArgs): Promise<void> {
-  const result = await container.reportStorage.get();
-  if (!result.exists) {
-    throw new ValidationError(
-      ValidationErrorCode.InvalidInput,
-      "Report config file not found",
-    );
-  }
-  const config = parseReportConfigText(result.content);
-
-  const current = await container.reportConfigurator.getReports();
-
-  await container.reportConfigurator.updateReports({
-    reports: config.reports,
-    revision: current.revision,
+  await applyFromConfig({
+    getStorage: () => container.reportStorage.get(),
+    parseConfig: parseReportConfigText,
+    fetchRemote: () => container.reportConfigurator.getReports(),
+    update: async (config, current) => {
+      await container.reportConfigurator.updateReports({
+        reports: config.reports,
+        revision: current.revision,
+      });
+    },
+    notFoundMessage: "Report config file not found",
   });
 }

--- a/src/core/application/report/captureReport.ts
+++ b/src/core/application/report/captureReport.ts
@@ -1,21 +1,18 @@
 import { ReportConfigSerializer } from "@/core/domain/report/services/configSerializer";
+import {
+  type CaptureOutput,
+  captureFromConfig,
+} from "../captureFromConfigBase";
 import type { ReportServiceArgs } from "../container/report";
 
-export type CaptureReportOutput = {
-  readonly configText: string;
-  readonly hasExistingConfig: boolean;
-};
+export type CaptureReportOutput = CaptureOutput;
 
 export async function captureReport({
   container,
 }: ReportServiceArgs): Promise<CaptureReportOutput> {
-  const { reports } = await container.reportConfigurator.getReports();
-
-  const configText = ReportConfigSerializer.serialize({ reports });
-  const existing = await container.reportStorage.get();
-
-  return {
-    configText,
-    hasExistingConfig: existing.exists,
-  };
+  return captureFromConfig({
+    fetchRemote: () => container.reportConfigurator.getReports(),
+    serialize: ({ reports }) => ReportConfigSerializer.serialize({ reports }),
+    getStorage: () => container.reportStorage.get(),
+  });
 }

--- a/src/core/application/seedData/parseConfig.ts
+++ b/src/core/application/seedData/parseConfig.ts
@@ -1,0 +1,7 @@
+import type { SeedData } from "@/core/domain/seedData/entity";
+import { SeedParser } from "@/core/domain/seedData/services/seedParser";
+import { wrapBusinessRuleError } from "../error";
+
+export function parseSeedText(rawText: string): SeedData {
+  return wrapBusinessRuleError(() => SeedParser.parse(rawText));
+}

--- a/src/core/application/seedData/upsertSeed.ts
+++ b/src/core/application/seedData/upsertSeed.ts
@@ -1,8 +1,8 @@
-import { SeedParser } from "@/core/domain/seedData/services/seedParser";
 import { UpsertPlanner } from "@/core/domain/seedData/services/upsertPlanner";
 import type { SeedServiceArgs } from "../container/seed";
 import { ValidationError, ValidationErrorCode } from "../error";
 import type { UpsertSeedOutput } from "./dto";
+import { parseSeedText } from "./parseConfig";
 
 export type UpsertSeedInput = {
   readonly clean?: boolean;
@@ -19,7 +19,7 @@ export async function upsertSeed({
       "Seed file not found",
     );
   }
-  const seedData = SeedParser.parse(result.content);
+  const seedData = parseSeedText(result.content);
 
   if (input.clean) {
     const { deletedCount } = await container.recordManager.deleteAllRecords();

--- a/src/core/application/view/applyView.ts
+++ b/src/core/application/view/applyView.ts
@@ -32,7 +32,10 @@ export async function applyView({
 
   const current = await container.viewConfigurator.getViews();
 
-  // Merge remote builtinType views to preserve them during the replacement operation
+  // Merge remote builtinType views to preserve them during the replacement operation.
+  // Edge case: if a local non-builtinType view has the same name as a remote
+  // builtinType view, the local view takes precedence. This is unlikely in
+  // practice since builtinType names are system-assigned.
   for (const [name, view] of Object.entries(current.views)) {
     if (view.builtinType !== undefined && filteredViews[name] === undefined) {
       filteredViews[name] = view;

--- a/src/core/application/view/captureView.ts
+++ b/src/core/application/view/captureView.ts
@@ -1,21 +1,18 @@
 import { ViewConfigSerializer } from "@/core/domain/view/services/configSerializer";
+import {
+  type CaptureOutput,
+  captureFromConfig,
+} from "../captureFromConfigBase";
 import type { ViewServiceArgs } from "../container/view";
 
-export type CaptureViewOutput = {
-  readonly configText: string;
-  readonly hasExistingConfig: boolean;
-};
+export type CaptureViewOutput = CaptureOutput;
 
 export async function captureView({
   container,
 }: ViewServiceArgs): Promise<CaptureViewOutput> {
-  const { views } = await container.viewConfigurator.getViews();
-
-  const configText = ViewConfigSerializer.serialize({ views });
-  const existing = await container.viewStorage.get();
-
-  return {
-    configText,
-    hasExistingConfig: existing.exists,
-  };
+  return captureFromConfig({
+    fetchRemote: () => container.viewConfigurator.getViews(),
+    serialize: ({ views }) => ViewConfigSerializer.serialize({ views }),
+    getStorage: () => container.viewStorage.get(),
+  });
 }

--- a/src/core/domain/formSchema/services/__tests__/subtableFieldSplitter.test.ts
+++ b/src/core/domain/formSchema/services/__tests__/subtableFieldSplitter.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import type {
+  FieldCode,
+  FieldDefinition,
+  SubtableFieldDefinition,
+} from "../../valueObject";
+import { FieldCode as FC } from "../../valueObject";
+import { splitSubtableInnerFields } from "../subtableFieldSplitter";
+
+function makeSubtable(
+  code: string,
+  fields: ReadonlyMap<FieldCode, FieldDefinition>,
+): SubtableFieldDefinition {
+  return {
+    code: FC.create(code),
+    type: "SUBTABLE",
+    label: code,
+    properties: { fields },
+  };
+}
+
+function textField(code: string): FieldDefinition {
+  return {
+    code: FC.create(code),
+    type: "SINGLE_LINE_TEXT",
+    label: code,
+    properties: {},
+  } as FieldDefinition;
+}
+
+describe("splitSubtableInnerFields", () => {
+  it("全フィールドが新規の場合、newInnerFieldsに全て入る", () => {
+    const desired = makeSubtable(
+      "table",
+      new Map([
+        [FC.create("a"), textField("a")],
+        [FC.create("b"), textField("b")],
+      ]),
+    );
+    const current = makeSubtable("table", new Map());
+
+    const result = splitSubtableInnerFields(desired, current);
+
+    expect(result.newInnerFields.size).toBe(2);
+    expect(result.existingInnerFields.size).toBe(0);
+    expect(result.newInnerFields.has(FC.create("a"))).toBe(true);
+    expect(result.newInnerFields.has(FC.create("b"))).toBe(true);
+  });
+
+  it("全フィールドが既存の場合、existingInnerFieldsに全て入る", () => {
+    const desired = makeSubtable(
+      "table",
+      new Map([
+        [FC.create("a"), textField("a")],
+        [FC.create("b"), textField("b")],
+      ]),
+    );
+    const current = makeSubtable(
+      "table",
+      new Map([
+        [FC.create("a"), textField("a")],
+        [FC.create("b"), textField("b")],
+      ]),
+    );
+
+    const result = splitSubtableInnerFields(desired, current);
+
+    expect(result.newInnerFields.size).toBe(0);
+    expect(result.existingInnerFields.size).toBe(2);
+  });
+
+  it("新規と既存が混在する場合、正しく分割される", () => {
+    const desired = makeSubtable(
+      "table",
+      new Map([
+        [FC.create("existing"), textField("existing")],
+        [FC.create("new_field"), textField("new_field")],
+      ]),
+    );
+    const current = makeSubtable(
+      "table",
+      new Map([[FC.create("existing"), textField("existing")]]),
+    );
+
+    const result = splitSubtableInnerFields(desired, current);
+
+    expect(result.newInnerFields.size).toBe(1);
+    expect(result.existingInnerFields.size).toBe(1);
+    expect(result.newInnerFields.has(FC.create("new_field"))).toBe(true);
+    expect(result.existingInnerFields.has(FC.create("existing"))).toBe(true);
+  });
+
+  it("desiredが空の場合、両方とも空になる", () => {
+    const desired = makeSubtable("table", new Map());
+    const current = makeSubtable(
+      "table",
+      new Map([[FC.create("a"), textField("a")]]),
+    );
+
+    const result = splitSubtableInnerFields(desired, current);
+
+    expect(result.newInnerFields.size).toBe(0);
+    expect(result.existingInnerFields.size).toBe(0);
+  });
+});

--- a/src/core/domain/formSchema/services/subtableFieldSplitter.ts
+++ b/src/core/domain/formSchema/services/subtableFieldSplitter.ts
@@ -1,0 +1,28 @@
+import type {
+  FieldCode,
+  FieldDefinition,
+  SubtableFieldDefinition,
+} from "../valueObject";
+
+export type SubtableSplitResult = Readonly<{
+  newInnerFields: ReadonlyMap<FieldCode, FieldDefinition>;
+  existingInnerFields: ReadonlyMap<FieldCode, FieldDefinition>;
+}>;
+
+export function splitSubtableInnerFields(
+  desired: SubtableFieldDefinition,
+  current: SubtableFieldDefinition,
+): SubtableSplitResult {
+  const newInnerFields = new Map<FieldCode, FieldDefinition>();
+  const existingInnerFields = new Map<FieldCode, FieldDefinition>();
+
+  for (const [code, def] of desired.properties.fields) {
+    if (current.properties.fields.has(code)) {
+      existingInnerFields.set(code, def);
+    } else {
+      newInnerFields.set(code, def);
+    }
+  }
+
+  return { newInnerFields, existingInnerFields };
+}


### PR DESCRIPTION
## Summary

`logs/review-application.md` のコードレビュー指摘（HIGH 3件、MEDIUM 14件、LOW 8件）のうち、対応可能な全件（25件中20件）に対応。

### HIGH severity（バグ修正・重複解消）
- **D-01**: `splitSubtableInnerFields` ドメインサービスに SUBTABLE 分割ロジックを共通化（`executeMigration.ts` / `forceOverrideForm.ts`）
- **B-01/F-01**: `detectDiff.ts` の `toFieldDto` で SUBTABLE の `ReadonlyMap` → プレーンオブジェクト変換を追加（情報喪失バグ修正）
- **E-01**: `validateSchema.ts` を `parseSchemaText` + `isValidationError` パターンに統一

### MEDIUM severity（小規模修正）
- **U-01**: `parseSeedText` ラッパー追加で `wrapBusinessRuleError` の一貫性確保
- **U-02**: `captureNotification.ts` の3 API呼び出しを `Promise.all` で並列化
- **E-02**: `loadProjectConfig.ts` に try-catch 理由コメント追加
- **A-01/A-02**: `captureCustomization` / `saveCustomization` を `ServiceArgs` パターンに統一
- **T-01**: `saveCustomization.test.ts` テスト追加
- **B-02**: `applyView.ts` の builtinType エッジケースコメント拡充

### MEDIUM severity（大規模リファクタリング）
- **D-02/C-01**: `createKintoneClient` ユーティリティ作成 + 全13 CLI コンテナに `client?` オプション追加 → `captureAllCli.ts` で1クライアント共有
- **D-03**: `applyFromConfig` ジェネリック関数で7ファイルのボイラープレート解消
- **D-05**: `captureFromConfig` ジェネリック関数で10ファイルのボイラープレート解消

### LOW severity
- **S-02**: `generateProjectConfig.ts` のスプレッド構文によるイミュータブル構築
- **U-03**: `applyNotification.ts` に非トランザクション docコメント追加

### スキップ（LOW / 影響小）
- F-02, C-02, T-02, T-03, V-01, A-03: リスクの割にリターンが少ないためスコープ外

## Test plan

- [x] `pnpm typecheck` — 型チェック通過
- [x] `pnpm lint:fix` — lint 通過
- [x] `pnpm format` — フォーマット通過
- [x] `pnpm test` — 全 203 テストファイル / 2086 テスト通過
- [ ] `subtableFieldSplitter.test.ts` の新規テスト4件が正常動作を確認
- [ ] `saveCustomization.test.ts` の新規テスト3件が正常動作を確認
- [ ] SUBTABLE フィールドを含む diff 出力で内部フィールド情報が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)