### PR TITLE
fix: format complex objects with indented JSON in schema diff output

### DIFF
--- a/src/core/domain/action/services/__tests__/diffDetector.test.ts
+++ b/src/core/domain/action/services/__tests__/diffDetector.test.ts
@@ -84,8 +84,8 @@ describe("ActionDiffDetector", () => {
       expect(result.entries).toHaveLength(1);
       expect(result.entries[0].details).toContain("destApp:");
       expect(result.entries[0].details).toContain("->");
-      expect(result.entries[0].details).toContain('"app":"1"');
-      expect(result.entries[0].details).toContain('"app":"2"');
+      expect(result.entries[0].details).toContain('"app": "1"');
+      expect(result.entries[0].details).toContain('"app": "2"');
     });
 
     it("should detect filterCond change", () => {

--- a/src/core/domain/services/__tests__/formatValue.test.ts
+++ b/src/core/domain/services/__tests__/formatValue.test.ts
@@ -24,11 +24,13 @@ describe("formatValue", () => {
   });
 
   it("should return JSON string for an object", () => {
-    expect(formatValue({ a: 1, b: "two" })).toBe('{"a":1,"b":"two"}');
+    expect(formatValue({ a: 1, b: "two" })).toBe(
+      '{\n  "a": 1,\n  "b": "two"\n}',
+    );
   });
 
   it("should return JSON string for an array", () => {
-    expect(formatValue([1, 2, 3])).toBe("[1,2,3]");
+    expect(formatValue([1, 2, 3])).toBe("[\n  1,\n  2,\n  3\n]");
   });
 
   it("should return JSON string for an empty object", () => {
@@ -37,5 +39,13 @@ describe("formatValue", () => {
 
   it("should return JSON string for an empty array", () => {
     expect(formatValue([])).toBe("[]");
+  });
+
+  it("should return indented JSON string for a nested object", () => {
+    const nested = {
+      option1: { label: "選択肢1", index: 0 },
+      option2: { label: "選択肢2", index: 1 },
+    };
+    expect(formatValue(nested)).toBe(JSON.stringify(nested, null, 2));
   });
 });

--- a/src/core/domain/services/__tests__/formatValue.test.ts
+++ b/src/core/domain/services/__tests__/formatValue.test.ts
@@ -42,10 +42,24 @@ describe("formatValue", () => {
   });
 
   it("should return indented JSON string for a nested object", () => {
-    const nested = {
-      option1: { label: "選択肢1", index: 0 },
-      option2: { label: "選択肢2", index: 1 },
-    };
-    expect(formatValue(nested)).toBe(JSON.stringify(nested, null, 2));
+    expect(
+      formatValue({
+        option1: { label: "選択肢1", index: 0 },
+        option2: { label: "選択肢2", index: 1 },
+      }),
+    ).toBe(
+      '{\n  "option1": {\n    "label": "選択肢1",\n    "index": 0\n  },\n  "option2": {\n    "label": "選択肢2",\n    "index": 1\n  }\n}',
+    );
+  });
+
+  it("should return indented JSON string for an array of objects", () => {
+    expect(
+      formatValue([
+        { type: "USER", code: "user1" },
+        { type: "USER", code: "user2" },
+      ]),
+    ).toBe(
+      '[\n  {\n    "type": "USER",\n    "code": "user1"\n  },\n  {\n    "type": "USER",\n    "code": "user2"\n  }\n]',
+    );
   });
 });

--- a/src/core/domain/services/formatValue.ts
+++ b/src/core/domain/services/formatValue.ts
@@ -1,3 +1,5 @@
 export function formatValue(v: unknown): string {
-  return v === undefined ? "(none)" : JSON.stringify(v);
+  if (v === undefined) return "(none)";
+  if (v === null || typeof v !== "object") return JSON.stringify(v);
+  return JSON.stringify(v, null, 2);
 }


### PR DESCRIPTION
## Summary
- `formatValue` がオブジェクト/配列に `JSON.stringify(v, null, 2)` を使うように変更し、`schema diff` の details 出力を人が読みやすいインデント付き JSON に整形
- プリミティブ値（string, number, boolean, null）は従来通りコンパクト表示を維持
- ネストしたオブジェクトのテストケースを追加

## Issue
Closes #159

## Implementation Plan
Based on `.issue/159/plan.md`

## Test plan

### デプロイ・動作確認方法
```bash
pnpm install
pnpm build
pnpm test
pnpm typecheck && pnpm lint:fix && pnpm format
```

### 確認項目
- [x] プリミティブ値の表示が変わらない
- [x] オブジェクトがインデント付き JSON で表示される
- [x] 配列がインデント付き JSON で表示される
- [x] 空オブジェクト/空配列が `{}` / `[]` のまま
- [x] ネストしたオブジェクトのインデントが正しい
- [x] action diffDetector テストが PASS
- [x] 全テストスイートが PASS（222ファイル、2313テスト）
- [x] 型チェック PASS
- [x] リント・フォーマット PASS
- [x] ビルド PASS

## E2E Test
- プロジェクトにE2Eテスト環境が存在しないためスキップ
- ユニットテストで formatValue の全パターン（プリミティブ、オブジェクト、配列、空、ネスト）をカバー

## Known limitation
`changes.join(", ")` で複数プロパティの変更が結合される際、マルチライン JSON が混在すると変更境界が分かりにくくなるケースがある。単一プロパティ変更時は大幅に改善される。セパレータ変更は別 Issue として検討可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)