### PR TITLE
improve: apply コマンドの seed 注記を条件付き表示にする

### DIFF
--- a/src/cli/commands/__tests__/apply.test.ts
+++ b/src/cli/commands/__tests__/apply.test.ts
@@ -402,6 +402,39 @@ describe("apply command", () => {
     expect(p.log.success).toHaveBeenCalledWith("No changes detected.");
   });
 
+  it("seed.yaml が存在し --dry-run かつ差分なしの場合は dry-run の seed 注記が表示されること", async () => {
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          singleApp: (app: AppEntry, config: ProjectConfig) => Promise<void>;
+        },
+      ) => {
+        await handlers.singleApp(mockApp, mockProjectConfig);
+      },
+    );
+    vi.mocked(diffAllForApp).mockResolvedValueOnce([
+      {
+        domain: "schema",
+        success: true,
+        result: {
+          isEmpty: true,
+          entries: [],
+          schemaFields: [],
+          summary: { added: 0, modified: 0, deleted: 0, total: 0 },
+          hasLayoutChanges: false,
+        },
+      },
+    ]);
+
+    await applyCommand.run({ values: { "dry-run": true } } as never);
+
+    expect(p.log.info).toHaveBeenCalledWith(
+      "Note: Seed data would still be upserted when running without --dry-run.",
+    );
+    expect(applyAllForApp).not.toHaveBeenCalled();
+  });
+
   it("seed.yaml が存在せず --dry-run かつ差分なしの場合は dry-run の seed 注記が表示されないこと", async () => {
     vi.mocked(routeMultiApp).mockImplementationOnce(
       async (

--- a/src/cli/commands/__tests__/apply.test.ts
+++ b/src/cli/commands/__tests__/apply.test.ts
@@ -52,9 +52,18 @@ vi.mock("../../applyAllOutput", () => ({
   printApplyAllResults: vi.fn(),
 }));
 
+const { mockSeedStorageGet } = vi.hoisted(() => ({
+  mockSeedStorageGet: vi.fn(async () => ({
+    exists: true,
+    content: "records: []",
+  })),
+}));
+
 vi.mock("@/core/application/container/applyAllCli", () => ({
   createCliApplyAllContainers: vi.fn(() => ({
-    containers: {},
+    containers: {
+      seed: { seedStorage: { get: mockSeedStorageGet } },
+    },
     diffContainers: {},
     paths: {
       schema: "test-app/schema.yaml",
@@ -337,6 +346,94 @@ describe("apply command", () => {
     expect(p.log.info).toHaveBeenCalledWith(
       "Note: Seed data will be upserted (no diff preview available).",
     );
+  });
+
+  it("seed.yaml が存在しない場合は seed 注記が表示されないこと", async () => {
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          singleApp: (app: AppEntry, config: ProjectConfig) => Promise<void>;
+        },
+      ) => {
+        await handlers.singleApp(mockApp, mockProjectConfig);
+      },
+    );
+    mockSeedStorageGet.mockResolvedValueOnce({ exists: false, content: "" });
+    vi.mocked(p.confirm).mockResolvedValueOnce(true);
+
+    await applyCommand.run({ values: {} } as never);
+
+    expect(p.log.info).not.toHaveBeenCalledWith(
+      "Note: Seed data will be upserted (no diff preview available).",
+    );
+    expect(applyAllForApp).toHaveBeenCalled();
+  });
+
+  it("seed.yaml が存在せず diff 変更もない場合は 'No changes detected.' と表示されること", async () => {
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          singleApp: (app: AppEntry, config: ProjectConfig) => Promise<void>;
+        },
+      ) => {
+        await handlers.singleApp(mockApp, mockProjectConfig);
+      },
+    );
+    vi.mocked(diffAllForApp).mockResolvedValueOnce([
+      {
+        domain: "schema",
+        success: true,
+        result: {
+          isEmpty: true,
+          entries: [],
+          schemaFields: [],
+          summary: { added: 0, modified: 0, deleted: 0, total: 0 },
+          hasLayoutChanges: false,
+        },
+      },
+    ]);
+    mockSeedStorageGet.mockResolvedValueOnce({ exists: false, content: "" });
+    vi.mocked(p.confirm).mockResolvedValueOnce(true);
+
+    await applyCommand.run({ values: {} } as never);
+
+    expect(p.log.success).toHaveBeenCalledWith("No changes detected.");
+  });
+
+  it("seed.yaml が存在せず --dry-run かつ差分なしの場合は dry-run の seed 注記が表示されないこと", async () => {
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          singleApp: (app: AppEntry, config: ProjectConfig) => Promise<void>;
+        },
+      ) => {
+        await handlers.singleApp(mockApp, mockProjectConfig);
+      },
+    );
+    vi.mocked(diffAllForApp).mockResolvedValueOnce([
+      {
+        domain: "schema",
+        success: true,
+        result: {
+          isEmpty: true,
+          entries: [],
+          schemaFields: [],
+          summary: { added: 0, modified: 0, deleted: 0, total: 0 },
+          hasLayoutChanges: false,
+        },
+      },
+    ]);
+    mockSeedStorageGet.mockResolvedValueOnce({ exists: false, content: "" });
+
+    await applyCommand.run({ values: { "dry-run": true } } as never);
+
+    expect(p.log.info).not.toHaveBeenCalledWith(
+      "Note: Seed data would still be upserted when running without --dry-run.",
+    );
+    expect(applyAllForApp).not.toHaveBeenCalled();
   });
 
   it("apply で失敗があった場合に exitCode が 1 になること", async () => {

--- a/src/cli/commands/apply.ts
+++ b/src/cli/commands/apply.ts
@@ -74,18 +74,25 @@ async function runApplyAll(
   printDiffAllResults(diffResults);
 
   // Note about seed data (not included in diff preview)
-  p.log.info("Note: Seed data will be upserted (no diff preview available).");
+  const seedExists = (await containers.seed.seedStorage.get()).exists;
+  if (seedExists) {
+    p.log.info("Note: Seed data will be upserted (no diff preview available).");
+  }
 
   // Check if there are any changes
   const hasChanges = diffResults.some((r) => r.success && !r.result.isEmpty);
   if (!hasChanges) {
-    p.log.success("No changes detected. Seed data will still be upserted.");
+    p.log.success(
+      seedExists
+        ? "No changes detected. Seed data will still be upserted."
+        : "No changes detected.",
+    );
   }
 
   // Step 2: Dry run exits here
   if (options.dryRun) {
     p.log.info("Dry run complete. No changes will be applied.");
-    if (!hasChanges) {
+    if (!hasChanges && seedExists) {
       p.log.info(
         "Note: Seed data would still be upserted when running without --dry-run.",
       );


### PR DESCRIPTION
## Summary
- `apply` コマンドの seed 注記「Note: Seed data will be upserted (no diff preview available).」を、seed.yaml が存在する場合のみ表示するように変更
- 差分なし時のメッセージを seed.yaml の有無で分岐（なしの場合は "No changes detected."）
- dry-run 時の seed 注記も seed.yaml が存在する場合のみ表示
- seed 存在判定は `SeedStorage` ポート経由で行い、CLI 層から fs を直接触らない

## Issue
Closes #156

## Implementation Plan
Based on `.issue/156/plan.md`

## Test plan

### デプロイ・動作確認方法
```bash
pnpm test src/cli/commands/__tests__/apply.test.ts
pnpm dev apply --dry-run
```

### 確認項目
- seed.yaml がある場合、従来どおり seed 注記が表示される（AC-1）
- seed.yaml がない場合、seed 注記（3箇所すべて）が表示されない（AC-2）
- seed.yaml がない場合の差分なしメッセージは "No changes detected."（AC-3）

## Browser Verification
- スキップ理由: CLI ツールで Web UI なし。testing.md に画面操作項目が1件もないことを確認済み（全項目 CLI コマンド実行）

🤖 Generated with [Claude Code](https://claude.com/claude-code)