### PR TITLE
feat: add top-level apply command for all-domain batch application

### DIFF
--- a/src/cli/__tests__/applyAllOutput.test.ts
+++ b/src/cli/__tests__/applyAllOutput.test.ts
@@ -253,6 +253,9 @@ describe("printApplyAllResults", () => {
     const summaryLine = messageCalls[messageCalls.length - 1][0] as string;
     expect(summaryLine).toContain("1");
     expect(summaryLine).toContain("skipped");
+
+    // logError should NOT be called for skipped results
+    expect(logError).not.toHaveBeenCalled();
   });
 
   it("deployed が false で deployError がある場合にエラー詳細が表示されること", () => {

--- a/src/cli/__tests__/applyAllOutput.test.ts
+++ b/src/cli/__tests__/applyAllOutput.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@clack/prompts", () => ({
+  log: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    success: vi.fn(),
+    step: vi.fn(),
+    error: vi.fn(),
+    message: vi.fn(),
+  },
+}));
+
+vi.mock("../handleError", () => ({
+  formatErrorForDisplay: vi.fn((e: unknown) =>
+    e instanceof Error ? e.message : String(e),
+  ),
+  logError: vi.fn(),
+}));
+
+import * as p from "@clack/prompts";
+import type { ApplyAllForAppOutput } from "@/core/application/applyAll/applyAllForApp";
+import { printApplyAllResults } from "../applyAllOutput";
+import { logError } from "../handleError";
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function makeSuccessOutput(): ApplyAllForAppOutput {
+  return {
+    phases: [
+      {
+        phase: "Schema",
+        results: [{ domain: "schema", success: true }],
+      },
+      {
+        phase: "Views & Customization",
+        results: [
+          { domain: "customize", success: true },
+          { domain: "view", success: true },
+        ],
+      },
+      {
+        phase: "Permissions",
+        results: [
+          { domain: "field-acl", success: true },
+          { domain: "app-acl", success: true },
+          { domain: "record-acl", success: true },
+        ],
+      },
+      {
+        phase: "Settings & Others",
+        results: [
+          { domain: "settings", success: true },
+          { domain: "notification", success: true },
+          { domain: "report", success: true },
+          { domain: "action", success: true },
+          { domain: "process", success: true },
+          { domain: "admin-notes", success: true },
+          { domain: "plugin", success: true },
+        ],
+      },
+      {
+        phase: "Seed Data",
+        results: [{ domain: "seed", success: true }],
+      },
+    ],
+    deployed: true,
+  };
+}
+
+describe("printApplyAllResults", () => {
+  it("ヘッダーに 'Apply Results:' が表示されること", () => {
+    printApplyAllResults(makeSuccessOutput());
+
+    expect(p.log.step).toHaveBeenCalledWith(
+      expect.stringContaining("Apply Results"),
+    );
+  });
+
+  it("全14ドメインが成功した場合、全てに checkmark を表示し Summary に succeeded を含む", () => {
+    printApplyAllResults(makeSuccessOutput());
+
+    const messageCalls = vi.mocked(p.log.message).mock.calls;
+    // 14 results + 1 summary = 15 message calls
+    expect(messageCalls).toHaveLength(15);
+
+    // All result lines should contain checkmark
+    for (let i = 0; i < 14; i++) {
+      const line = messageCalls[i][0] as string;
+      expect(line).toContain("\u2713");
+    }
+
+    // Summary line
+    const summaryLine = messageCalls[14][0] as string;
+    expect(summaryLine).toContain("14");
+    expect(summaryLine).toContain("succeeded");
+  });
+
+  it("deployed が true の場合は 'Deployed to production.' が表示されること", () => {
+    printApplyAllResults(makeSuccessOutput());
+
+    expect(p.log.success).toHaveBeenCalledWith("Deployed to production.");
+  });
+
+  it("フェーズ名がヘッダーとして表示されること", () => {
+    printApplyAllResults(makeSuccessOutput());
+
+    const stepCalls = vi
+      .mocked(p.log.step)
+      .mock.calls.map((call) => call[0] as string);
+
+    expect(stepCalls).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("Schema"),
+        expect.stringContaining("Views & Customization"),
+        expect.stringContaining("Permissions"),
+        expect.stringContaining("Settings & Others"),
+        expect.stringContaining("Seed Data"),
+      ]),
+    );
+  });
+
+  it("失敗結果に cross mark と failed が表示されること", () => {
+    const output: ApplyAllForAppOutput = {
+      phases: [
+        {
+          phase: "Schema",
+          results: [
+            {
+              domain: "schema",
+              success: false,
+              error: new Error("migration failed"),
+            },
+          ],
+        },
+      ],
+      deployed: false,
+    };
+
+    printApplyAllResults(output);
+
+    const messageCalls = vi.mocked(p.log.message).mock.calls;
+    const schemaLine = messageCalls[0][0] as string;
+    expect(schemaLine).toContain("\u2717");
+    expect(schemaLine).toContain("failed");
+    expect(schemaLine).toContain("migration failed");
+
+    expect(logError).toHaveBeenCalledTimes(1);
+  });
+
+  it("成功と失敗が混在する場合、Summary に両方を含む", () => {
+    const output: ApplyAllForAppOutput = {
+      phases: [
+        {
+          phase: "Schema",
+          results: [{ domain: "schema", success: true }],
+        },
+        {
+          phase: "Views & Customization",
+          results: [
+            {
+              domain: "customize",
+              success: false,
+              error: new Error("API error"),
+            },
+            { domain: "view", success: true },
+          ],
+        },
+      ],
+      deployed: true,
+    };
+
+    printApplyAllResults(output);
+
+    const messageCalls = vi.mocked(p.log.message).mock.calls;
+    const summaryLine = messageCalls[messageCalls.length - 1][0] as string;
+    expect(summaryLine).toContain("2");
+    expect(summaryLine).toContain("succeeded");
+    expect(summaryLine).toContain("1");
+    expect(summaryLine).toContain("failed");
+  });
+
+  it("空の結果配列でもクラッシュしないこと", () => {
+    const output: ApplyAllForAppOutput = {
+      phases: [],
+      deployed: false,
+    };
+
+    expect(() => printApplyAllResults(output)).not.toThrow();
+  });
+
+  it("deployed が false で成功ドメインがある場合に警告が表示されること", () => {
+    const output: ApplyAllForAppOutput = {
+      phases: [
+        {
+          phase: "Schema",
+          results: [{ domain: "schema", success: true }],
+        },
+        {
+          phase: "Views & Customization",
+          results: [
+            { domain: "customize", success: true },
+            {
+              domain: "view",
+              success: false,
+              error: new Error("view failed"),
+            },
+          ],
+        },
+      ],
+      deployed: false,
+    };
+
+    printApplyAllResults(output);
+
+    expect(p.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("deployment may not have completed"),
+    );
+  });
+});

--- a/src/cli/__tests__/applyAllOutput.test.ts
+++ b/src/cli/__tests__/applyAllOutput.test.ts
@@ -132,6 +132,7 @@ describe("printApplyAllResults", () => {
               domain: "schema",
               success: false,
               error: new Error("migration failed"),
+              skipped: false,
             },
           ],
         },
@@ -164,6 +165,7 @@ describe("printApplyAllResults", () => {
               domain: "customize",
               success: false,
               error: new Error("API error"),
+              skipped: false,
             },
             { domain: "view", success: true },
           ],
@@ -206,6 +208,7 @@ describe("printApplyAllResults", () => {
               domain: "view",
               success: false,
               error: new Error("view failed"),
+              skipped: false,
             },
           ],
         },
@@ -218,5 +221,95 @@ describe("printApplyAllResults", () => {
     expect(p.log.warn).toHaveBeenCalledWith(
       expect.stringContaining("deployment may not have completed"),
     );
+  });
+
+  it("skipped 結果に yellow marker と skipped が表示されること", () => {
+    const output: ApplyAllForAppOutput = {
+      phases: [
+        {
+          phase: "Schema",
+          results: [
+            {
+              domain: "schema",
+              success: false,
+              error: new Error("Skipped due to fatal error"),
+              skipped: true,
+            },
+          ],
+        },
+      ],
+      deployed: false,
+    };
+
+    printApplyAllResults(output);
+
+    const messageCalls = vi.mocked(p.log.message).mock.calls;
+    const schemaLine = messageCalls[0][0] as string;
+    expect(schemaLine).toContain("\u2298");
+    expect(schemaLine).toContain("skipped");
+    expect(schemaLine).not.toContain("failed");
+
+    // Summary should show skipped count
+    const summaryLine = messageCalls[messageCalls.length - 1][0] as string;
+    expect(summaryLine).toContain("1");
+    expect(summaryLine).toContain("skipped");
+  });
+
+  it("deployed が false で deployError がある場合にエラー詳細が表示されること", () => {
+    const output: ApplyAllForAppOutput = {
+      phases: [
+        {
+          phase: "Schema",
+          results: [{ domain: "schema", success: true }],
+        },
+      ],
+      deployed: false,
+      deployError: new Error("Deploy API timeout"),
+    };
+
+    printApplyAllResults(output);
+
+    expect(p.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Deployment failed"),
+    );
+    expect(p.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Deploy API timeout"),
+    );
+  });
+
+  it("deployed が false で succeeded が 0 の場合に 'Not deployed due to errors.' が表示されること", () => {
+    const output: ApplyAllForAppOutput = {
+      phases: [
+        {
+          phase: "Schema",
+          results: [
+            {
+              domain: "schema",
+              success: false,
+              error: new Error("failed"),
+              skipped: false,
+            },
+          ],
+        },
+      ],
+      deployed: false,
+    };
+
+    printApplyAllResults(output);
+
+    expect(p.log.warn).toHaveBeenCalledWith("Not deployed due to errors.");
+  });
+
+  it("空の phases の場合に 'No domains processed' が表示されること", () => {
+    const output: ApplyAllForAppOutput = {
+      phases: [],
+      deployed: false,
+    };
+
+    printApplyAllResults(output);
+
+    const messageCalls = vi.mocked(p.log.message).mock.calls;
+    const summaryLine = messageCalls[messageCalls.length - 1][0] as string;
+    expect(summaryLine).toContain("No domains processed");
   });
 });

--- a/src/cli/__tests__/applyAllOutput.test.ts
+++ b/src/cli/__tests__/applyAllOutput.test.ts
@@ -193,7 +193,7 @@ describe("printApplyAllResults", () => {
     expect(() => printApplyAllResults(output)).not.toThrow();
   });
 
-  it("deployed が false で成功ドメインがある場合に警告が表示されること", () => {
+  it("deployed が false で失敗ドメインがある場合にスキップメッセージが表示されること", () => {
     const output: ApplyAllForAppOutput = {
       phases: [
         {
@@ -218,8 +218,8 @@ describe("printApplyAllResults", () => {
 
     printApplyAllResults(output);
 
-    expect(p.log.warn).toHaveBeenCalledWith(
-      expect.stringContaining("deployment may not have completed"),
+    expect(p.log.info).toHaveBeenCalledWith(
+      expect.stringContaining("Deployment skipped"),
     );
   });
 

--- a/src/cli/applyAllOutput.ts
+++ b/src/cli/applyAllOutput.ts
@@ -1,0 +1,75 @@
+import * as p from "@clack/prompts";
+import pc from "picocolors";
+import type {
+  ApplyAllForAppOutput,
+  ApplyDomain,
+  ApplyPhaseResult,
+  ApplyTaskResult,
+} from "@/core/application/applyAll/applyAllForApp";
+import { formatErrorForDisplay, logError } from "./handleError";
+
+const domainDisplayName: Record<ApplyDomain, string> = {
+  schema: "Schema",
+  customize: "Customization",
+  view: "View",
+  "field-acl": "Field Permission",
+  "app-acl": "App Permission",
+  "record-acl": "Record Permission",
+  settings: "General Settings",
+  notification: "Notification",
+  report: "Report",
+  action: "Action",
+  process: "Process Management",
+  "admin-notes": "Admin Notes",
+  plugin: "Plugin",
+  seed: "Seed Data",
+};
+
+function formatTaskResult(result: ApplyTaskResult): string {
+  const name = domainDisplayName[result.domain];
+  if (result.success) {
+    return `  ${pc.green("\u2713")} ${name}`;
+  }
+  return `  ${pc.red("\u2717")} ${name} ${pc.dim("\u2014")} ${pc.red(`failed (${formatErrorForDisplay(result.error)})`)}`;
+}
+
+function printPhaseResult(phaseResult: ApplyPhaseResult): void {
+  p.log.step(pc.bold(`Phase: ${phaseResult.phase}`));
+
+  for (const result of phaseResult.results) {
+    p.log.message(formatTaskResult(result));
+    if (!result.success) {
+      logError(result.error);
+    }
+  }
+}
+
+export function printApplyAllResults(output: ApplyAllForAppOutput): void {
+  p.log.step(`\n${"─".repeat(40)}`);
+  p.log.step(pc.bold("Apply Results:"));
+
+  for (const phaseResult of output.phases) {
+    printPhaseResult(phaseResult);
+  }
+
+  // Deploy status
+  p.log.step(`${"─".repeat(40)}`);
+
+  const allResults = output.phases.flatMap((pr) => pr.results);
+  const succeeded = allResults.filter((r) => r.success).length;
+  const failed = allResults.filter((r) => !r.success).length;
+
+  if (output.deployed) {
+    p.log.success("Deployed to production.");
+  } else if (succeeded > 0 && failed > 0) {
+    p.log.warn(
+      "Some domains were applied but deployment may not have completed. Check app status in kintone.",
+    );
+  }
+
+  // Summary
+  const parts: string[] = [];
+  if (succeeded > 0) parts.push(pc.green(`${succeeded} succeeded`));
+  if (failed > 0) parts.push(pc.red(`${failed} failed`));
+  p.log.message(`  Summary: ${parts.join(pc.dim(" | "))}`);
+}

--- a/src/cli/applyAllOutput.ts
+++ b/src/cli/applyAllOutput.ts
@@ -41,7 +41,7 @@ function printPhaseResult(phaseResult: ApplyPhaseResult): void {
 
   for (const result of phaseResult.results) {
     p.log.message(formatTaskResult(result));
-    if (!result.success) {
+    if (!result.success && !result.skipped) {
       logError(result.error);
     }
   }

--- a/src/cli/applyAllOutput.ts
+++ b/src/cli/applyAllOutput.ts
@@ -30,6 +30,9 @@ function formatTaskResult(result: ApplyTaskResult): string {
   if (result.success) {
     return `  ${pc.green("\u2713")} ${name}`;
   }
+  if (result.skipped) {
+    return `  ${pc.yellow("\u2298")} ${name} ${pc.dim("\u2014")} ${pc.yellow("skipped")}`;
+  }
   return `  ${pc.red("\u2717")} ${name} ${pc.dim("\u2014")} ${pc.red(`failed (${formatErrorForDisplay(result.error)})`)}`;
 }
 
@@ -57,11 +60,18 @@ export function printApplyAllResults(output: ApplyAllForAppOutput): void {
 
   const allResults = output.phases.flatMap((pr) => pr.results);
   const succeeded = allResults.filter((r) => r.success).length;
-  const failed = allResults.filter((r) => !r.success).length;
+  const failed = allResults.filter((r) => !r.success && !r.skipped).length;
+  const skipped = allResults.filter((r) => !r.success && r.skipped).length;
 
   if (output.deployed) {
     p.log.success("Deployed to production.");
-  } else if (succeeded > 0 && failed > 0) {
+  } else if (output.deployError) {
+    p.log.warn(
+      `Deployment failed: ${formatErrorForDisplay(output.deployError)}`,
+    );
+  } else if (succeeded === 0) {
+    p.log.warn("Not deployed due to errors.");
+  } else if (succeeded > 0 && (failed > 0 || skipped > 0)) {
     p.log.warn(
       "Some domains were applied but deployment may not have completed. Check app status in kintone.",
     );
@@ -71,5 +81,8 @@ export function printApplyAllResults(output: ApplyAllForAppOutput): void {
   const parts: string[] = [];
   if (succeeded > 0) parts.push(pc.green(`${succeeded} succeeded`));
   if (failed > 0) parts.push(pc.red(`${failed} failed`));
-  p.log.message(`  Summary: ${parts.join(pc.dim(" | "))}`);
+  if (skipped > 0) parts.push(pc.yellow(`${skipped} skipped`));
+  p.log.message(
+    `  Summary: ${parts.length > 0 ? parts.join(pc.dim(" | ")) : "No domains processed"}`,
+  );
 }

--- a/src/cli/applyAllOutput.ts
+++ b/src/cli/applyAllOutput.ts
@@ -71,9 +71,11 @@ export function printApplyAllResults(output: ApplyAllForAppOutput): void {
     );
   } else if (succeeded === 0) {
     p.log.warn("Not deployed due to errors.");
-  } else if (succeeded > 0 && (failed > 0 || skipped > 0)) {
-    p.log.warn(
-      "Some domains were applied but deployment may not have completed. Check app status in kintone.",
+  } else if (failed > 0 || skipped > 0) {
+    // Deploy was intentionally skipped because no Phase 2-4 domains succeeded.
+    // Schema was already deployed in Phase 1, and seed doesn't need deploy.
+    p.log.info(
+      "Deployment skipped (no Phase 2-4 changes applied successfully).",
     );
   }
 

--- a/src/cli/commands/__tests__/apply.test.ts
+++ b/src/cli/commands/__tests__/apply.test.ts
@@ -201,7 +201,7 @@ describe("apply command", () => {
     expect(printDiffAllResults).toHaveBeenCalled();
     expect(applyAllForApp).not.toHaveBeenCalled();
     expect(p.log.info).toHaveBeenCalledWith(
-      "Dry run complete. No changes applied.",
+      "Dry run complete. No changes will be applied.",
     );
   });
 
@@ -263,6 +263,60 @@ describe("apply command", () => {
     await applyCommand.run({ values: {} } as never);
 
     expect(handleCliError).toHaveBeenCalledWith(testError);
+  });
+
+  it("singleApp で Ctrl+C でキャンセルした場合は apply されないこと", async () => {
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          singleApp: (app: AppEntry, config: ProjectConfig) => Promise<void>;
+        },
+      ) => {
+        await handlers.singleApp(mockApp, mockProjectConfig);
+      },
+    );
+    vi.mocked(p.isCancel).mockReturnValueOnce(true);
+    vi.mocked(p.confirm).mockResolvedValueOnce(undefined as never);
+
+    await applyCommand.run({ values: {} } as never);
+
+    expect(p.cancel).toHaveBeenCalled();
+    expect(applyAllForApp).not.toHaveBeenCalled();
+  });
+
+  it("singleApp で diff 変更がない場合でも apply が実行されること（seed のため）", async () => {
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          singleApp: (app: AppEntry, config: ProjectConfig) => Promise<void>;
+        },
+      ) => {
+        await handlers.singleApp(mockApp, mockProjectConfig);
+      },
+    );
+    vi.mocked(diffAllForApp).mockResolvedValueOnce([
+      {
+        domain: "schema",
+        success: true,
+        result: {
+          isEmpty: true,
+          entries: [],
+          schemaFields: [],
+          summary: { added: 0, modified: 0, deleted: 0, total: 0 },
+          hasLayoutChanges: false,
+        },
+      },
+    ]);
+    vi.mocked(p.confirm).mockResolvedValueOnce(true);
+
+    await applyCommand.run({ values: {} } as never);
+
+    expect(p.log.success).toHaveBeenCalledWith(
+      "No changes detected. Seed data will still be upserted.",
+    );
+    expect(applyAllForApp).toHaveBeenCalled();
   });
 
   it("seed data のメッセージが表示されること", async () => {

--- a/src/cli/commands/__tests__/apply.test.ts
+++ b/src/cli/commands/__tests__/apply.test.ts
@@ -338,4 +338,38 @@ describe("apply command", () => {
       "Note: Seed data will be upserted (no diff preview available).",
     );
   });
+
+  it("apply で失敗があった場合に exitCode が 1 になること", async () => {
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          singleApp: (app: AppEntry, config: ProjectConfig) => Promise<void>;
+        },
+      ) => {
+        await handlers.singleApp(mockApp, mockProjectConfig);
+      },
+    );
+    vi.mocked(p.confirm).mockResolvedValueOnce(true);
+    vi.mocked(applyAllForApp).mockResolvedValueOnce({
+      phases: [
+        {
+          phase: "Schema",
+          results: [
+            {
+              domain: "schema",
+              success: false,
+              error: new Error("fail"),
+              skipped: false,
+            },
+          ],
+        },
+      ],
+      deployed: false,
+    });
+
+    await applyCommand.run({ values: {} } as never);
+
+    expect(process.exitCode).toBe(1);
+  });
 });

--- a/src/cli/commands/__tests__/apply.test.ts
+++ b/src/cli/commands/__tests__/apply.test.ts
@@ -1,0 +1,287 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@clack/prompts", () => ({
+  spinner: vi.fn(() => ({
+    start: vi.fn(),
+    stop: vi.fn(),
+  })),
+  log: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+    step: vi.fn(),
+    message: vi.fn(),
+  },
+  note: vi.fn(),
+  confirm: vi.fn(),
+  isCancel: vi.fn(() => false),
+  cancel: vi.fn(),
+}));
+
+vi.mock("../../handleError", () => ({
+  handleCliError: vi.fn(),
+}));
+
+vi.mock("../../projectConfig", () => ({
+  routeMultiApp: vi.fn(
+    async (
+      _values: unknown,
+      handlers: { singleLegacy: () => Promise<void> },
+    ) => {
+      await handlers.singleLegacy();
+    },
+  ),
+  resolveAppCliConfig: vi.fn(() => ({
+    baseUrl: "https://example.kintone.com",
+    auth: { type: "apiToken", apiToken: "test-token" },
+    appId: "123",
+  })),
+  runMultiAppWithFailCheck: vi.fn(),
+}));
+
+vi.mock("../../output", () => ({
+  printAppHeader: vi.fn(),
+}));
+
+vi.mock("../../diffAllOutput", () => ({
+  printDiffAllResults: vi.fn(),
+}));
+
+vi.mock("../../applyAllOutput", () => ({
+  printApplyAllResults: vi.fn(),
+}));
+
+vi.mock("@/core/application/container/applyAllCli", () => ({
+  createCliApplyAllContainers: vi.fn(() => ({
+    containers: {},
+    diffContainers: {},
+    paths: {
+      schema: "test-app/schema.yaml",
+      customize: "test-app/customize.yaml",
+      view: "test-app/view.yaml",
+      settings: "test-app/settings.yaml",
+      notification: "test-app/notification.yaml",
+      report: "test-app/report.yaml",
+      action: "test-app/action.yaml",
+      process: "test-app/process.yaml",
+      fieldAcl: "test-app/field-acl.yaml",
+      appAcl: "test-app/app-acl.yaml",
+      recordAcl: "test-app/record-acl.yaml",
+      adminNotes: "test-app/admin-notes.yaml",
+      plugin: "test-app/plugin.yaml",
+      seed: "test-app/seed.yaml",
+    },
+  })),
+}));
+
+vi.mock("@/core/application/diffAll/diffAllForApp", () => ({
+  diffAllForApp: vi.fn(async () => [
+    {
+      domain: "schema",
+      success: true,
+      result: {
+        isEmpty: false,
+        entries: [],
+        summary: { added: 1, modified: 0, deleted: 0, total: 1 },
+        hasLayoutChanges: false,
+      },
+    },
+  ]),
+}));
+
+vi.mock("@/core/application/applyAll/applyAllForApp", () => ({
+  applyAllForApp: vi.fn(async () => ({
+    phases: [
+      {
+        phase: "Schema",
+        results: [{ domain: "schema", success: true }],
+      },
+    ],
+    deployed: true,
+  })),
+}));
+
+import * as p from "@clack/prompts";
+import { applyAllForApp } from "@/core/application/applyAll/applyAllForApp";
+import { diffAllForApp } from "@/core/application/diffAll/diffAllForApp";
+import type {
+  AppEntry,
+  ExecutionPlan,
+  ProjectConfig,
+} from "@/core/domain/projectConfig/entity";
+import type { AppName } from "@/core/domain/projectConfig/valueObject";
+import { printApplyAllResults } from "../../applyAllOutput";
+import { printDiffAllResults } from "../../diffAllOutput";
+import { handleCliError } from "../../handleError";
+import { printAppHeader } from "../../output";
+import { routeMultiApp, runMultiAppWithFailCheck } from "../../projectConfig";
+import applyCommand from "../apply";
+
+afterEach(() => {
+  vi.clearAllMocks();
+  process.exitCode = undefined;
+});
+
+const mockApp: AppEntry = {
+  name: "test-app" as AppName,
+  appId: "123",
+  dependsOn: [],
+};
+
+const mockProjectConfig: ProjectConfig = {
+  domain: "example.kintone.com",
+  apps: new Map([["test-app" as AppName, mockApp]]),
+};
+
+describe("apply command", () => {
+  it("singleLegacy ではエラーメッセージを表示し exitCode を 1 にすること", async () => {
+    await applyCommand.run({ values: {} } as never);
+
+    expect(p.log.error).toHaveBeenCalledWith(
+      expect.stringContaining("requires a project config file"),
+    );
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("singleApp では diffAllForApp と applyAllForApp が呼ばれること", async () => {
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          singleApp: (app: AppEntry, config: ProjectConfig) => Promise<void>;
+        },
+      ) => {
+        await handlers.singleApp(mockApp, mockProjectConfig);
+      },
+    );
+    vi.mocked(p.confirm).mockResolvedValueOnce(true);
+
+    await applyCommand.run({ values: {} } as never);
+
+    expect(diffAllForApp).toHaveBeenCalled();
+    expect(printDiffAllResults).toHaveBeenCalled();
+    expect(applyAllForApp).toHaveBeenCalled();
+    expect(printApplyAllResults).toHaveBeenCalled();
+  });
+
+  it("singleApp で --yes の場合は確認プロンプトをスキップすること", async () => {
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          singleApp: (app: AppEntry, config: ProjectConfig) => Promise<void>;
+        },
+      ) => {
+        await handlers.singleApp(mockApp, mockProjectConfig);
+      },
+    );
+
+    await applyCommand.run({ values: { yes: true } } as never);
+
+    expect(p.confirm).not.toHaveBeenCalled();
+    expect(applyAllForApp).toHaveBeenCalled();
+  });
+
+  it("singleApp で --dry-run の場合は apply せず diff のみ表示すること", async () => {
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          singleApp: (app: AppEntry, config: ProjectConfig) => Promise<void>;
+        },
+      ) => {
+        await handlers.singleApp(mockApp, mockProjectConfig);
+      },
+    );
+
+    await applyCommand.run({ values: { "dry-run": true } } as never);
+
+    expect(diffAllForApp).toHaveBeenCalled();
+    expect(printDiffAllResults).toHaveBeenCalled();
+    expect(applyAllForApp).not.toHaveBeenCalled();
+    expect(p.log.info).toHaveBeenCalledWith(
+      "Dry run complete. No changes applied.",
+    );
+  });
+
+  it("singleApp で確認プロンプトをキャンセルした場合は apply されないこと", async () => {
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          singleApp: (app: AppEntry, config: ProjectConfig) => Promise<void>;
+        },
+      ) => {
+        await handlers.singleApp(mockApp, mockProjectConfig);
+      },
+    );
+    vi.mocked(p.confirm).mockResolvedValueOnce(false);
+
+    await applyCommand.run({ values: {} } as never);
+
+    expect(applyAllForApp).not.toHaveBeenCalled();
+  });
+
+  it("multiApp では runMultiAppWithFailCheck が呼ばれ printAppHeader が表示されること", async () => {
+    const plan: ExecutionPlan = { orderedApps: [mockApp] };
+
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          multiApp: (
+            plan: ExecutionPlan,
+            config: ProjectConfig,
+          ) => Promise<void>;
+        },
+      ) => {
+        await handlers.multiApp(plan, mockProjectConfig);
+      },
+    );
+
+    vi.mocked(runMultiAppWithFailCheck).mockImplementationOnce(
+      async (_plan, executor) => {
+        await executor(mockApp);
+      },
+    );
+
+    vi.mocked(p.confirm).mockResolvedValueOnce(true);
+
+    await applyCommand.run({ values: {} } as never);
+
+    expect(runMultiAppWithFailCheck).toHaveBeenCalled();
+    expect(printAppHeader).toHaveBeenCalledWith("test-app", "123");
+    expect(diffAllForApp).toHaveBeenCalled();
+    expect(applyAllForApp).toHaveBeenCalled();
+  });
+
+  it("エラー発生時に handleCliError が呼ばれること", async () => {
+    const testError = new Error("test error");
+    vi.mocked(routeMultiApp).mockRejectedValueOnce(testError);
+
+    await applyCommand.run({ values: {} } as never);
+
+    expect(handleCliError).toHaveBeenCalledWith(testError);
+  });
+
+  it("seed data のメッセージが表示されること", async () => {
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          singleApp: (app: AppEntry, config: ProjectConfig) => Promise<void>;
+        },
+      ) => {
+        await handlers.singleApp(mockApp, mockProjectConfig);
+      },
+    );
+    vi.mocked(p.confirm).mockResolvedValueOnce(true);
+
+    await applyCommand.run({ values: {} } as never);
+
+    expect(p.log.info).toHaveBeenCalledWith(
+      "Note: Seed data will be upserted (no diff preview available).",
+    );
+  });
+});

--- a/src/cli/commands/apply.ts
+++ b/src/cli/commands/apply.ts
@@ -1,0 +1,160 @@
+import { dirname, resolve } from "node:path";
+import * as p from "@clack/prompts";
+import { define } from "gunshi";
+import { applyAllForApp } from "@/core/application/applyAll/applyAllForApp";
+import { createCliApplyAllContainers } from "@/core/application/container/applyAllCli";
+import { diffAllForApp } from "@/core/application/diffAll/diffAllForApp";
+import { printApplyAllResults } from "../applyAllOutput";
+import {
+  confirmArgs,
+  kintoneArgs,
+  multiAppArgs,
+  type WithConfirm,
+} from "../config";
+import { printDiffAllResults } from "../diffAllOutput";
+import { handleCliError } from "../handleError";
+import { printAppHeader } from "../output";
+import {
+  type MultiAppCliValues,
+  resolveAppCliConfig,
+  routeMultiApp,
+  runMultiAppWithFailCheck,
+} from "../projectConfig";
+
+const dryRunArgs = {
+  "dry-run": {
+    type: "boolean" as const,
+    description: "Show diff preview only without applying changes",
+  },
+};
+
+const applyArgs = {
+  domain: kintoneArgs.domain,
+  username: kintoneArgs.username,
+  password: kintoneArgs.password,
+  "api-token": kintoneArgs["api-token"],
+  "guest-space-id": kintoneArgs["guest-space-id"],
+  ...multiAppArgs,
+  ...confirmArgs,
+  ...dryRunArgs,
+};
+
+type ApplyCliValues = MultiAppCliValues & {
+  yes?: boolean;
+  "dry-run"?: boolean;
+};
+
+async function runApplyAll(
+  cliConfig: {
+    baseUrl: string;
+    auth:
+      | { type: "apiToken"; apiToken: string | string[] }
+      | { type: "password"; username: string; password: string };
+    appId: string;
+    guestSpaceId?: string;
+  },
+  appName: string,
+  options: { skipConfirm: boolean; dryRun: boolean },
+): Promise<void> {
+  const { containers, diffContainers, paths } = createCliApplyAllContainers({
+    ...cliConfig,
+    appName:
+      appName as import("@/core/domain/projectConfig/valueObject").AppName,
+  });
+
+  const customizeBasePath = dirname(resolve(paths.customize));
+
+  // Step 1: Diff preview
+  const ds = p.spinner();
+  ds.start(`Comparing all domains for ${appName}...`);
+  const diffResults = await diffAllForApp({
+    containers: diffContainers,
+    customizeBasePath,
+  });
+  const diffFailCount = diffResults.filter((r) => !r.success).length;
+  ds.stop(
+    `Comparison complete.${diffFailCount > 0 ? ` (${diffFailCount} failed)` : ""}`,
+  );
+
+  printDiffAllResults(diffResults);
+
+  // Note about seed data (not included in diff preview)
+  p.log.info("Note: Seed data will be upserted (no diff preview available).");
+
+  // Check if there are any changes
+  const hasChanges = diffResults.some((r) => r.success && !r.result.isEmpty);
+  if (!hasChanges) {
+    p.log.success("No changes detected. Seed data will still be upserted.");
+  }
+
+  // Step 2: Dry run exits here
+  if (options.dryRun) {
+    p.log.info("Dry run complete. No changes applied.");
+    return;
+  }
+
+  // Step 3: Confirm
+  if (!options.skipConfirm) {
+    const shouldContinue = await p.confirm({
+      message: "Apply these changes?",
+    });
+
+    if (p.isCancel(shouldContinue) || !shouldContinue) {
+      p.cancel("Apply cancelled.");
+      return;
+    }
+  }
+
+  // Step 4: Apply all domains
+  const as = p.spinner();
+  as.start(`Applying all domains for ${appName}...`);
+  const output = await applyAllForApp({
+    containers,
+    customizeBasePath,
+  });
+  const applyFailCount = output.phases
+    .flatMap((pr) => pr.results)
+    .filter((r) => !r.success).length;
+  as.stop(
+    `Apply complete.${applyFailCount > 0 ? ` (${applyFailCount} failed)` : ""}`,
+  );
+
+  // Step 5: Print results
+  printApplyAllResults(output);
+}
+
+export default define({
+  name: "apply",
+  description:
+    "Apply all domain configurations (schema, customize, views, etc.) to kintone app with diff preview",
+  args: applyArgs,
+  run: async (ctx) => {
+    try {
+      const values = ctx.values as ApplyCliValues;
+      const skipConfirm = (values as WithConfirm<ApplyCliValues>).yes === true;
+      const dryRun = values["dry-run"] === true;
+
+      await routeMultiApp(values, {
+        singleLegacy: async () => {
+          p.log.error(
+            "The 'apply' command requires a project config file.\nRun 'kintone-migrator init' to create one, or use individual apply commands (e.g. 'schema migrate').",
+          );
+          process.exitCode = 1;
+        },
+        singleApp: async (app, projectConfig) => {
+          const cliConfig = resolveAppCliConfig(app, projectConfig, values);
+          await runApplyAll(cliConfig, app.name, { skipConfirm, dryRun });
+        },
+        multiApp: async (plan, projectConfig) => {
+          await runMultiAppWithFailCheck(plan, async (app) => {
+            const cliConfig = resolveAppCliConfig(app, projectConfig, values);
+            printAppHeader(app.name, app.appId);
+            await runApplyAll(cliConfig, app.name, { skipConfirm, dryRun });
+          });
+        },
+      });
+    } catch (error) {
+      handleCliError(error);
+    }
+  },
+});

--- a/src/cli/commands/apply.ts
+++ b/src/cli/commands/apply.ts
@@ -122,7 +122,10 @@ async function runApplyAll(
   // Step 5: Print results
   printApplyAllResults(output);
 
-  // Set exit code if any domains failed or deploy failed
+  // Set non-zero exit code for CI/CD pipelines.
+  // Triggered when any domain failed/skipped OR deploy was not completed.
+  // When needsDeploy is false (no Phase 2-4 successes), deployed=false
+  // but hasFailures is also true, so the condition is correct.
   const hasFailures = output.phases
     .flatMap((pr) => pr.results)
     .some((r) => !r.success);

--- a/src/cli/commands/apply.ts
+++ b/src/cli/commands/apply.ts
@@ -5,12 +5,7 @@ import { applyAllForApp } from "@/core/application/applyAll/applyAllForApp";
 import { createCliApplyAllContainers } from "@/core/application/container/applyAllCli";
 import { diffAllForApp } from "@/core/application/diffAll/diffAllForApp";
 import { printApplyAllResults } from "../applyAllOutput";
-import {
-  confirmArgs,
-  kintoneArgs,
-  multiAppArgs,
-  type WithConfirm,
-} from "../config";
+import { confirmArgs, kintoneArgs, multiAppArgs } from "../config";
 import { printDiffAllResults } from "../diffAllOutput";
 import { handleCliError } from "../handleError";
 import { printAppHeader } from "../output";
@@ -89,7 +84,12 @@ async function runApplyAll(
 
   // Step 2: Dry run exits here
   if (options.dryRun) {
-    p.log.info("Dry run complete. No changes applied.");
+    p.log.info("Dry run complete. No changes will be applied.");
+    if (!hasChanges) {
+      p.log.info(
+        "Note: Seed data would still be upserted when running without --dry-run.",
+      );
+    }
     return;
   }
 
@@ -131,7 +131,7 @@ export default define({
   run: async (ctx) => {
     try {
       const values = ctx.values as ApplyCliValues;
-      const skipConfirm = (values as WithConfirm<ApplyCliValues>).yes === true;
+      const skipConfirm = values.yes === true;
       const dryRun = values["dry-run"] === true;
 
       await routeMultiApp(values, {

--- a/src/cli/commands/apply.ts
+++ b/src/cli/commands/apply.ts
@@ -121,6 +121,14 @@ async function runApplyAll(
 
   // Step 5: Print results
   printApplyAllResults(output);
+
+  // Set exit code if any domains failed or deploy failed
+  const hasFailures = output.phases
+    .flatMap((pr) => pr.results)
+    .some((r) => !r.success);
+  if (hasFailures || !output.deployed) {
+    process.exitCode = 1;
+  }
 }
 
 export default define({

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,6 +6,7 @@ import { cli, define } from "gunshi";
 import actionGroup from "./commands/action";
 import adminNotesGroup from "./commands/admin-notes";
 import appAclGroup from "./commands/app-acl";
+import applyCommand from "./commands/apply";
 import captureCommand from "./commands/capture";
 import customizeGroup from "./commands/customize";
 import diffCommand from "./commands/diff";
@@ -43,6 +44,7 @@ await cli(process.argv.slice(2), main, {
   version: loadVersion(),
   subCommands: {
     init: initCommand,
+    apply: applyCommand,
     capture: captureCommand,
     diff: diffCommand,
     schema: schemaGroup,

--- a/src/core/application/applyAll/__tests__/applyAllForApp.test.ts
+++ b/src/core/application/applyAll/__tests__/applyAllForApp.test.ts
@@ -514,8 +514,8 @@ describe("applyAllForApp", () => {
       expect(output.phases[1].results[1].skipped).toBe(false);
     }
 
-    // Phase 3+ should be skipped
-    for (const phase of output.phases.slice(2, 4)) {
+    // Phase 3+ should be skipped (including Phase 5 Seed)
+    for (const phase of output.phases.slice(2)) {
       for (const result of phase.results) {
         expect(result.success).toBe(false);
         if (!result.success) {

--- a/src/core/application/applyAll/__tests__/applyAllForApp.test.ts
+++ b/src/core/application/applyAll/__tests__/applyAllForApp.test.ts
@@ -1,0 +1,461 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ApplyAllContainers } from "@/core/application/container/applyAll";
+import {
+  SystemError,
+  SystemErrorCode,
+  UnauthenticatedError,
+  UnauthenticatedErrorCode,
+} from "@/core/application/error";
+import {
+  type ApplyAllForAppInput,
+  type ApplyDomain,
+  applyAllForApp,
+} from "../applyAllForApp";
+
+// Mock all apply/migrate functions
+vi.mock("@/core/application/formSchema/executeMigration");
+vi.mock("@/core/application/formSchema/deployApp");
+vi.mock("@/core/application/customization/applyCustomization");
+vi.mock("@/core/application/view/applyView");
+vi.mock("@/core/application/fieldPermission/applyFieldPermission");
+vi.mock("@/core/application/appPermission/applyAppPermission");
+vi.mock("@/core/application/recordPermission/applyRecordPermission");
+vi.mock("@/core/application/generalSettings/applyGeneralSettings");
+vi.mock("@/core/application/notification/applyNotification");
+vi.mock("@/core/application/report/applyReport");
+vi.mock("@/core/application/action/applyAction");
+vi.mock("@/core/application/processManagement/applyProcessManagement");
+vi.mock("@/core/application/adminNotes/applyAdminNotes");
+vi.mock("@/core/application/plugin/applyPlugin");
+vi.mock("@/core/application/seedData/upsertSeed");
+
+import { applyAction } from "@/core/application/action/applyAction";
+import { applyAdminNotes } from "@/core/application/adminNotes/applyAdminNotes";
+import { applyAppPermission } from "@/core/application/appPermission/applyAppPermission";
+import { applyCustomization } from "@/core/application/customization/applyCustomization";
+import { applyFieldPermission } from "@/core/application/fieldPermission/applyFieldPermission";
+import { deployApp } from "@/core/application/formSchema/deployApp";
+import { executeMigration } from "@/core/application/formSchema/executeMigration";
+import { applyGeneralSettings } from "@/core/application/generalSettings/applyGeneralSettings";
+import { applyNotification } from "@/core/application/notification/applyNotification";
+import { applyPlugin } from "@/core/application/plugin/applyPlugin";
+import { applyProcessManagement } from "@/core/application/processManagement/applyProcessManagement";
+import { applyRecordPermission } from "@/core/application/recordPermission/applyRecordPermission";
+import { applyReport } from "@/core/application/report/applyReport";
+import { upsertSeed } from "@/core/application/seedData/upsertSeed";
+import { applyView } from "@/core/application/view/applyView";
+
+const stubContainers = {} as ApplyAllContainers;
+
+const baseArgs: ApplyAllForAppInput = {
+  containers: stubContainers,
+  customizeBasePath: "apps/test-app",
+};
+
+function setupAllMocksToSucceed(): void {
+  vi.mocked(executeMigration).mockResolvedValue(undefined);
+  vi.mocked(deployApp).mockResolvedValue(undefined);
+  vi.mocked(applyCustomization).mockResolvedValue(undefined);
+  vi.mocked(applyView).mockResolvedValue({
+    skippedBuiltinViews: [],
+  });
+  vi.mocked(applyFieldPermission).mockResolvedValue(undefined);
+  vi.mocked(applyAppPermission).mockResolvedValue(undefined);
+  vi.mocked(applyRecordPermission).mockResolvedValue(undefined);
+  vi.mocked(applyGeneralSettings).mockResolvedValue(undefined);
+  vi.mocked(applyNotification).mockResolvedValue(undefined);
+  vi.mocked(applyReport).mockResolvedValue(undefined);
+  vi.mocked(applyAction).mockResolvedValue(undefined);
+  vi.mocked(applyProcessManagement).mockResolvedValue({
+    enableChanged: false,
+    newEnable: true,
+  });
+  vi.mocked(applyAdminNotes).mockResolvedValue(undefined);
+  vi.mocked(applyPlugin).mockResolvedValue(undefined);
+  vi.mocked(upsertSeed).mockResolvedValue({
+    added: 0,
+    updated: 0,
+    unchanged: 0,
+    deleted: 0,
+    total: 0,
+  });
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("applyAllForApp", () => {
+  it("全5フェーズ・14ドメインが成功すること", async () => {
+    setupAllMocksToSucceed();
+
+    const output = await applyAllForApp(baseArgs);
+
+    expect(output.phases).toHaveLength(5);
+    expect(output.phases[0].phase).toBe("Schema");
+    expect(output.phases[1].phase).toBe("Views & Customization");
+    expect(output.phases[2].phase).toBe("Permissions");
+    expect(output.phases[3].phase).toBe("Settings & Others");
+    expect(output.phases[4].phase).toBe("Seed Data");
+
+    const allResults = output.phases.flatMap((p) => p.results);
+    expect(allResults).toHaveLength(14);
+    for (const result of allResults) {
+      expect(result.success).toBe(true);
+    }
+
+    // Verify domain ordering within phases
+    const domains = allResults.map((r) => r.domain);
+    expect(domains).toEqual([
+      "schema",
+      "customize",
+      "view",
+      "field-acl",
+      "app-acl",
+      "record-acl",
+      "settings",
+      "notification",
+      "report",
+      "action",
+      "process",
+      "admin-notes",
+      "plugin",
+      "seed",
+    ]);
+  });
+
+  it("全成功時に deployed が true であること", async () => {
+    setupAllMocksToSucceed();
+
+    const output = await applyAllForApp(baseArgs);
+
+    expect(output.deployed).toBe(true);
+  });
+
+  it("Phase 1 (Schema) で deploy が schema apply 直後に呼ばれること", async () => {
+    setupAllMocksToSucceed();
+    const callOrder: string[] = [];
+
+    vi.mocked(executeMigration).mockImplementation(async () => {
+      callOrder.push("executeMigration");
+    });
+    vi.mocked(deployApp).mockImplementation(async () => {
+      callOrder.push("deployApp");
+    });
+    vi.mocked(applyCustomization).mockImplementation(async () => {
+      callOrder.push("applyCustomization");
+    });
+
+    await applyAllForApp(baseArgs);
+
+    expect(callOrder[0]).toBe("executeMigration");
+    expect(callOrder[1]).toBe("deployApp");
+    // customization comes after schema deploy
+    expect(callOrder[2]).toBe("applyCustomization");
+  });
+
+  it("Phase 1 失敗で後続の全フェーズが中止されること", async () => {
+    setupAllMocksToSucceed();
+    vi.mocked(executeMigration).mockRejectedValue(
+      new SystemError(
+        SystemErrorCode.ExternalApiError,
+        "Schema migration failed",
+      ),
+    );
+
+    const output = await applyAllForApp(baseArgs);
+
+    // Phase 1 fails
+    expect(output.phases[0].results[0].success).toBe(false);
+
+    // All subsequent phases should be skipped
+    for (const phase of output.phases.slice(1)) {
+      for (const result of phase.results) {
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(result.error.message).toContain("Skipped due to fatal error");
+        }
+      }
+    }
+
+    // No deploy after Phase 2-4 since all were skipped
+    expect(output.deployed).toBe(false);
+  });
+
+  it("Phase 1 deploy 失敗でも後続フェーズが中止されること", async () => {
+    setupAllMocksToSucceed();
+    // executeMigration succeeds but deploy fails
+    vi.mocked(deployApp).mockRejectedValueOnce(
+      new SystemError(SystemErrorCode.ExternalApiError, "Deploy failed"),
+    );
+
+    const output = await applyAllForApp(baseArgs);
+
+    // Phase 1 schema should fail
+    expect(output.phases[0].results[0].success).toBe(false);
+
+    // All subsequent phases should be skipped
+    for (const phase of output.phases.slice(1)) {
+      for (const result of phase.results) {
+        expect(result.success).toBe(false);
+      }
+    }
+  });
+
+  it("Phase 2-4 で非致命的エラーが発生しても他のドメインは継続すること", async () => {
+    setupAllMocksToSucceed();
+    vi.mocked(applyCustomization).mockRejectedValue(
+      new SystemError(
+        SystemErrorCode.ExternalApiError,
+        "Customization API error",
+      ),
+    );
+
+    const output = await applyAllForApp(baseArgs);
+
+    // Phase 1 succeeds
+    expect(output.phases[0].results[0].success).toBe(true);
+
+    // Phase 2: customize fails, view succeeds
+    const phase2 = output.phases[1];
+    expect(phase2.results[0].domain).toBe("customize");
+    expect(phase2.results[0].success).toBe(false);
+    expect(phase2.results[1].domain).toBe("view");
+    expect(phase2.results[1].success).toBe(true);
+
+    // Phase 3-5 continue normally
+    for (const phase of output.phases.slice(2)) {
+      for (const result of phase.results) {
+        expect(result.success).toBe(true);
+      }
+    }
+
+    // Deploy still happens for successful domains
+    expect(output.deployed).toBe(true);
+  });
+
+  it("Phase 2-4 で致命的エラー (UnauthenticatedError) が発生すると後続タスク・フェーズが中止されること", async () => {
+    setupAllMocksToSucceed();
+    vi.mocked(applyFieldPermission).mockRejectedValue(
+      new UnauthenticatedError(
+        UnauthenticatedErrorCode.InvalidCredentials,
+        "Invalid credentials",
+      ),
+    );
+
+    const output = await applyAllForApp(baseArgs);
+
+    // Phase 1 succeeds
+    expect(output.phases[0].results[0].success).toBe(true);
+
+    // Phase 2 succeeds
+    expect(output.phases[1].results.every((r) => r.success)).toBe(true);
+
+    // Phase 3: field-acl fails fatally, app-acl and record-acl are skipped
+    const phase3 = output.phases[2];
+    expect(phase3.results[0].domain).toBe("field-acl");
+    expect(phase3.results[0].success).toBe(false);
+    expect(phase3.results[1].domain).toBe("app-acl");
+    expect(phase3.results[1].success).toBe(false);
+    if (!phase3.results[1].success) {
+      expect(phase3.results[1].error.message).toContain("Skipped");
+    }
+
+    // Phase 4 and 5 are all skipped
+    for (const phase of output.phases.slice(3)) {
+      for (const result of phase.results) {
+        expect(result.success).toBe(false);
+      }
+    }
+  });
+
+  it("Phase 2-4 が全てスキップされた場合は deploy されないこと", async () => {
+    setupAllMocksToSucceed();
+    // Phase 1 succeeds but Phase 2 first task hits fatal error
+    vi.mocked(applyCustomization).mockRejectedValue(
+      new UnauthenticatedError(
+        UnauthenticatedErrorCode.InvalidCredentials,
+        "Invalid credentials",
+      ),
+    );
+
+    const output = await applyAllForApp(baseArgs);
+
+    // customize failed fatally -> view is skipped
+    // All Phase 3, 4, 5 are skipped
+    // Phase 2 has customize (failed) and view (skipped) — no successes in Phase 2-4
+    const phase2And3And4Successes = output.phases
+      .slice(1, 4)
+      .flatMap((p) => p.results)
+      .filter((r) => r.success);
+    expect(phase2And3And4Successes).toHaveLength(0);
+
+    expect(output.deployed).toBe(false);
+  });
+
+  it("Phase 2-4 完了後に一括 deploy が実行されること", async () => {
+    setupAllMocksToSucceed();
+    const deployCallCount = { count: 0 };
+    vi.mocked(deployApp).mockImplementation(async () => {
+      deployCallCount.count++;
+    });
+
+    await applyAllForApp(baseArgs);
+
+    // deployApp should be called twice:
+    // 1. After schema migration (Phase 1)
+    // 2. After Phase 2-4 complete (batch deploy)
+    expect(deployCallCount.count).toBe(2);
+  });
+
+  it("Phase 2-4 一括 deploy が失敗した場合に deployed が false になること", async () => {
+    setupAllMocksToSucceed();
+    let deployCount = 0;
+    vi.mocked(deployApp).mockImplementation(async () => {
+      deployCount++;
+      // First call (Phase 1 schema deploy) succeeds
+      // Second call (Phase 2-4 batch deploy) fails
+      if (deployCount === 2) {
+        throw new SystemError(
+          SystemErrorCode.ExternalApiError,
+          "Deploy failed",
+        );
+      }
+    });
+
+    const output = await applyAllForApp(baseArgs);
+
+    // Phase results should still show success for each domain
+    const allResults = output.phases.flatMap((p) => p.results);
+    for (const result of allResults) {
+      expect(result.success).toBe(true);
+    }
+
+    // But deployed should be false
+    expect(output.deployed).toBe(false);
+  });
+
+  it("フェーズ内のタスクが直列実行されること（実行順序の検証）", async () => {
+    setupAllMocksToSucceed();
+    const callOrder: ApplyDomain[] = [];
+
+    vi.mocked(executeMigration).mockImplementation(async () => {
+      callOrder.push("schema");
+    });
+    vi.mocked(applyCustomization).mockImplementation(async () => {
+      callOrder.push("customize");
+    });
+    vi.mocked(applyView).mockImplementation(async () => {
+      callOrder.push("view");
+      return { skippedBuiltinViews: [] };
+    });
+    vi.mocked(applyFieldPermission).mockImplementation(async () => {
+      callOrder.push("field-acl");
+    });
+    vi.mocked(applyAppPermission).mockImplementation(async () => {
+      callOrder.push("app-acl");
+    });
+    vi.mocked(applyRecordPermission).mockImplementation(async () => {
+      callOrder.push("record-acl");
+    });
+    vi.mocked(applyGeneralSettings).mockImplementation(async () => {
+      callOrder.push("settings");
+    });
+    vi.mocked(applyNotification).mockImplementation(async () => {
+      callOrder.push("notification");
+    });
+    vi.mocked(applyReport).mockImplementation(async () => {
+      callOrder.push("report");
+    });
+    vi.mocked(applyAction).mockImplementation(async () => {
+      callOrder.push("action");
+    });
+    vi.mocked(applyProcessManagement).mockImplementation(async () => {
+      callOrder.push("process");
+      return { enableChanged: false, newEnable: true };
+    });
+    vi.mocked(applyAdminNotes).mockImplementation(async () => {
+      callOrder.push("admin-notes");
+    });
+    vi.mocked(applyPlugin).mockImplementation(async () => {
+      callOrder.push("plugin");
+    });
+    vi.mocked(upsertSeed).mockImplementation(async () => {
+      callOrder.push("seed");
+      return { added: 0, updated: 0, unchanged: 0, deleted: 0, total: 0 };
+    });
+
+    await applyAllForApp(baseArgs);
+
+    expect(callOrder).toEqual([
+      "schema",
+      "customize",
+      "view",
+      "field-acl",
+      "app-acl",
+      "record-acl",
+      "settings",
+      "notification",
+      "report",
+      "action",
+      "process",
+      "admin-notes",
+      "plugin",
+      "seed",
+    ]);
+  });
+
+  it("seed (Phase 5) が deploy を必要としないこと", async () => {
+    setupAllMocksToSucceed();
+    // Make all Phase 2-4 domains fail with non-fatal errors
+    vi.mocked(applyCustomization).mockRejectedValue(
+      new SystemError(SystemErrorCode.ExternalApiError, "fail"),
+    );
+    vi.mocked(applyView).mockRejectedValue(
+      new SystemError(SystemErrorCode.ExternalApiError, "fail"),
+    );
+    vi.mocked(applyFieldPermission).mockRejectedValue(
+      new SystemError(SystemErrorCode.ExternalApiError, "fail"),
+    );
+    vi.mocked(applyAppPermission).mockRejectedValue(
+      new SystemError(SystemErrorCode.ExternalApiError, "fail"),
+    );
+    vi.mocked(applyRecordPermission).mockRejectedValue(
+      new SystemError(SystemErrorCode.ExternalApiError, "fail"),
+    );
+    vi.mocked(applyGeneralSettings).mockRejectedValue(
+      new SystemError(SystemErrorCode.ExternalApiError, "fail"),
+    );
+    vi.mocked(applyNotification).mockRejectedValue(
+      new SystemError(SystemErrorCode.ExternalApiError, "fail"),
+    );
+    vi.mocked(applyReport).mockRejectedValue(
+      new SystemError(SystemErrorCode.ExternalApiError, "fail"),
+    );
+    vi.mocked(applyAction).mockRejectedValue(
+      new SystemError(SystemErrorCode.ExternalApiError, "fail"),
+    );
+    vi.mocked(applyProcessManagement).mockRejectedValue(
+      new SystemError(SystemErrorCode.ExternalApiError, "fail"),
+    );
+    vi.mocked(applyAdminNotes).mockRejectedValue(
+      new SystemError(SystemErrorCode.ExternalApiError, "fail"),
+    );
+    vi.mocked(applyPlugin).mockRejectedValue(
+      new SystemError(SystemErrorCode.ExternalApiError, "fail"),
+    );
+
+    const output = await applyAllForApp(baseArgs);
+
+    // Seed still succeeds
+    const seedResult = output.phases[4].results[0];
+    expect(seedResult.domain).toBe("seed");
+    expect(seedResult.success).toBe(true);
+
+    // No deploy since Phase 2-4 have no successes
+    expect(output.deployed).toBe(false);
+
+    // deployApp should only be called once (Phase 1 schema)
+    expect(vi.mocked(deployApp)).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/core/application/applyAll/__tests__/applyAllForApp.test.ts
+++ b/src/core/application/applyAll/__tests__/applyAllForApp.test.ts
@@ -165,8 +165,11 @@ describe("applyAllForApp", () => {
 
     const output = await applyAllForApp(baseArgs);
 
-    // Phase 1 fails
+    // Phase 1 fails (not skipped — it actually ran and failed)
     expect(output.phases[0].results[0].success).toBe(false);
+    if (!output.phases[0].results[0].success) {
+      expect(output.phases[0].results[0].skipped).toBe(false);
+    }
 
     // All subsequent phases should be skipped
     for (const phase of output.phases.slice(1)) {
@@ -174,6 +177,7 @@ describe("applyAllForApp", () => {
         expect(result.success).toBe(false);
         if (!result.success) {
           expect(result.error.message).toContain("Skipped due to fatal error");
+          expect(result.skipped).toBe(true);
         }
       }
     }
@@ -191,13 +195,19 @@ describe("applyAllForApp", () => {
 
     const output = await applyAllForApp(baseArgs);
 
-    // Phase 1 schema should fail
+    // Phase 1 schema should fail (not skipped)
     expect(output.phases[0].results[0].success).toBe(false);
+    if (!output.phases[0].results[0].success) {
+      expect(output.phases[0].results[0].skipped).toBe(false);
+    }
 
     // All subsequent phases should be skipped
     for (const phase of output.phases.slice(1)) {
       for (const result of phase.results) {
         expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(result.skipped).toBe(true);
+        }
       }
     }
   });
@@ -216,10 +226,13 @@ describe("applyAllForApp", () => {
     // Phase 1 succeeds
     expect(output.phases[0].results[0].success).toBe(true);
 
-    // Phase 2: customize fails, view succeeds
+    // Phase 2: customize fails (not skipped), view succeeds
     const phase2 = output.phases[1];
     expect(phase2.results[0].domain).toBe("customize");
     expect(phase2.results[0].success).toBe(false);
+    if (!phase2.results[0].success) {
+      expect(phase2.results[0].skipped).toBe(false);
+    }
     expect(phase2.results[1].domain).toBe("view");
     expect(phase2.results[1].success).toBe(true);
 
@@ -251,20 +264,27 @@ describe("applyAllForApp", () => {
     // Phase 2 succeeds
     expect(output.phases[1].results.every((r) => r.success)).toBe(true);
 
-    // Phase 3: field-acl fails fatally, app-acl and record-acl are skipped
+    // Phase 3: field-acl fails fatally (not skipped), app-acl and record-acl are skipped
     const phase3 = output.phases[2];
     expect(phase3.results[0].domain).toBe("field-acl");
     expect(phase3.results[0].success).toBe(false);
+    if (!phase3.results[0].success) {
+      expect(phase3.results[0].skipped).toBe(false);
+    }
     expect(phase3.results[1].domain).toBe("app-acl");
     expect(phase3.results[1].success).toBe(false);
     if (!phase3.results[1].success) {
       expect(phase3.results[1].error.message).toContain("Skipped");
+      expect(phase3.results[1].skipped).toBe(true);
     }
 
     // Phase 4 and 5 are all skipped
     for (const phase of output.phases.slice(3)) {
       for (const result of phase.results) {
         expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(result.skipped).toBe(true);
+        }
       }
     }
   });
@@ -281,7 +301,15 @@ describe("applyAllForApp", () => {
 
     const output = await applyAllForApp(baseArgs);
 
-    // customize failed fatally -> view is skipped
+    // customize failed fatally (not skipped) -> view is skipped
+    const phase2 = output.phases[1];
+    if (!phase2.results[0].success) {
+      expect(phase2.results[0].skipped).toBe(false);
+    }
+    if (!phase2.results[1].success) {
+      expect(phase2.results[1].skipped).toBe(true);
+    }
+
     // All Phase 3, 4, 5 are skipped
     // Phase 2 has customize (failed) and view (skipped) — no successes in Phase 2-4
     const phase2And3And4Successes = output.phases
@@ -308,7 +336,7 @@ describe("applyAllForApp", () => {
     expect(deployCallCount.count).toBe(2);
   });
 
-  it("Phase 2-4 一括 deploy が失敗した場合に deployed が false になること", async () => {
+  it("Phase 2-4 一括 deploy が失敗した場合に deployed が false で deployError が設定されること", async () => {
     setupAllMocksToSucceed();
     let deployCount = 0;
     vi.mocked(deployApp).mockImplementation(async () => {
@@ -331,8 +359,10 @@ describe("applyAllForApp", () => {
       expect(result.success).toBe(true);
     }
 
-    // But deployed should be false
+    // But deployed should be false with error
     expect(output.deployed).toBe(false);
+    expect(output.deployError).toBeInstanceOf(SystemError);
+    expect(output.deployError?.message).toBe("Deploy failed");
   });
 
   it("フェーズ内のタスクが直列実行されること（実行順序の検証）", async () => {
@@ -447,6 +477,16 @@ describe("applyAllForApp", () => {
 
     const output = await applyAllForApp(baseArgs);
 
+    // All Phase 2-4 failures should have skipped: false (they actually ran)
+    for (const phase of output.phases.slice(1, 4)) {
+      for (const result of phase.results) {
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(result.skipped).toBe(false);
+        }
+      }
+    }
+
     // Seed still succeeds
     const seedResult = output.phases[4].results[0];
     expect(seedResult.domain).toBe("seed");
@@ -457,5 +497,31 @@ describe("applyAllForApp", () => {
 
     // deployApp should only be called once (Phase 1 schema)
     expect(vi.mocked(deployApp)).toHaveBeenCalledTimes(1);
+  });
+
+  it("Phase 2-4 で致命的エラー (NetworkError) が発生すると後続タスク・フェーズが中止されること", async () => {
+    setupAllMocksToSucceed();
+    vi.mocked(applyView).mockRejectedValue(
+      new SystemError(SystemErrorCode.NetworkError, "Network timeout"),
+    );
+
+    const output = await applyAllForApp(baseArgs);
+
+    // Phase 2: customize succeeds, view fails fatally
+    expect(output.phases[1].results[0].success).toBe(true);
+    expect(output.phases[1].results[1].success).toBe(false);
+    if (!output.phases[1].results[1].success) {
+      expect(output.phases[1].results[1].skipped).toBe(false);
+    }
+
+    // Phase 3+ should be skipped
+    for (const phase of output.phases.slice(2, 4)) {
+      for (const result of phase.results) {
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(result.skipped).toBe(true);
+        }
+      }
+    }
   });
 });

--- a/src/core/application/applyAll/applyAllForApp.ts
+++ b/src/core/application/applyAll/applyAllForApp.ts
@@ -246,6 +246,8 @@ async function executeSchemaPhase(
       await deployApp({ container: containers.schema });
       results.push({ domain: task.domain, success: true });
     } catch (error) {
+      // Schema phase failure is always fatal regardless of isFatalError check.
+      // Without a deployed schema, subsequent phases cannot function correctly.
       const err = toError(error);
       results.push({
         domain: task.domain,

--- a/src/core/application/applyAll/applyAllForApp.ts
+++ b/src/core/application/applyAll/applyAllForApp.ts
@@ -1,0 +1,338 @@
+import { applyAction } from "@/core/application/action/applyAction";
+import { applyAdminNotes } from "@/core/application/adminNotes/applyAdminNotes";
+import { applyAppPermission } from "@/core/application/appPermission/applyAppPermission";
+import type { ApplyAllContainers } from "@/core/application/container/applyAll";
+import { applyCustomization } from "@/core/application/customization/applyCustomization";
+import {
+  isFatalError,
+  SystemError,
+  SystemErrorCode,
+} from "@/core/application/error";
+import { applyFieldPermission } from "@/core/application/fieldPermission/applyFieldPermission";
+import { deployApp } from "@/core/application/formSchema/deployApp";
+import { executeMigration } from "@/core/application/formSchema/executeMigration";
+import { applyGeneralSettings } from "@/core/application/generalSettings/applyGeneralSettings";
+import { applyNotification } from "@/core/application/notification/applyNotification";
+import { applyPlugin } from "@/core/application/plugin/applyPlugin";
+import { applyProcessManagement } from "@/core/application/processManagement/applyProcessManagement";
+import { applyRecordPermission } from "@/core/application/recordPermission/applyRecordPermission";
+import { applyReport } from "@/core/application/report/applyReport";
+import { upsertSeed } from "@/core/application/seedData/upsertSeed";
+import { applyView } from "@/core/application/view/applyView";
+
+export type ApplyDomain =
+  | "schema"
+  | "customize"
+  | "view"
+  | "field-acl"
+  | "app-acl"
+  | "record-acl"
+  | "settings"
+  | "notification"
+  | "report"
+  | "action"
+  | "process"
+  | "admin-notes"
+  | "plugin"
+  | "seed";
+
+export type ApplyPhaseName =
+  | "Schema"
+  | "Views & Customization"
+  | "Permissions"
+  | "Settings & Others"
+  | "Seed Data";
+
+export type ApplyTaskResult =
+  | Readonly<{ domain: ApplyDomain; success: true }>
+  | Readonly<{ domain: ApplyDomain; success: false; error: Error }>;
+
+export type ApplyPhaseResult = Readonly<{
+  phase: ApplyPhaseName;
+  results: readonly ApplyTaskResult[];
+}>;
+
+export type ApplyAllForAppOutput = Readonly<{
+  phases: readonly ApplyPhaseResult[];
+  deployed: boolean;
+}>;
+
+export type ApplyAllForAppInput = Readonly<{
+  containers: ApplyAllContainers;
+  customizeBasePath: string;
+}>;
+
+type ApplyTask = {
+  readonly domain: ApplyDomain;
+  readonly run: () => Promise<void>;
+};
+
+type PhaseDefinition = {
+  readonly name: ApplyPhaseName;
+  readonly tasks: readonly ApplyTask[];
+};
+
+function buildPhases(args: ApplyAllForAppInput): readonly PhaseDefinition[] {
+  const c = args.containers;
+
+  return [
+    {
+      name: "Schema",
+      tasks: [
+        {
+          domain: "schema",
+          run: async () => {
+            await executeMigration({ container: c.schema });
+          },
+        },
+      ],
+    },
+    {
+      name: "Views & Customization",
+      tasks: [
+        {
+          domain: "customize",
+          run: async () => {
+            await applyCustomization({
+              container: c.customization,
+              input: { basePath: args.customizeBasePath },
+            });
+          },
+        },
+        {
+          domain: "view",
+          run: async () => {
+            await applyView({ container: c.view });
+          },
+        },
+      ],
+    },
+    {
+      name: "Permissions",
+      tasks: [
+        {
+          domain: "field-acl",
+          run: async () => {
+            await applyFieldPermission({ container: c.fieldPermission });
+          },
+        },
+        {
+          domain: "app-acl",
+          run: async () => {
+            await applyAppPermission({ container: c.appPermission });
+          },
+        },
+        {
+          domain: "record-acl",
+          run: async () => {
+            await applyRecordPermission({ container: c.recordPermission });
+          },
+        },
+      ],
+    },
+    {
+      name: "Settings & Others",
+      tasks: [
+        {
+          domain: "settings",
+          run: async () => {
+            await applyGeneralSettings({ container: c.settings });
+          },
+        },
+        {
+          domain: "notification",
+          run: async () => {
+            await applyNotification({ container: c.notification });
+          },
+        },
+        {
+          domain: "report",
+          run: async () => {
+            await applyReport({ container: c.report });
+          },
+        },
+        {
+          domain: "action",
+          run: async () => {
+            await applyAction({ container: c.action });
+          },
+        },
+        {
+          domain: "process",
+          run: async () => {
+            await applyProcessManagement({ container: c.process });
+          },
+        },
+        {
+          domain: "admin-notes",
+          run: async () => {
+            await applyAdminNotes({ container: c.adminNotes });
+          },
+        },
+        {
+          domain: "plugin",
+          run: async () => {
+            await applyPlugin({ container: c.plugin });
+          },
+        },
+      ],
+    },
+    {
+      name: "Seed Data",
+      tasks: [
+        {
+          domain: "seed",
+          run: async () => {
+            await upsertSeed({ container: c.seed, input: {} });
+          },
+        },
+      ],
+    },
+  ];
+}
+
+type AbortState = {
+  aborted: boolean;
+  reason: unknown;
+  phaseName: ApplyPhaseName | undefined;
+};
+
+function createSkipError(state: AbortState): SystemError {
+  return new SystemError(
+    SystemErrorCode.InternalServerError,
+    `Skipped due to fatal error in phase "${state.phaseName}"`,
+    state.reason,
+  );
+}
+
+function buildSkippedPhaseResult(
+  phase: PhaseDefinition,
+  state: AbortState,
+): ApplyPhaseResult {
+  const skipError = createSkipError(state);
+  return {
+    phase: phase.name,
+    results: phase.tasks.map((task) => ({
+      domain: task.domain,
+      success: false as const,
+      error: skipError,
+    })),
+  };
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+async function executeSchemaPhase(
+  phase: PhaseDefinition,
+  containers: ApplyAllContainers,
+  state: AbortState,
+): Promise<ApplyPhaseResult> {
+  const results: ApplyTaskResult[] = [];
+  for (const task of phase.tasks) {
+    try {
+      await task.run();
+      await deployApp({ container: containers.schema });
+      results.push({ domain: task.domain, success: true });
+    } catch (error) {
+      const err = toError(error);
+      results.push({ domain: task.domain, success: false, error: err });
+      state.aborted = true;
+      state.reason = err;
+      state.phaseName = phase.name;
+    }
+  }
+  return { phase: phase.name, results };
+}
+
+async function executeStandardPhase(
+  phase: PhaseDefinition,
+  state: AbortState,
+): Promise<ApplyPhaseResult> {
+  const results: ApplyTaskResult[] = [];
+  for (const task of phase.tasks) {
+    if (state.aborted) {
+      results.push({
+        domain: task.domain,
+        success: false,
+        error: createSkipError(state),
+      });
+      continue;
+    }
+
+    try {
+      await task.run();
+      results.push({ domain: task.domain, success: true });
+    } catch (error) {
+      const err = toError(error);
+      results.push({ domain: task.domain, success: false, error: err });
+      if (isFatalError(err)) {
+        state.aborted = true;
+        state.reason = err;
+        state.phaseName = phase.name;
+      }
+    }
+  }
+  return { phase: phase.name, results };
+}
+
+async function tryDeploy(containers: ApplyAllContainers): Promise<boolean> {
+  try {
+    await deployApp({ container: containers.schema });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Apply all domains for a single app in phased order.
+ *
+ * Phase 1 (Schema): executeMigration + deployApp. Failure is always fatal.
+ * Phase 2-4: apply only (no deploy until all complete).
+ * Phase 5 (Seed): upsertSeed (no deploy needed).
+ *
+ * After Phase 2-4 complete, a single deployApp is executed.
+ * Fatal errors (auth/network) or Phase 1 failure abort all remaining phases.
+ * Non-fatal errors in Phase 2-4 are recorded but do not block other domains.
+ */
+export async function applyAllForApp(
+  args: ApplyAllForAppInput,
+): Promise<ApplyAllForAppOutput> {
+  const phases = buildPhases(args);
+  const phaseResults: ApplyPhaseResult[] = [];
+  const state: AbortState = {
+    aborted: false,
+    reason: undefined,
+    phaseName: undefined,
+  };
+
+  for (const phase of phases) {
+    if (state.aborted) {
+      phaseResults.push(buildSkippedPhaseResult(phase, state));
+      continue;
+    }
+
+    if (phase.name === "Schema") {
+      phaseResults.push(
+        await executeSchemaPhase(phase, args.containers, state),
+      );
+    } else {
+      phaseResults.push(await executeStandardPhase(phase, state));
+    }
+  }
+
+  // Deploy after Phase 2-4 complete (Phase 5 = Seed Data, no deploy needed)
+  // Deploy even if some domains failed — successful changes should be deployed
+  const needsDeploy = phaseResults.some(
+    (pr) =>
+      pr.phase !== "Schema" &&
+      pr.phase !== "Seed Data" &&
+      pr.results.some((r) => r.success),
+  );
+
+  const deployed = needsDeploy ? await tryDeploy(args.containers) : false;
+
+  return { phases: phaseResults, deployed };
+}

--- a/src/core/application/applyAll/applyAllForApp.ts
+++ b/src/core/application/applyAll/applyAllForApp.ts
@@ -45,7 +45,12 @@ export type ApplyPhaseName =
 
 export type ApplyTaskResult =
   | Readonly<{ domain: ApplyDomain; success: true }>
-  | Readonly<{ domain: ApplyDomain; success: false; error: Error }>;
+  | Readonly<{
+      domain: ApplyDomain;
+      success: false;
+      error: Error;
+      skipped: boolean;
+    }>;
 
 export type ApplyPhaseResult = Readonly<{
   phase: ApplyPhaseName;
@@ -55,6 +60,7 @@ export type ApplyPhaseResult = Readonly<{
 export type ApplyAllForAppOutput = Readonly<{
   phases: readonly ApplyPhaseResult[];
   deployed: boolean;
+  deployError?: Error;
 }>;
 
 export type ApplyAllForAppInput = Readonly<{
@@ -216,6 +222,7 @@ function buildSkippedPhaseResult(
       domain: task.domain,
       success: false as const,
       error: skipError,
+      skipped: true,
     })),
   };
 }
@@ -224,6 +231,9 @@ function toError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
 }
 
+// Schema phase always has exactly one task (executeMigration).
+// Deploy is called after the task to ensure schema changes are deployed
+// before subsequent phases depend on them.
 async function executeSchemaPhase(
   phase: PhaseDefinition,
   containers: ApplyAllContainers,
@@ -237,7 +247,12 @@ async function executeSchemaPhase(
       results.push({ domain: task.domain, success: true });
     } catch (error) {
       const err = toError(error);
-      results.push({ domain: task.domain, success: false, error: err });
+      results.push({
+        domain: task.domain,
+        success: false,
+        error: err,
+        skipped: false,
+      });
       state.aborted = true;
       state.reason = err;
       state.phaseName = phase.name;
@@ -257,6 +272,7 @@ async function executeStandardPhase(
         domain: task.domain,
         success: false,
         error: createSkipError(state),
+        skipped: true,
       });
       continue;
     }
@@ -266,7 +282,12 @@ async function executeStandardPhase(
       results.push({ domain: task.domain, success: true });
     } catch (error) {
       const err = toError(error);
-      results.push({ domain: task.domain, success: false, error: err });
+      results.push({
+        domain: task.domain,
+        success: false,
+        error: err,
+        skipped: false,
+      });
       if (isFatalError(err)) {
         state.aborted = true;
         state.reason = err;
@@ -277,12 +298,14 @@ async function executeStandardPhase(
   return { phase: phase.name, results };
 }
 
-async function tryDeploy(containers: ApplyAllContainers): Promise<boolean> {
+async function tryDeploy(
+  containers: ApplyAllContainers,
+): Promise<{ deployed: boolean; error?: Error }> {
   try {
     await deployApp({ container: containers.schema });
-    return true;
-  } catch {
-    return false;
+    return { deployed: true };
+  } catch (error) {
+    return { deployed: false, error: toError(error) };
   }
 }
 
@@ -332,7 +355,13 @@ export async function applyAllForApp(
       pr.results.some((r) => r.success),
   );
 
-  const deployed = needsDeploy ? await tryDeploy(args.containers) : false;
+  const deployResult = needsDeploy
+    ? await tryDeploy(args.containers)
+    : { deployed: false };
 
-  return { phases: phaseResults, deployed };
+  return {
+    phases: phaseResults,
+    deployed: deployResult.deployed,
+    deployError: deployResult.error,
+  };
 }

--- a/src/core/application/container/applyAll.ts
+++ b/src/core/application/container/applyAll.ts
@@ -1,0 +1,37 @@
+import type { ActionContainer } from "./action";
+import type { AdminNotesContainer } from "./adminNotes";
+import type { AppPermissionContainer } from "./appPermission";
+import type { CustomizationContainer } from "./customization";
+import type { FieldPermissionContainer } from "./fieldPermission";
+import type { FormSchemaContainer } from "./formSchema";
+import type { GeneralSettingsContainer } from "./generalSettings";
+import type { NotificationContainer } from "./notification";
+import type { PluginContainer } from "./plugin";
+import type { ProcessManagementContainer } from "./processManagement";
+import type { RecordPermissionContainer } from "./recordPermission";
+import type { ReportContainer } from "./report";
+import type { SeedContainer } from "./seed";
+import type { ViewContainer } from "./view";
+
+/**
+ * Aggregates full containers for all 14 domains used by the top-level apply command.
+ *
+ * Each member uses the full container type (e.g. `CustomizationContainer` = apply & capture & diff)
+ * so the same containers can be used for both diff preview (`diffAllForApp`) and apply (`applyAllForApp`).
+ */
+export type ApplyAllContainers = {
+  readonly schema: FormSchemaContainer;
+  readonly seed: SeedContainer;
+  readonly customization: CustomizationContainer;
+  readonly view: ViewContainer;
+  readonly settings: GeneralSettingsContainer;
+  readonly notification: NotificationContainer;
+  readonly report: ReportContainer;
+  readonly action: ActionContainer;
+  readonly process: ProcessManagementContainer;
+  readonly fieldPermission: FieldPermissionContainer;
+  readonly appPermission: AppPermissionContainer;
+  readonly recordPermission: RecordPermissionContainer;
+  readonly adminNotes: AdminNotesContainer;
+  readonly plugin: PluginContainer;
+};

--- a/src/core/application/container/applyAllCli.ts
+++ b/src/core/application/container/applyAllCli.ts
@@ -1,0 +1,139 @@
+import {
+  type AppFilePaths,
+  buildAppFilePaths,
+} from "@/core/domain/projectConfig/appFilePaths";
+import type { AppName } from "@/core/domain/projectConfig/valueObject";
+import { createActionCliContainer } from "./actionCli";
+import { createAdminNotesCliContainer } from "./adminNotesCli";
+import type { ApplyAllContainers } from "./applyAll";
+import { createAppPermissionCliContainer } from "./appPermissionCli";
+import {
+  createCliContainer,
+  createCustomizationCliContainer,
+  createSeedCliContainer,
+  type KintoneAuth,
+} from "./cli";
+import type { DiffAllContainers } from "./diffAll";
+import { createFieldPermissionCliContainer } from "./fieldPermissionCli";
+import { createGeneralSettingsCliContainer } from "./generalSettingsCli";
+import { createKintoneClient } from "./kintoneClient";
+import { createNotificationCliContainer } from "./notificationCli";
+import { createPluginCliContainer } from "./pluginCli";
+import { createProcessManagementCliContainer } from "./processManagementCli";
+import { createRecordPermissionCliContainer } from "./recordPermissionCli";
+import { createReportCliContainer } from "./reportCli";
+import { createViewCliContainer } from "./viewCli";
+
+export type CreateApplyAllContainersInput = Readonly<{
+  baseUrl: string;
+  auth: KintoneAuth;
+  appId: string;
+  guestSpaceId?: string;
+  appName: AppName;
+  baseDir?: string;
+}>;
+
+export type CreateApplyAllContainersResult = Readonly<{
+  containers: ApplyAllContainers;
+  diffContainers: DiffAllContainers;
+  paths: AppFilePaths;
+}>;
+
+export function createCliApplyAllContainers(
+  input: CreateApplyAllContainersInput,
+): CreateApplyAllContainersResult {
+  const client = createKintoneClient(input);
+  const base = {
+    baseUrl: input.baseUrl,
+    auth: input.auth,
+    appId: input.appId,
+    guestSpaceId: input.guestSpaceId,
+    client,
+  };
+  const paths = buildAppFilePaths(input.appName, input.baseDir);
+
+  const schema = createCliContainer({ ...base, schemaFilePath: paths.schema });
+  const seed = createSeedCliContainer({ ...base, seedFilePath: paths.seed });
+  const customization = createCustomizationCliContainer({
+    ...base,
+    customizeFilePath: paths.customize,
+  });
+  const view = createViewCliContainer({ ...base, viewFilePath: paths.view });
+  const settings = createGeneralSettingsCliContainer({
+    ...base,
+    settingsFilePath: paths.settings,
+  });
+  const notification = createNotificationCliContainer({
+    ...base,
+    notificationFilePath: paths.notification,
+  });
+  const report = createReportCliContainer({
+    ...base,
+    reportFilePath: paths.report,
+  });
+  const action = createActionCliContainer({
+    ...base,
+    actionFilePath: paths.action,
+  });
+  const process = createProcessManagementCliContainer({
+    ...base,
+    processFilePath: paths.process,
+  });
+  const fieldPermission = createFieldPermissionCliContainer({
+    ...base,
+    fieldAclFilePath: paths.fieldAcl,
+  });
+  const appPermission = createAppPermissionCliContainer({
+    ...base,
+    appAclFilePath: paths.appAcl,
+  });
+  const recordPermission = createRecordPermissionCliContainer({
+    ...base,
+    recordAclFilePath: paths.recordAcl,
+  });
+  const adminNotes = createAdminNotesCliContainer({
+    ...base,
+    adminNotesFilePath: paths.adminNotes,
+  });
+  const plugin = createPluginCliContainer({
+    ...base,
+    pluginFilePath: paths.plugin,
+  });
+
+  const containers: ApplyAllContainers = {
+    schema,
+    seed,
+    customization,
+    view,
+    settings,
+    notification,
+    report,
+    action,
+    process,
+    fieldPermission,
+    appPermission,
+    recordPermission,
+    adminNotes,
+    plugin,
+  };
+
+  // DiffAllContainers uses the subset (diff-only) types, which are satisfied
+  // by the full container types above.
+  const diffContainers: DiffAllContainers = {
+    schema,
+    customization,
+    view,
+    settings,
+    notification,
+    report,
+    action,
+    process,
+    fieldPermission,
+    appPermission,
+    recordPermission,
+    adminNotes,
+    plugin,
+  };
+
+  return { containers, diffContainers, paths };
+}


### PR DESCRIPTION
## Summary
- Add top-level `apply` command that applies all domain configurations in dependency-ordered phases
- Phase-based execution: Schema → Views/Customize → Permissions → Settings/Others → Seed
- Diff preview before apply with `--dry-run` and `--yes` options
- Fatal error handling (auth/network/schema deploy failure) aborts remaining phases
- Non-fatal errors isolated per domain, other domains continue

## Issue
Closes #150

## Implementation Plan
Based on `.issue/150/plan.md`

## Test plan
- Unit tests for `applyAllForApp` (10 tests: phase ordering, fatal/non-fatal error handling, deploy orchestration)
- Unit tests for CLI `apply` command (8 tests: routing, --dry-run, --yes, multiApp, error handling)
- Unit tests for `applyAllOutput` (7 tests: phase display, summary formatting)
- Manual: `apply --help`, `apply --dry-run`, `apply --yes`, multi-app mode, error scenarios

## E2E Test
- E2E test environment not present in project; coverage provided by unit tests
- Manual testing items documented in `.issue/150/testing.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)