### PR TITLE
fix(diff): use newline separator for multi-property changes in details

### DIFF
--- a/src/cli/__tests__/output.test.ts
+++ b/src/cli/__tests__/output.test.ts
@@ -404,6 +404,32 @@ describe("printViewDiffResult", () => {
     expect(lines[1]).toBe("    fields: [");
     expect(lines[2]).toBe('      "f1"');
     expect(lines[3]).toBe("    ] -> [");
+    expect(lines[4]).toBe('      "f2"');
+    expect(lines[5]).toBe("    ]");
+  });
+
+  it("マルチライン details のエントリの次のエントリは行頭から出力される", () => {
+    const result: DiffResult<ViewDiffEntry> = {
+      entries: [
+        {
+          type: "modified",
+          viewName: "一覧",
+          details: 'sort: "f2 desc" -> "f1 asc"\nindex: 0 -> 1',
+        },
+        { type: "added", viewName: "新規", details: "LIST view を追加" },
+      ],
+      summary: { added: 1, modified: 1, deleted: 0, total: 2 },
+      isEmpty: false,
+      warnings: [],
+    };
+    printViewDiffResult(result);
+    const noteBody = vi.mocked(p.note).mock.calls[0][0] as string;
+    const lines = noteBody.split("\n");
+    expect(lines).toHaveLength(3);
+    expect(lines[1]).toBe("    index: 0 -> 1");
+    // 2 エントリ目の見出し行はインデントされない
+    expect(lines[2]).not.toMatch(/^\s/);
+    expect(lines[2]).toContain("新規");
   });
 
   it("warnings がある場合、p.log.warn で出力される", () => {
@@ -1082,6 +1108,11 @@ describe("indentContinuationLines", () => {
 
   it("インデント幅を指定できる", () => {
     expect(indentContinuationLines("a\nb", "  ")).toBe("a\n  b");
+  });
+
+  it("空の継続行にはインデントを付与しない", () => {
+    expect(indentContinuationLines("a\n\nb")).toBe("a\n\n    b");
+    expect(indentContinuationLines("a\n")).toBe("a\n");
   });
 
   it("空文字列はそのまま返す", () => {

--- a/src/cli/__tests__/output.test.ts
+++ b/src/cli/__tests__/output.test.ts
@@ -39,6 +39,7 @@ import type { AppName } from "@/core/domain/projectConfig/valueObject";
 import { logError } from "../handleError";
 import {
   confirmAndDeploy,
+  indentContinuationLines,
   printActionDiffResult,
   printAdminNotesDiffResult,
   printAppHeader,
@@ -279,6 +280,30 @@ describe("printDiffResult", () => {
       expect.objectContaining({ format: expect.any(Function) }),
     );
   });
+
+  it("details に改行を含む場合、2行目以降がインデントされて出力される", () => {
+    const result: DetectDiffOutput = {
+      entries: [
+        {
+          type: "modified",
+          fieldCode: "email" as FieldCode,
+          fieldLabel: "メール",
+          details: "type: SINGLE_LINE_TEXT -> NUMBER\nlabel: 旧 -> 新",
+        },
+      ],
+      schemaFields: [],
+      summary: { added: 0, modified: 1, deleted: 0, total: 1 },
+      isEmpty: false,
+      hasLayoutChanges: false,
+    };
+
+    printDiffResult(result);
+
+    const noteBody = vi.mocked(p.note).mock.calls[0][0] as string;
+    const lines = noteBody.split("\n");
+    expect(lines[0]).toContain("type: SINGLE_LINE_TEXT -> NUMBER");
+    expect(lines[1]).toBe("    label: 旧 -> 新");
+  });
 });
 
 describe("printViewDiffResult", () => {
@@ -356,6 +381,29 @@ describe("printViewDiffResult", () => {
     expect(changeLine).toContain("+1 added");
     expect(changeLine).toContain("~1 modified");
     expect(changeLine).toContain("-1 deleted");
+  });
+
+  it("details に改行を含む場合、2行目以降がインデントされて出力される", () => {
+    const result: DiffResult<ViewDiffEntry> = {
+      entries: [
+        {
+          type: "modified",
+          viewName: "一覧",
+          details:
+            'sort: "f2 desc" -> "f1 asc"\nfields: [\n  "f1"\n] -> [\n  "f2"\n]',
+        },
+      ],
+      summary: { added: 0, modified: 1, deleted: 0, total: 1 },
+      isEmpty: false,
+      warnings: [],
+    };
+    printViewDiffResult(result);
+    const noteBody = vi.mocked(p.note).mock.calls[0][0] as string;
+    const lines = noteBody.split("\n");
+    expect(lines[0]).toContain('sort: "f2 desc" -> "f1 asc"');
+    expect(lines[1]).toBe("    fields: [");
+    expect(lines[2]).toBe('      "f1"');
+    expect(lines[3]).toBe("    ] -> [");
   });
 
   it("warnings がある場合、p.log.warn で出力される", () => {
@@ -1018,5 +1066,25 @@ describe("printReportDiffResult", () => {
       "Report Diff Details",
       expect.objectContaining({ format: expect.any(Function) }),
     );
+  });
+});
+
+describe("indentContinuationLines", () => {
+  it("改行を含まない文字列はそのまま返す", () => {
+    expect(indentContinuationLines("single line")).toBe("single line");
+  });
+
+  it("2行目以降にデフォルトのインデントを付与する", () => {
+    expect(indentContinuationLines("first\nsecond\nthird")).toBe(
+      "first\n    second\n    third",
+    );
+  });
+
+  it("インデント幅を指定できる", () => {
+    expect(indentContinuationLines("a\nb", "  ")).toBe("a\n  b");
+  });
+
+  it("空文字列はそのまま返す", () => {
+    expect(indentContinuationLines("")).toBe("");
   });
 });

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -45,7 +45,10 @@ export function indentContinuationLines(text: string, indent = "    "): string {
     return text;
   }
   const [first, ...rest] = text.split("\n");
-  return [first, ...rest.map((line) => `${indent}${line}`)].join("\n");
+  return [
+    first,
+    ...rest.map((line) => (line.length > 0 ? `${indent}${line}` : line)),
+  ].join("\n");
 }
 
 function printGenericDiffResult<

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -37,6 +37,17 @@ function colorizeDiffEntry(type: "added" | "modified" | "deleted"): {
   return { colorize, prefix };
 }
 
+// Entry details may contain newlines (one property change per line, or
+// multiline JSON values). Indent continuation lines so they visually hang
+// under the entry heading (e.g. "~ name:").
+export function indentContinuationLines(text: string, indent = "    "): string {
+  if (!text.includes("\n")) {
+    return text;
+  }
+  const [first, ...rest] = text.split("\n");
+  return [first, ...rest.map((line) => `${indent}${line}`)].join("\n");
+}
+
 function printGenericDiffResult<
   E extends { type: "added" | "modified" | "deleted" },
 >(
@@ -61,7 +72,7 @@ function printGenericDiffResult<
 
   const lines = result.entries.map((entry) => {
     const { colorize, prefix } = colorizeDiffEntry(entry.type);
-    return formatEntry(entry, colorize, prefix);
+    return indentContinuationLines(formatEntry(entry, colorize, prefix));
   });
 
   p.note(lines.join("\n"), title, { format: (v) => v });
@@ -130,7 +141,9 @@ export function printDiffResult(result: DetectDiffOutput): void {
 
   const lines = result.entries.map((entry) => {
     const { colorize, prefix } = colorizeDiffEntry(entry.type);
-    return `${colorize(prefix)} ${pc.dim("[")}${colorize(entry.fieldCode)}${pc.dim("]")} ${entry.fieldLabel}${pc.dim(":")} ${entry.details}`;
+    return indentContinuationLines(
+      `${colorize(prefix)} ${pc.dim("[")}${colorize(entry.fieldCode)}${pc.dim("]")} ${entry.fieldLabel}${pc.dim(":")} ${entry.details}`,
+    );
   });
 
   p.note(lines.join("\n"), "Diff Details", { format: (v) => v });

--- a/src/core/domain/action/services/__tests__/diffDetector.test.ts
+++ b/src/core/domain/action/services/__tests__/diffDetector.test.ts
@@ -125,6 +125,19 @@ describe("ActionDiffDetector", () => {
       expect(result.entries[0].details).toContain("[] ->");
       expect(result.entries[0].details).toContain('"user1"');
     });
+
+    it("should separate multiple property changes by newline", () => {
+      const local = makeConfig({
+        a: makeAction({ index: 1, destApp: { app: "2" } }),
+      });
+      const remote = makeConfig({
+        a: makeAction({ index: 0, destApp: { app: "1" } }),
+      });
+      const result = ActionDiffDetector.detect(local, remote);
+      expect(result.entries).toHaveLength(1);
+      expect(result.entries[0].details).toContain("index: 0 -> 1\ndestApp:");
+      expect(result.entries[0].details).toContain('"app": "2"');
+    });
   });
 
   describe("multiple changes", () => {

--- a/src/core/domain/action/services/diffDetector.ts
+++ b/src/core/domain/action/services/diffDetector.ts
@@ -54,7 +54,7 @@ export const ActionDiffDetector = {
             return {
               type: "modified",
               actionName: name,
-              details: diffs.join(", "),
+              details: diffs.join("\n"),
             };
           }
           return undefined;

--- a/src/core/domain/appPermission/services/__tests__/diffDetector.test.ts
+++ b/src/core/domain/appPermission/services/__tests__/diffDetector.test.ts
@@ -49,6 +49,15 @@ describe("AppPermissionDiffDetector", () => {
       expect(result.entries[0].entityKey).toBe("USER:user1");
       expect(result.summary.added).toBe(1);
     });
+
+    it("should keep comma separator within permission flag summaries", () => {
+      const local = makeConfig([
+        makeRight({ recordViewable: true, recordAddable: true }),
+      ]);
+      const result = AppPermissionDiffDetector.detect(local, makeConfig());
+      expect(result.entries).toHaveLength(1);
+      expect(result.entries[0].details).toBe("recordViewable, recordAddable");
+    });
   });
 
   describe("deleted entities", () => {
@@ -91,6 +100,7 @@ describe("AppPermissionDiffDetector", () => {
       expect(result.entries[0].type).toBe("modified");
       expect(result.entries[0].details).toContain("recordAddable");
       expect(result.entries[0].details).toContain("recordEditable");
+      expect(result.entries[0].details.split("\n")).toHaveLength(2);
     });
   });
 

--- a/src/core/domain/appPermission/services/diffDetector.ts
+++ b/src/core/domain/appPermission/services/diffDetector.ts
@@ -59,7 +59,7 @@ export const AppPermissionDiffDetector = {
           entries.push({
             type: "modified",
             entityKey: key,
-            details: diffs.join(", "),
+            details: diffs.join("\n"),
           });
         }
       }

--- a/src/core/domain/fieldPermission/services/__tests__/diffDetector.test.ts
+++ b/src/core/domain/fieldPermission/services/__tests__/diffDetector.test.ts
@@ -158,6 +158,9 @@ describe("FieldPermissionDiffDetector", () => {
       expect(result.entries[0].type).toBe("modified");
       expect(result.entries[0].fieldCode).toBe("field1");
       expect(result.entries[0].details).toContain("entities:");
+      expect(result.entries[0].details).toContain(
+        "USER:user1(read), GROUP:group1(write)",
+      );
     });
 
     it("should not report diff between includeSubs undefined and false", () => {

--- a/src/core/domain/formSchema/services/__tests__/diffDetector.test.ts
+++ b/src/core/domain/formSchema/services/__tests__/diffDetector.test.ts
@@ -352,6 +352,7 @@ describe("DiffDetector", () => {
       const diff = DiffDetector.detect(schema, current);
       expect(diff.entries[0].details).toContain("type:");
       expect(diff.entries[0].details).toContain("label:");
+      expect(diff.entries[0].details.split("\n")).toHaveLength(2);
     });
 
     it("全く同一のフィールドは差分として検出されない", () => {

--- a/src/core/domain/formSchema/services/diffDetector.ts
+++ b/src/core/domain/formSchema/services/diffDetector.ts
@@ -123,7 +123,7 @@ function describeChanges(
     changes.push(...describePropertiesChanges(before, after));
   }
 
-  return changes.length > 0 ? changes.join(", ") : "no visible changes";
+  return changes.length > 0 ? changes.join("\n") : "no visible changes";
 }
 
 function isLayoutEqual(a: FormLayout, b: FormLayout): boolean {

--- a/src/core/domain/notification/services/__tests__/diffDetector.test.ts
+++ b/src/core/domain/notification/services/__tests__/diffDetector.test.ts
@@ -245,6 +245,7 @@ describe("NotificationDiffDetector", () => {
       expect(result.entries).toHaveLength(1);
       expect(result.entries[0].details).toContain("recordAdded");
       expect(result.entries[0].details).toContain("recordEdited");
+      expect(result.entries[0].details.split("\n")).toHaveLength(2);
     });
 
     it("should detect general section added", () => {
@@ -308,6 +309,28 @@ describe("NotificationDiffDetector", () => {
       expect(result.entries).toHaveLength(1);
       expect(result.entries[0].type).toBe("modified");
       expect(result.entries[0].section).toBe("perRecord");
+    });
+
+    it("should separate multiple perRecord property changes by newline", () => {
+      const local: NotificationConfig = {
+        perRecord: [
+          makePerRecord({
+            title: "New title",
+            targets: [
+              { entity: { type: "USER", code: "user1" }, includeSubs: false },
+            ],
+          }),
+        ],
+      };
+      const remote: NotificationConfig = {
+        perRecord: [makePerRecord({ title: "Old title", targets: [] })],
+      };
+      const result = NotificationDiffDetector.detect(local, remote);
+      expect(result.entries).toHaveLength(1);
+      expect(result.entries[0].details).toContain(
+        'title: "Old title" -> "New title"\ntargets:',
+      );
+      expect(result.entries[0].details).toContain('"user1"');
     });
   });
 
@@ -392,6 +415,7 @@ describe("NotificationDiffDetector", () => {
       expect(result.entries[0].name).toBe("reminder1");
       expect(result.entries[0].details).toContain("title:");
       expect(result.entries[0].details).toContain("daysLater:");
+      expect(result.entries[0].details.split("\n")).toHaveLength(2);
     });
 
     it("should detect hoursLater change in reminder", () => {

--- a/src/core/domain/notification/services/diffDetector.ts
+++ b/src/core/domain/notification/services/diffDetector.ts
@@ -83,7 +83,7 @@ function compareGeneralSection(
           type: "modified",
           section: "general",
           name: key,
-          details: diffs.join(", "),
+          details: diffs.join("\n"),
         });
       }
     }
@@ -135,7 +135,7 @@ function describePerRecordChanges(
     );
   // Fallback "changed" covers the case where deepEqual detects a difference
   // but no individual field check above caught it (should not happen in practice).
-  return diffs.length > 0 ? diffs.join(", ") : "changed";
+  return diffs.length > 0 ? diffs.join("\n") : "changed";
 }
 
 // Covers all ReminderNotification fields except code (used as Map key).
@@ -161,7 +161,7 @@ function describeReminderChanges(
     diffs.push(
       `targets: ${formatValue(remote.targets)} -> ${formatValue(local.targets)}`,
     );
-  return diffs.length > 0 ? diffs.join(", ") : "changed";
+  return diffs.length > 0 ? diffs.join("\n") : "changed";
 }
 
 function comparePerRecordSection(

--- a/src/core/domain/plugin/services/__tests__/diffDetector.test.ts
+++ b/src/core/domain/plugin/services/__tests__/diffDetector.test.ts
@@ -81,8 +81,9 @@ describe("PluginDiffDetector", () => {
       ]);
       const result = PluginDiffDetector.detect(local, remote);
       expect(result.entries).toHaveLength(1);
-      expect(result.entries[0].details).toContain("\n");
-      expect(result.entries[0].details.split("\n")).toHaveLength(2);
+      expect(result.entries[0].details).toBe(
+        'name: "Old Name" -> "New Name"\nenabled: true -> false',
+      );
     });
   });
 

--- a/src/core/domain/plugin/services/__tests__/diffDetector.test.ts
+++ b/src/core/domain/plugin/services/__tests__/diffDetector.test.ts
@@ -71,6 +71,19 @@ describe("PluginDiffDetector", () => {
       expect(result.entries[0].type).toBe("modified");
       expect(result.entries[0].details).toContain("name");
     });
+
+    it("should separate multiple property changes by newline", () => {
+      const local = makeConfig([
+        makePlugin({ name: "New Name", enabled: false }),
+      ]);
+      const remote = makeConfig([
+        makePlugin({ name: "Old Name", enabled: true }),
+      ]);
+      const result = PluginDiffDetector.detect(local, remote);
+      expect(result.entries).toHaveLength(1);
+      expect(result.entries[0].details).toContain("\n");
+      expect(result.entries[0].details.split("\n")).toHaveLength(2);
+    });
   });
 
   describe("multiple changes", () => {

--- a/src/core/domain/plugin/services/diffDetector.ts
+++ b/src/core/domain/plugin/services/diffDetector.ts
@@ -31,7 +31,7 @@ export const PluginDiffDetector = {
           entries.push({
             type: "modified",
             pluginId: id,
-            details: diffs.join(", "),
+            details: diffs.join("\n"),
           });
         }
       }

--- a/src/core/domain/processManagement/services/__tests__/diffDetector.test.ts
+++ b/src/core/domain/processManagement/services/__tests__/diffDetector.test.ts
@@ -242,6 +242,9 @@ describe("ProcessManagementDiffDetector", () => {
       expect(result.entries[0].details).toContain("index");
       expect(result.entries[0].details).toContain("assignee.type");
       expect(result.entries[0].details).toContain("assignee.entities:");
+      expect(result.entries[0].details).toContain(
+        "index: 0 -> 5\nassignee.type: ONE -> ALL\nassignee.entities:",
+      );
     });
 
     it("should detect entities change when includeSubs differs", () => {
@@ -334,6 +337,22 @@ describe("ProcessManagementDiffDetector", () => {
 
       expect(result.entries).toHaveLength(1);
       expect(result.entries[0].details).toContain("to");
+    });
+
+    it("should separate multiple action property changes by newline", () => {
+      const local = makeConfig({
+        actions: [makeAction({ from: "処理中", to: "完了" })],
+      });
+      const remote = makeConfig({
+        actions: [makeAction({ from: "未処理", to: "処理中" })],
+      });
+
+      const result = ProcessManagementDiffDetector.detect(local, remote);
+
+      expect(result.entries).toHaveLength(1);
+      expect(result.entries[0].details).toContain("from:");
+      expect(result.entries[0].details).toContain("to:");
+      expect(result.entries[0].details.split("\n")).toHaveLength(2);
     });
 
     it("should detect action filterCond change", () => {

--- a/src/core/domain/processManagement/services/diffDetector.ts
+++ b/src/core/domain/processManagement/services/diffDetector.ts
@@ -114,7 +114,7 @@ function compareStates(
           type: "modified",
           category: "state",
           name,
-          details: stateDiffs.join(", "),
+          details: stateDiffs.join("\n"),
         });
       }
     }
@@ -156,7 +156,7 @@ function compareActionEntries(
           type: "modified",
           category: "action",
           name,
-          details: actionDiffs.join(", "),
+          details: actionDiffs.join("\n"),
         });
       }
     }

--- a/src/core/domain/recordPermission/services/__tests__/diffDetector.test.ts
+++ b/src/core/domain/recordPermission/services/__tests__/diffDetector.test.ts
@@ -127,6 +127,55 @@ describe("RecordPermissionDiffDetector", () => {
       expect(result.entries[0].type).toBe("modified");
       expect(result.entries[0].details).toContain("1 -> 2");
     });
+
+    it("should keep comma separator within entity summaries", () => {
+      const local = makeConfig([
+        makeRight({
+          entities: [
+            {
+              entity: { type: "USER", code: "user1" },
+              viewable: true,
+              editable: true,
+              deletable: false,
+              includeSubs: false,
+            },
+            {
+              entity: { type: "GROUP", code: "group1" },
+              viewable: true,
+              editable: false,
+              deletable: false,
+              includeSubs: false,
+            },
+          ],
+        }),
+      ]);
+      const remote = makeConfig([
+        makeRight({
+          entities: [
+            {
+              entity: { type: "USER", code: "user1" },
+              viewable: true,
+              editable: false,
+              deletable: false,
+              includeSubs: false,
+            },
+            {
+              entity: { type: "GROUP", code: "group1" },
+              viewable: true,
+              editable: false,
+              deletable: false,
+              includeSubs: false,
+            },
+          ],
+        }),
+      ]);
+      const result = RecordPermissionDiffDetector.detect(local, remote);
+      expect(result.entries).toHaveLength(1);
+      expect(result.entries[0].details).toContain(
+        "USER:user1(view/edit), GROUP:group1(view)",
+      );
+      expect(result.entries[0].details).not.toContain("\n");
+    });
   });
 
   describe("filterCond-based comparison (order independent)", () => {

--- a/src/core/domain/report/services/__tests__/diffDetector.test.ts
+++ b/src/core/domain/report/services/__tests__/diffDetector.test.ts
@@ -158,6 +158,20 @@ describe("ReportDiffDetector", () => {
       expect(result.entries).toHaveLength(1);
       expect(result.entries[0].details).toContain("chartMode");
     });
+
+    it("should separate multiple property changes by newline", () => {
+      const local = makeConfig({
+        r1: makeReport({ chartType: "PIE", index: 1 }),
+      });
+      const remote = makeConfig({
+        r1: makeReport({ chartType: "BAR", index: 0 }),
+      });
+      const result = ReportDiffDetector.detect(local, remote);
+      expect(result.entries).toHaveLength(1);
+      expect(result.entries[0].details).toContain("chartType:");
+      expect(result.entries[0].details).toContain("index:");
+      expect(result.entries[0].details.split("\n")).toHaveLength(2);
+    });
   });
 
   describe("multiple changes", () => {

--- a/src/core/domain/report/services/diffDetector.ts
+++ b/src/core/domain/report/services/diffDetector.ts
@@ -66,7 +66,7 @@ export const ReportDiffDetector = {
             return {
               type: "modified",
               reportName: name,
-              details: diffs.join(", "),
+              details: diffs.join("\n"),
             };
           }
           return undefined;

--- a/src/core/domain/view/services/__tests__/diffDetector.test.ts
+++ b/src/core/domain/view/services/__tests__/diffDetector.test.ts
@@ -271,6 +271,41 @@ describe("ViewDiffDetector", () => {
       expect(result.entries[0].details).toContain("date:");
       expect(result.entries[0].details).toContain("title:");
       expect(result.entries[0].details).toContain("device:");
+      expect(result.entries[0].details).toBe(
+        [
+          'sort: "f2 desc" -> "f1 asc"',
+          'date: "d2" -> "d1"',
+          'title: "t2" -> "t1"',
+          'device: "ANY" -> "DESKTOP"',
+        ].join("\n"),
+      );
+    });
+
+    it("should separate changes by newline when combined with multiline values", () => {
+      const local: Record<string, ViewConfig> = {
+        view1: makeView({
+          type: "LIST",
+          name: "view1",
+          sort: "f1 asc",
+          fields: ["f1", "f2"],
+        }),
+      };
+      const remote: Record<string, ViewConfig> = {
+        view1: makeView({
+          type: "LIST",
+          name: "view1",
+          sort: "f2 desc",
+          fields: ["f1"],
+        }),
+      };
+
+      const result = ViewDiffDetector.detect(local, remote);
+
+      expect(result.entries).toHaveLength(1);
+      expect(result.entries[0].details).toContain(
+        'sort: "f2 desc" -> "f1 asc"\nfields:',
+      );
+      expect(result.entries[0].details).toContain('"f2"');
     });
 
     it("should treat undefined and empty string as equal for optional string fields", () => {

--- a/src/core/domain/view/services/diffDetector.ts
+++ b/src/core/domain/view/services/diffDetector.ts
@@ -83,7 +83,7 @@ export const ViewDiffDetector = {
             return {
               type: "modified",
               viewName: name,
-              details: changes.join(", "),
+              details: changes.join("\n"),
             };
           }
           return undefined;


### PR DESCRIPTION
## Summary
- プロパティ変更リストを結合する全 diffDetector（formSchema, view, notification, action, report, processManagement, appPermission, plugin — 計11箇所）の `join(", ")` を `join("\n")` に変更し、複数プロパティ同時変更時に各変更を独立した行で表示
- `describeRight` / `describeEntities` 系の単一値要約（fieldPermission / recordPermission / appPermission）は `", "` のまま維持
- `src/cli/output.ts` に `indentContinuationLines` ヘルパーを追加し、details の2行目以降をインデントしてエントリ見出しに視覚的にぶら下げる（Issue 本文の提案の一歩外だが、改行化に伴う表示の明瞭化として追加 — `.issue/161/adr.md` ADR-003）
- テスト14件追加（改行区切り・`", "` 維持・インデント整形の検証）

## Issue
Closes #161

## Implementation Plan
Based on `.issue/161/plan.md`

## Test plan

### 動作確認方法
```bash
pnpm test
pnpm dev:diff       # kintone 環境がある場合の目視確認
pnpm dev:diff-all
```

### 確認項目
- 複数プロパティ同時変更時に各変更が独立した行で表示され、マルチライン JSON の途中に `, ` が紛れない
- details の2行目以降がインデントされ、`p.note()` のボックス描画が崩れない
- 単一値要約（`entities: ...` 等）は従来どおり `", "` 区切り
- 全テスト PASS（222 ファイル / 2328 件）、typecheck・lint・format クリーン

### 留意点
- plugin / appPermission など従来1行だった details も複数行になる（一貫性優先の意図的変更）

## Browser Verification
- スキップ理由: Web UI なし（CLI ツール。package.json の dev は tsx での CLI 実行、UI ファイル不在、testing.md に画面操作項目ゼロを確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)