### PR TITLE
feat: add top-level capture command for all-domain configuration capture

### DIFF
--- a/src/cli/__tests__/captureAllOutput.test.ts
+++ b/src/cli/__tests__/captureAllOutput.test.ts
@@ -67,9 +67,7 @@ const mockPaths: AppFilePaths = {
 
 describe("printCaptureAllResults", () => {
   it("ヘッダーに 'Capture Results:' が表示されること", () => {
-    const results: CaptureResult[] = [
-      { domain: "schema", success: true },
-    ];
+    const results: CaptureResult[] = [{ domain: "schema", success: true }];
 
     printCaptureAllResults(results, mockPaths);
 

--- a/src/cli/__tests__/captureAllOutput.test.ts
+++ b/src/cli/__tests__/captureAllOutput.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@clack/prompts", () => ({
+  log: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    success: vi.fn(),
+    step: vi.fn(),
+    error: vi.fn(),
+    message: vi.fn(),
+  },
+}));
+
+vi.mock("../handleError", () => ({
+  formatErrorForDisplay: vi.fn((e: unknown) =>
+    e instanceof Error ? e.message : String(e),
+  ),
+  logError: vi.fn(),
+}));
+
+import * as p from "@clack/prompts";
+import type {
+  CaptureDomain,
+  CaptureResult,
+} from "@/core/application/init/captureAllForApp";
+import type { AppFilePaths } from "@/core/domain/projectConfig/appFilePaths";
+import { printCaptureAllResults } from "../captureAllOutput";
+import { logError } from "../handleError";
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+const ALL_DOMAINS: readonly CaptureDomain[] = [
+  "schema",
+  "customize",
+  "seed",
+  "view",
+  "settings",
+  "notification",
+  "report",
+  "action",
+  "process",
+  "field-acl",
+  "app-acl",
+  "record-acl",
+  "admin-notes",
+  "plugin",
+];
+
+const mockPaths: AppFilePaths = {
+  schema: "myapp/schema.yaml",
+  seed: "myapp/seed.yaml",
+  customize: "myapp/customize.yaml",
+  view: "myapp/view.yaml",
+  settings: "myapp/settings.yaml",
+  notification: "myapp/notification.yaml",
+  report: "myapp/report.yaml",
+  action: "myapp/action.yaml",
+  process: "myapp/process.yaml",
+  fieldAcl: "myapp/field-acl.yaml",
+  appAcl: "myapp/app-acl.yaml",
+  recordAcl: "myapp/record-acl.yaml",
+  adminNotes: "myapp/admin-notes.yaml",
+  plugin: "myapp/plugin.yaml",
+};
+
+describe("printCaptureAllResults", () => {
+  it("全14ドメインが成功した場合、全てに ✓ を表示し Summary に succeeded を含む", () => {
+    const results: CaptureResult[] = ALL_DOMAINS.map((domain) => ({
+      domain,
+      success: true as const,
+    }));
+
+    printCaptureAllResults(results, mockPaths);
+
+    // 14 results + 2 separator lines + 1 header + 1 summary = 18 calls
+    // Check that p.log.message was called 14 times for results + 1 for summary = 15
+    const messageCalls = vi.mocked(p.log.message).mock.calls;
+    expect(messageCalls).toHaveLength(15);
+
+    // Verify each success message contains ✓ and the file path
+    for (let i = 0; i < 14; i++) {
+      const line = messageCalls[i][0] as string;
+      expect(line).toContain("✓");
+    }
+
+    // Verify summary line
+    const summaryLine = messageCalls[14][0] as string;
+    expect(summaryLine).toContain("14");
+    expect(summaryLine).toContain("succeeded");
+  });
+
+  it("全14ドメインが失敗した場合、全てに ✗ を表示し Summary に failed を含む", () => {
+    const results: CaptureResult[] = ALL_DOMAINS.map((domain) => ({
+      domain,
+      success: false as const,
+      error: new Error(`${domain} failed`),
+    }));
+
+    printCaptureAllResults(results, mockPaths);
+
+    const messageCalls = vi.mocked(p.log.message).mock.calls;
+    expect(messageCalls).toHaveLength(15);
+
+    for (let i = 0; i < 14; i++) {
+      const line = messageCalls[i][0] as string;
+      expect(line).toContain("✗");
+      expect(line).toContain("failed");
+    }
+
+    // logError should be called for each failure
+    expect(logError).toHaveBeenCalledTimes(14);
+
+    const summaryLine = messageCalls[14][0] as string;
+    expect(summaryLine).toContain("14");
+    expect(summaryLine).toContain("failed");
+  });
+
+  it("成功と失敗が混在する場合、Summary に両方を含む", () => {
+    const results: CaptureResult[] = [
+      { domain: "schema", success: true },
+      { domain: "customize", success: false, error: new Error("API error") },
+      { domain: "seed", success: true },
+    ];
+
+    printCaptureAllResults(results, mockPaths);
+
+    const messageCalls = vi.mocked(p.log.message).mock.calls;
+    expect(messageCalls).toHaveLength(4); // 3 results + 1 summary
+
+    expect(messageCalls[0][0] as string).toContain("✓");
+    expect(messageCalls[1][0] as string).toContain("✗");
+    expect(messageCalls[2][0] as string).toContain("✓");
+
+    const summaryLine = messageCalls[3][0] as string;
+    expect(summaryLine).toContain("2");
+    expect(summaryLine).toContain("succeeded");
+    expect(summaryLine).toContain("1");
+    expect(summaryLine).toContain("failed");
+  });
+
+  it("成功結果にドメインに対応する正しいファイルパスが表示される", () => {
+    const results: CaptureResult[] = [
+      { domain: "field-acl", success: true },
+      { domain: "app-acl", success: true },
+      { domain: "record-acl", success: true },
+      { domain: "admin-notes", success: true },
+    ];
+
+    printCaptureAllResults(results, mockPaths);
+
+    const messageCalls = vi.mocked(p.log.message).mock.calls;
+    expect(messageCalls[0][0] as string).toContain("myapp/field-acl.yaml");
+    expect(messageCalls[1][0] as string).toContain("myapp/app-acl.yaml");
+    expect(messageCalls[2][0] as string).toContain("myapp/record-acl.yaml");
+    expect(messageCalls[3][0] as string).toContain("myapp/admin-notes.yaml");
+  });
+
+  it("domainPathKey マッピングが全14ドメインをカバーしている", () => {
+    // This test verifies completeness by passing all 14 domains and checking
+    // that no error is thrown and all paths are resolved
+    const results: CaptureResult[] = ALL_DOMAINS.map((domain) => ({
+      domain,
+      success: true as const,
+    }));
+
+    // Should not throw
+    expect(() => printCaptureAllResults(results, mockPaths)).not.toThrow();
+
+    const messageCalls = vi.mocked(p.log.message).mock.calls;
+    // 14 result lines + 1 summary
+    expect(messageCalls).toHaveLength(15);
+
+    // All lines should contain "saved to" and a valid path (not "undefined")
+    for (let i = 0; i < 14; i++) {
+      const line = messageCalls[i][0] as string;
+      expect(line).toContain("saved to");
+      expect(line).not.toContain("undefined");
+    }
+  });
+});

--- a/src/cli/__tests__/captureAllOutput.test.ts
+++ b/src/cli/__tests__/captureAllOutput.test.ts
@@ -25,7 +25,7 @@ import type {
 } from "@/core/application/init/captureAllForApp";
 import type { AppFilePaths } from "@/core/domain/projectConfig/appFilePaths";
 import { printCaptureAllResults } from "../captureAllOutput";
-import { logError } from "../handleError";
+import { formatErrorForDisplay, logError } from "../handleError";
 
 afterEach(() => {
   vi.clearAllMocks();
@@ -66,6 +66,22 @@ const mockPaths: AppFilePaths = {
 };
 
 describe("printCaptureAllResults", () => {
+  it("ヘッダーに 'Capture Results:' が表示されること", () => {
+    const results: CaptureResult[] = [
+      { domain: "schema", success: true },
+    ];
+
+    printCaptureAllResults(results, mockPaths);
+
+    expect(p.log.step).toHaveBeenCalledWith(
+      expect.stringContaining("Capture Results"),
+    );
+  });
+
+  it("空の結果配列でもクラッシュしないこと", () => {
+    expect(() => printCaptureAllResults([], mockPaths)).not.toThrow();
+  });
+
   it("全14ドメインが成功した場合、全てに ✓ を表示し Summary に succeeded を含む", () => {
     const results: CaptureResult[] = ALL_DOMAINS.map((domain) => ({
       domain,
@@ -111,6 +127,13 @@ describe("printCaptureAllResults", () => {
 
     // logError should be called for each failure
     expect(logError).toHaveBeenCalledTimes(14);
+
+    // formatErrorForDisplay should be called for each failure
+    expect(formatErrorForDisplay).toHaveBeenCalledTimes(14);
+
+    // Verify error messages are included in the output
+    const firstLine = messageCalls[0][0] as string;
+    expect(firstLine).toContain("schema failed");
 
     const summaryLine = messageCalls[14][0] as string;
     expect(summaryLine).toContain("14");

--- a/src/cli/captureAllOutput.ts
+++ b/src/cli/captureAllOutput.ts
@@ -1,0 +1,58 @@
+import * as p from "@clack/prompts";
+import pc from "picocolors";
+import type {
+  CaptureDomain,
+  CaptureResult,
+} from "@/core/application/init/captureAllForApp";
+import type { AppFilePaths } from "@/core/domain/projectConfig/appFilePaths";
+import { formatErrorForDisplay, logError } from "./handleError";
+
+const domainPathKey: Record<CaptureDomain, keyof AppFilePaths> = {
+  schema: "schema",
+  customize: "customize",
+  view: "view",
+  settings: "settings",
+  notification: "notification",
+  report: "report",
+  action: "action",
+  process: "process",
+  plugin: "plugin",
+  seed: "seed",
+  "field-acl": "fieldAcl",
+  "app-acl": "appAcl",
+  "record-acl": "recordAcl",
+  "admin-notes": "adminNotes",
+};
+
+export function printCaptureAllResults(
+  results: readonly CaptureResult[],
+  paths: AppFilePaths,
+): void {
+  const succeeded = results.filter((r) => r.success).length;
+  const failed = results.filter((r) => !r.success).length;
+
+  p.log.step(`\n${"─".repeat(40)}`);
+  p.log.step(pc.bold("Capture Results:"));
+
+  for (const result of results) {
+    const filePath = paths[domainPathKey[result.domain]];
+
+    if (result.success) {
+      p.log.message(
+        `  ${pc.green("✓")} ${result.domain} ${pc.dim("—")} saved to ${pc.dim(filePath)}`,
+      );
+    } else {
+      p.log.message(
+        `  ${pc.red("✗")} ${result.domain} ${pc.dim("—")} ${pc.red(`failed (${formatErrorForDisplay(result.error)})`)}`,
+      );
+      logError(result.error);
+    }
+  }
+
+  p.log.step(`${"─".repeat(40)}`);
+
+  const parts: string[] = [];
+  if (succeeded > 0) parts.push(pc.green(`${succeeded} succeeded`));
+  if (failed > 0) parts.push(pc.red(`${failed} failed`));
+  p.log.message(`  Summary: ${parts.join(pc.dim(" | "))}`);
+}

--- a/src/cli/commands/__tests__/capture.test.ts
+++ b/src/cli/commands/__tests__/capture.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@clack/prompts", () => ({
+  spinner: vi.fn(() => ({
+    start: vi.fn(),
+    stop: vi.fn(),
+  })),
+  log: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+    step: vi.fn(),
+    message: vi.fn(),
+  },
+  note: vi.fn(),
+}));
+
+vi.mock("../../handleError", () => ({
+  handleCliError: vi.fn(),
+}));
+
+vi.mock("../../projectConfig", () => ({
+  routeMultiApp: vi.fn(
+    async (
+      _values: unknown,
+      handlers: { singleLegacy: () => Promise<void> },
+    ) => {
+      await handlers.singleLegacy();
+    },
+  ),
+  resolveAppCliConfig: vi.fn(() => ({
+    baseUrl: "https://example.kintone.com",
+    auth: { type: "apiToken", apiToken: "test-token" },
+    appId: "123",
+  })),
+  runMultiAppWithFailCheck: vi.fn(),
+}));
+
+vi.mock("../../output", () => ({
+  printAppHeader: vi.fn(),
+}));
+
+vi.mock("../../captureAllOutput", () => ({
+  printCaptureAllResults: vi.fn(),
+}));
+
+vi.mock("@/core/application/container/captureAllCli", () => ({
+  createCliCaptureContainers: vi.fn(() => ({
+    containers: {},
+    paths: {
+      schema: "test-app/schema.yaml",
+      customize: "test-app/customize.yaml",
+      view: "test-app/view.yaml",
+      settings: "test-app/settings.yaml",
+      notification: "test-app/notification.yaml",
+      report: "test-app/report.yaml",
+      action: "test-app/action.yaml",
+      process: "test-app/process.yaml",
+      fieldAcl: "test-app/field-acl.yaml",
+      appAcl: "test-app/app-acl.yaml",
+      recordAcl: "test-app/record-acl.yaml",
+      adminNotes: "test-app/admin-notes.yaml",
+      plugin: "test-app/plugin.yaml",
+      seed: "test-app/seed.yaml",
+    },
+  })),
+}));
+
+vi.mock("@/core/application/init/captureAllForApp", () => ({
+  captureAllForApp: vi.fn(async () => [
+    { domain: "schema", success: true },
+  ]),
+}));
+
+import * as p from "@clack/prompts";
+import { captureAllForApp } from "@/core/application/init/captureAllForApp";
+import type {
+  AppEntry,
+  ExecutionPlan,
+  ProjectConfig,
+} from "@/core/domain/projectConfig/entity";
+import type { AppName } from "@/core/domain/projectConfig/valueObject";
+import { printCaptureAllResults } from "../../captureAllOutput";
+import { handleCliError } from "../../handleError";
+import { printAppHeader } from "../../output";
+import { routeMultiApp, runMultiAppWithFailCheck } from "../../projectConfig";
+import captureCommand from "../capture";
+
+afterEach(() => {
+  vi.clearAllMocks();
+  process.exitCode = undefined;
+});
+
+const mockApp: AppEntry = {
+  name: "test-app" as AppName,
+  appId: "123",
+  dependsOn: [],
+};
+
+const mockProjectConfig: ProjectConfig = {
+  domain: "example.kintone.com",
+  apps: new Map([["test-app" as AppName, mockApp]]),
+};
+
+describe("capture command", () => {
+  it("singleLegacy ではエラーメッセージを表示し exitCode を 1 にすること", async () => {
+    await captureCommand.run({ values: {} } as never);
+
+    expect(p.log.error).toHaveBeenCalledWith(
+      expect.stringContaining("requires a project config file"),
+    );
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("singleApp では captureAllForApp と printCaptureAllResults が呼ばれること", async () => {
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          singleApp: (app: AppEntry, config: ProjectConfig) => Promise<void>;
+        },
+      ) => {
+        await handlers.singleApp(mockApp, mockProjectConfig);
+      },
+    );
+
+    await captureCommand.run({ values: {} } as never);
+
+    expect(captureAllForApp).toHaveBeenCalled();
+    expect(printCaptureAllResults).toHaveBeenCalled();
+  });
+
+  it("multiApp では runMultiAppWithFailCheck が呼ばれ printAppHeader が表示されること", async () => {
+    const plan: ExecutionPlan = { orderedApps: [mockApp] };
+
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          multiApp: (
+            plan: ExecutionPlan,
+            config: ProjectConfig,
+          ) => Promise<void>;
+        },
+      ) => {
+        await handlers.multiApp(plan, mockProjectConfig);
+      },
+    );
+
+    vi.mocked(runMultiAppWithFailCheck).mockImplementationOnce(
+      async (_plan, executor) => {
+        await executor(mockApp);
+      },
+    );
+
+    await captureCommand.run({ values: {} } as never);
+
+    expect(runMultiAppWithFailCheck).toHaveBeenCalled();
+    expect(printAppHeader).toHaveBeenCalledWith("test-app", "123");
+    expect(captureAllForApp).toHaveBeenCalled();
+    expect(printCaptureAllResults).toHaveBeenCalled();
+  });
+
+  it("エラー発生時に handleCliError が呼ばれること", async () => {
+    const testError = new Error("test error");
+    vi.mocked(routeMultiApp).mockRejectedValueOnce(testError);
+
+    await captureCommand.run({ values: {} } as never);
+
+    expect(handleCliError).toHaveBeenCalledWith(testError);
+  });
+});

--- a/src/cli/commands/__tests__/capture.test.ts
+++ b/src/cli/commands/__tests__/capture.test.ts
@@ -68,9 +68,7 @@ vi.mock("@/core/application/container/captureAllCli", () => ({
 }));
 
 vi.mock("@/core/application/init/captureAllForApp", () => ({
-  captureAllForApp: vi.fn(async () => [
-    { domain: "schema", success: true },
-  ]),
+  captureAllForApp: vi.fn(async () => [{ domain: "schema", success: true }]),
 }));
 
 import * as p from "@clack/prompts";

--- a/src/cli/commands/capture.ts
+++ b/src/cli/commands/capture.ts
@@ -68,7 +68,7 @@ export default define({
       await routeMultiApp(values, {
         singleLegacy: async () => {
           p.log.error(
-            "This command requires a project config file.\nRun 'kintone-migrator init' to create one, or use individual capture commands (e.g. 'schema capture').",
+            "The 'capture' command requires a project config file.\nRun 'kintone-migrator init' to create one, or use individual capture commands (e.g. 'schema capture').",
           );
           process.exitCode = 1;
         },

--- a/src/cli/commands/capture.ts
+++ b/src/cli/commands/capture.ts
@@ -1,0 +1,91 @@
+import { dirname, resolve } from "node:path";
+import * as p from "@clack/prompts";
+import { define } from "gunshi";
+import { createCliCaptureContainers } from "@/core/application/container/captureAllCli";
+import { captureAllForApp } from "@/core/application/init/captureAllForApp";
+import { printCaptureAllResults } from "../captureAllOutput";
+import { kintoneArgs, multiAppArgs } from "../config";
+import { handleCliError } from "../handleError";
+import { printAppHeader } from "../output";
+import {
+  type MultiAppCliValues,
+  resolveAppCliConfig,
+  routeMultiApp,
+  runMultiAppWithFailCheck,
+} from "../projectConfig";
+
+const captureArgs = {
+  domain: kintoneArgs.domain,
+  username: kintoneArgs.username,
+  password: kintoneArgs.password,
+  "api-token": kintoneArgs["api-token"],
+  "guest-space-id": kintoneArgs["guest-space-id"],
+  ...multiAppArgs,
+};
+
+type CaptureCliValues = MultiAppCliValues;
+
+async function runCaptureAll(
+  cliConfig: {
+    baseUrl: string;
+    auth:
+      | { type: "apiToken"; apiToken: string | string[] }
+      | { type: "password"; username: string; password: string };
+    appId: string;
+    guestSpaceId?: string;
+  },
+  appName: string,
+): Promise<void> {
+  const { containers, paths } = createCliCaptureContainers({
+    ...cliConfig,
+    appName:
+      appName as import("@/core/domain/projectConfig/valueObject").AppName,
+  });
+
+  const customizeBasePath = dirname(resolve(paths.customize));
+
+  const s = p.spinner();
+  s.start(`Capturing all domains for ${appName}...`);
+  const results = await captureAllForApp({
+    container: containers,
+    input: { customizeBasePath },
+  });
+  const failCount = results.filter((r) => !r.success).length;
+  s.stop(`Capture complete.${failCount > 0 ? ` (${failCount} failed)` : ""}`);
+
+  printCaptureAllResults(results, paths);
+}
+
+export default define({
+  name: "capture",
+  description:
+    "Capture all domain configurations (schema, customize, views, etc.) from kintone app and save to local files",
+  args: captureArgs,
+  run: async (ctx) => {
+    try {
+      const values = ctx.values as CaptureCliValues;
+
+      await routeMultiApp(values, {
+        singleLegacy: async () => {
+          p.log.error(
+            "This command requires a project config file.\nRun 'kintone-migrator init' to create one, or use individual capture commands (e.g. 'schema capture').",
+          );
+          process.exitCode = 1;
+        },
+        singleApp: async (app, projectConfig) => {
+          const cliConfig = resolveAppCliConfig(app, projectConfig, values);
+          await runCaptureAll(cliConfig, app.name);
+        },
+        multiApp: async (plan, projectConfig) => {
+          await runMultiAppWithFailCheck(plan, async (app) => {
+            const cliConfig = resolveAppCliConfig(app, projectConfig, values);
+            printAppHeader(app.name, app.appId);
+            await runCaptureAll(cliConfig, app.name);
+          });
+        },
+      });
+    } catch (error) {
+      handleCliError(error);
+    }
+  },
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,6 +6,7 @@ import { cli, define } from "gunshi";
 import actionGroup from "./commands/action";
 import adminNotesGroup from "./commands/admin-notes";
 import appAclGroup from "./commands/app-acl";
+import captureCommand from "./commands/capture";
 import customizeGroup from "./commands/customize";
 import diffCommand from "./commands/diff";
 import fieldAclGroup from "./commands/field-acl";
@@ -42,6 +43,7 @@ await cli(process.argv.slice(2), main, {
   version: loadVersion(),
   subCommands: {
     init: initCommand,
+    capture: captureCommand,
     diff: diffCommand,
     schema: schemaGroup,
     seed: seedGroup,


### PR DESCRIPTION
## Summary
- Add top-level `capture` CLI command that batch-captures all 14 domains (including seed) from kintone apps
- Reuse existing `captureAllForApp` from `init` module (no application layer changes needed)
- Support multi-app mode with `--app` / `--all` flags, matching `diff` command's interface
- Display per-domain results with saved file paths and summary counts

## Issue
Closes #149

## Implementation Plan
Based on `.issue/149/plan.md`

## Test plan
- [x] `capture` command registered and shown in `--help`
- [x] Output format: `✓ domain — saved to path` / `✗ domain — failed (error)`
- [x] Summary line: `N succeeded | M failed`
- [x] `singleLegacy` mode shows error message with guidance
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (2 pre-existing warnings only)
- [x] `pnpm test` — all 218 test files, 2270 tests pass
- [ ] Manual: single-app capture with real kintone environment
- [ ] Manual: multi-app capture with `--all` flag
- [ ] Manual: non-fatal error isolation (one domain fails, others continue)
- [ ] Manual: fatal error (auth failure) aborts remaining batches

## E2E Test
- `src/cli/__tests__/captureAllOutput.test.ts` — 5 test cases covering all-success, all-failure, mixed, kebab-case domain path mapping, and 14-domain completeness verification
- Manual-only items: actual kintone API integration, real multi-app routing (requires live environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)