### PR TITLE
improve(apply): 設定ファイルが存在しないドメインを graceful にスキップする

### DIFF
--- a/src/cli/__tests__/applyAllOutput.test.ts
+++ b/src/cli/__tests__/applyAllOutput.test.ts
@@ -258,6 +258,76 @@ describe("printApplyAllResults", () => {
     expect(logError).not.toHaveBeenCalled();
   });
 
+  it("skipReason が not-found の場合に 'skipped (file not found)' と表示されること", () => {
+    const output: ApplyAllForAppOutput = {
+      phases: [
+        {
+          phase: "Schema",
+          results: [
+            {
+              domain: "schema",
+              success: false,
+              error: new Error("Schema file not found"),
+              skipped: true,
+              skipReason: "not-found",
+            },
+          ],
+        },
+      ],
+      deployed: false,
+    };
+
+    printApplyAllResults(output);
+
+    const messageCalls = vi.mocked(p.log.message).mock.calls;
+    const schemaLine = messageCalls[0][0] as string;
+    expect(schemaLine).toContain("⊘");
+    expect(schemaLine).toContain("skipped (file not found)");
+    expect(schemaLine).not.toContain("failed");
+
+    // Summary still lumps it into the single skipped count (no not-found breakdown)
+    const summaryLine = messageCalls[messageCalls.length - 1][0] as string;
+    expect(summaryLine).toContain("1");
+    expect(summaryLine).toContain("skipped");
+    expect(summaryLine).not.toContain("not found");
+  });
+
+  it("skipReason が aborted / 未設定の場合は 'skipped' にフォールバックすること", () => {
+    const output: ApplyAllForAppOutput = {
+      phases: [
+        {
+          phase: "Permissions",
+          results: [
+            {
+              domain: "app-acl",
+              success: false,
+              error: new Error("Skipped due to fatal error"),
+              skipped: true,
+              skipReason: "aborted",
+            },
+            {
+              domain: "record-acl",
+              success: false,
+              error: new Error("Skipped"),
+              skipped: true,
+            },
+          ],
+        },
+      ],
+      deployed: false,
+    };
+
+    printApplyAllResults(output);
+
+    const messageCalls = vi.mocked(p.log.message).mock.calls;
+    const abortedLine = messageCalls[0][0] as string;
+    const undefinedLine = messageCalls[1][0] as string;
+    expect(abortedLine).toContain("skipped");
+    expect(abortedLine).not.toContain("file not found");
+    expect(undefinedLine).toContain("skipped");
+    expect(undefinedLine).not.toContain("file not found");
+  });
+
   it("deployed が false で deployError がある場合にエラー詳細が表示されること", () => {
     const output: ApplyAllForAppOutput = {
       phases: [

--- a/src/cli/applyAllOutput.ts
+++ b/src/cli/applyAllOutput.ts
@@ -31,7 +31,11 @@ function formatTaskResult(result: ApplyTaskResult): string {
     return `  ${pc.green("\u2713")} ${name}`;
   }
   if (result.skipped) {
-    return `  ${pc.yellow("\u2298")} ${name} ${pc.dim("\u2014")} ${pc.yellow("skipped")}`;
+    const label =
+      result.skipReason === "not-found"
+        ? "skipped (file not found)"
+        : "skipped";
+    return `  ${pc.yellow("\u2298")} ${name} ${pc.dim("\u2014")} ${pc.yellow(label)}`;
   }
   return `  ${pc.red("\u2717")} ${name} ${pc.dim("\u2014")} ${pc.red(`failed (${formatErrorForDisplay(result.error)})`)}`;
 }

--- a/src/cli/commands/__tests__/apply.test.ts
+++ b/src/cli/commands/__tests__/apply.test.ts
@@ -112,6 +112,7 @@ vi.mock("@/core/application/applyAll/applyAllForApp", () => ({
 }));
 
 import * as p from "@clack/prompts";
+import type { ApplyAllForAppOutput } from "@/core/application/applyAll/applyAllForApp";
 import { applyAllForApp } from "@/core/application/applyAll/applyAllForApp";
 import { diffAllForApp } from "@/core/application/diffAll/diffAllForApp";
 import type {
@@ -125,7 +126,7 @@ import { printDiffAllResults } from "../../diffAllOutput";
 import { handleCliError } from "../../handleError";
 import { printAppHeader } from "../../output";
 import { routeMultiApp, runMultiAppWithFailCheck } from "../../projectConfig";
-import applyCommand from "../apply";
+import applyCommand, { shouldFailApply } from "../apply";
 
 afterEach(() => {
   vi.clearAllMocks();
@@ -501,5 +502,136 @@ describe("apply command", () => {
     await applyCommand.run({ values: {} } as never);
 
     expect(process.exitCode).toBe(1);
+  });
+
+  it("全ドメインが not-found skip の場合は exitCode が 1 にならないこと", async () => {
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          singleApp: (app: AppEntry, config: ProjectConfig) => Promise<void>;
+        },
+      ) => {
+        await handlers.singleApp(mockApp, mockProjectConfig);
+      },
+    );
+    vi.mocked(p.confirm).mockResolvedValueOnce(true);
+    vi.mocked(applyAllForApp).mockResolvedValueOnce({
+      phases: [
+        {
+          phase: "Views & Customization",
+          results: [
+            {
+              domain: "customize",
+              success: false,
+              error: new Error("Customization config file not found"),
+              skipped: true,
+              skipReason: "not-found",
+            },
+          ],
+        },
+      ],
+      deployed: false,
+    });
+
+    await applyCommand.run({ values: {} } as never);
+
+    expect(process.exitCode).toBeUndefined();
+  });
+});
+
+describe("shouldFailApply", () => {
+  const deployableSuccess: ApplyAllForAppOutput["phases"][number] = {
+    phase: "Views & Customization",
+    results: [{ domain: "customize", success: true }],
+  };
+
+  it("真の失敗があるとき true", () => {
+    const output: ApplyAllForAppOutput = {
+      phases: [
+        {
+          phase: "Schema",
+          results: [
+            {
+              domain: "schema",
+              success: false,
+              error: new Error("boom"),
+              skipped: false,
+            },
+          ],
+        },
+      ],
+      deployed: false,
+    };
+    expect(shouldFailApply(output)).toBe(true);
+  });
+
+  it("全ドメインが not-found skip でデプロイ対象ゼロのとき false", () => {
+    const output: ApplyAllForAppOutput = {
+      phases: [
+        {
+          phase: "Views & Customization",
+          results: [
+            {
+              domain: "customize",
+              success: false,
+              error: new Error("not found"),
+              skipped: true,
+              skipReason: "not-found",
+            },
+          ],
+        },
+      ],
+      deployed: false,
+    };
+    expect(shouldFailApply(output)).toBe(false);
+  });
+
+  it("aborted skip のみでデプロイ対象ゼロのとき false", () => {
+    const output: ApplyAllForAppOutput = {
+      phases: [
+        {
+          phase: "Seed Data",
+          results: [
+            {
+              domain: "seed",
+              success: false,
+              error: new Error("skipped"),
+              skipped: true,
+              skipReason: "aborted",
+            },
+          ],
+        },
+      ],
+      deployed: false,
+    };
+    expect(shouldFailApply(output)).toBe(false);
+  });
+
+  it("Phase 2-4 に success があるのに未デプロイのとき true", () => {
+    const output: ApplyAllForAppOutput = {
+      phases: [deployableSuccess],
+      deployed: false,
+    };
+    expect(shouldFailApply(output)).toBe(true);
+  });
+
+  it("Phase 2-4 に success がありデプロイ済みのとき false", () => {
+    const output: ApplyAllForAppOutput = {
+      phases: [deployableSuccess],
+      deployed: true,
+    };
+    expect(shouldFailApply(output)).toBe(false);
+  });
+
+  it("Schema/Seed のみ success（Phase 2-4 success なし）で未デプロイでも false", () => {
+    const output: ApplyAllForAppOutput = {
+      phases: [
+        { phase: "Schema", results: [{ domain: "schema", success: true }] },
+        { phase: "Seed Data", results: [{ domain: "seed", success: true }] },
+      ],
+      deployed: false,
+    };
+    expect(shouldFailApply(output)).toBe(false);
   });
 });

--- a/src/cli/commands/apply.ts
+++ b/src/cli/commands/apply.ts
@@ -39,6 +39,34 @@ type ApplyCliValues = MultiAppCliValues & {
   "dry-run"?: boolean;
 };
 
+/**
+ * Determines whether the apply run should set a non-zero exit code.
+ *
+ * Skipped domains (config file not found, or aborted) are NOT treated as
+ * failures. The exit code is non-zero only when:
+ *   - a real failure occurred (a non-success, non-skipped task), or
+ *   - there was a deployable change (a Phase 2-4 success, mirroring the
+ *     `needsDeploy` condition in applyAllForApp) but deploy did not complete.
+ *
+ * When every domain is skipped (e.g. all config files missing), there is no
+ * deployable success, so a `deployed === false` does not flip the exit code.
+ */
+export function shouldFailApply(
+  output: import("@/core/application/applyAll/applyAllForApp").ApplyAllForAppOutput,
+): boolean {
+  const allResults = output.phases.flatMap((pr) => pr.results);
+  const hasRealFailure = allResults.some((r) => !r.success && !r.skipped);
+
+  const hasDeployableSuccess = output.phases.some(
+    (pr) =>
+      pr.phase !== "Schema" &&
+      pr.phase !== "Seed Data" &&
+      pr.results.some((r) => r.success),
+  );
+
+  return hasRealFailure || (hasDeployableSuccess && !output.deployed);
+}
+
 async function runApplyAll(
   cliConfig: {
     baseUrl: string;
@@ -119,9 +147,10 @@ async function runApplyAll(
     containers,
     customizeBasePath,
   });
+  // Skipped domains (aborted or not-found) are not counted as failures.
   const applyFailCount = output.phases
     .flatMap((pr) => pr.results)
-    .filter((r) => !r.success).length;
+    .filter((r) => !r.success && !r.skipped).length;
   as.stop(
     `Apply complete.${applyFailCount > 0 ? ` (${applyFailCount} failed)` : ""}`,
   );
@@ -130,13 +159,7 @@ async function runApplyAll(
   printApplyAllResults(output);
 
   // Set non-zero exit code for CI/CD pipelines.
-  // Triggered when any domain failed/skipped OR deploy was not completed.
-  // When needsDeploy is false (no Phase 2-4 successes), deployed=false
-  // but hasFailures is also true, so the condition is correct.
-  const hasFailures = output.phases
-    .flatMap((pr) => pr.results)
-    .some((r) => !r.success);
-  if (hasFailures || !output.deployed) {
+  if (shouldFailApply(output)) {
     process.exitCode = 1;
   }
 }

--- a/src/core/application/applyAll/__tests__/applyAllForApp.test.ts
+++ b/src/core/application/applyAll/__tests__/applyAllForApp.test.ts
@@ -5,6 +5,8 @@ import {
   SystemErrorCode,
   UnauthenticatedError,
   UnauthenticatedErrorCode,
+  ValidationError,
+  ValidationErrorCode,
 } from "@/core/application/error";
 import {
   type ApplyAllForAppInput,
@@ -523,5 +525,146 @@ describe("applyAllForApp", () => {
         }
       }
     }
+  });
+
+  function notFound(message: string): ValidationError {
+    return new ValidationError(ValidationErrorCode.ConfigFileNotFound, message);
+  }
+
+  describe("config-file-not-found graceful skip", () => {
+    it("schema が not-found のとき abort せず後続フェーズが継続し最終 deploy まで走ること", async () => {
+      setupAllMocksToSucceed();
+      vi.mocked(executeMigration).mockRejectedValue(
+        notFound("Schema file not found"),
+      );
+
+      const output = await applyAllForApp(baseArgs);
+
+      const schema = output.phases[0].results[0];
+      expect(schema.success).toBe(false);
+      if (!schema.success) {
+        expect(schema.skipped).toBe(true);
+        expect(schema.skipReason).toBe("not-found");
+      }
+
+      // Subsequent phases continue (not aborted)
+      for (const phase of output.phases.slice(1, 4)) {
+        for (const result of phase.results) {
+          expect(result.success).toBe(true);
+        }
+      }
+      expect(output.phases[4].results[0].success).toBe(true);
+
+      // Phase 2-4 had successes, so the batch deploy runs
+      expect(output.deployed).toBe(true);
+    });
+
+    it("schema の非 not-found 失敗は従来通り fatal abort されること（回帰防止）", async () => {
+      setupAllMocksToSucceed();
+      vi.mocked(executeMigration).mockRejectedValue(
+        new ValidationError(
+          ValidationErrorCode.InvalidInput,
+          "kintone REST API does not support adding fields to an existing subtable",
+        ),
+      );
+
+      const output = await applyAllForApp(baseArgs);
+
+      const schema = output.phases[0].results[0];
+      expect(schema.success).toBe(false);
+      if (!schema.success) {
+        expect(schema.skipped).toBe(false);
+      }
+      // Everything after is aborted
+      for (const phase of output.phases.slice(1)) {
+        for (const result of phase.results) {
+          expect(result.success).toBe(false);
+          if (!result.success) {
+            expect(result.skipped).toBe(true);
+            expect(result.skipReason).toBe("aborted");
+          }
+        }
+      }
+      expect(output.deployed).toBe(false);
+    });
+
+    it("Phase 2-4 ドメインの not-found は skip 扱いで他ドメインは継続すること", async () => {
+      setupAllMocksToSucceed();
+      vi.mocked(applyCustomization).mockRejectedValue(
+        notFound("Customization config file not found"),
+      );
+
+      const output = await applyAllForApp(baseArgs);
+
+      const customize = output.phases[1].results[0];
+      expect(customize.domain).toBe("customize");
+      expect(customize.success).toBe(false);
+      if (!customize.success) {
+        expect(customize.skipped).toBe(true);
+        expect(customize.skipReason).toBe("not-found");
+      }
+      // view still runs
+      expect(output.phases[1].results[1].success).toBe(true);
+      // Deploy still happens for the successful domains
+      expect(output.deployed).toBe(true);
+    });
+
+    it("全14ドメインが not-found のとき全て skipReason=not-found で deploy 対象ゼロになること", async () => {
+      vi.mocked(executeMigration).mockRejectedValue(
+        notFound("Schema file not found"),
+      );
+      vi.mocked(applyCustomization).mockRejectedValue(
+        notFound("Customization config file not found"),
+      );
+      vi.mocked(applyView).mockRejectedValue(
+        notFound("View config file not found"),
+      );
+      vi.mocked(applyFieldPermission).mockRejectedValue(
+        notFound("Field permission config file not found"),
+      );
+      vi.mocked(applyAppPermission).mockRejectedValue(
+        notFound("App permission config file not found"),
+      );
+      vi.mocked(applyRecordPermission).mockRejectedValue(
+        notFound("Record permission config file not found"),
+      );
+      vi.mocked(applyGeneralSettings).mockRejectedValue(
+        notFound("Settings config file not found"),
+      );
+      vi.mocked(applyNotification).mockRejectedValue(
+        notFound("Notification config file not found"),
+      );
+      vi.mocked(applyReport).mockRejectedValue(
+        notFound("Report config file not found"),
+      );
+      vi.mocked(applyAction).mockRejectedValue(
+        notFound("Action config file not found"),
+      );
+      vi.mocked(applyProcessManagement).mockRejectedValue(
+        notFound("Process management config file not found"),
+      );
+      vi.mocked(applyAdminNotes).mockRejectedValue(
+        notFound("Admin notes config file not found"),
+      );
+      vi.mocked(applyPlugin).mockRejectedValue(
+        notFound("Plugin config file not found"),
+      );
+      vi.mocked(upsertSeed).mockRejectedValue(notFound("Seed file not found"));
+
+      const output = await applyAllForApp(baseArgs);
+
+      const allResults = output.phases.flatMap((p) => p.results);
+      expect(allResults).toHaveLength(14);
+      for (const result of allResults) {
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(result.skipped).toBe(true);
+          expect(result.skipReason).toBe("not-found");
+        }
+      }
+      // No deployable success -> no batch deploy
+      expect(output.deployed).toBe(false);
+      expect(output.deployError).toBeUndefined();
+    });
   });
 });

--- a/src/core/application/applyAll/applyAllForApp.ts
+++ b/src/core/application/applyAll/applyAllForApp.ts
@@ -4,6 +4,7 @@ import { applyAppPermission } from "@/core/application/appPermission/applyAppPer
 import type { ApplyAllContainers } from "@/core/application/container/applyAll";
 import { applyCustomization } from "@/core/application/customization/applyCustomization";
 import {
+  isConfigFileNotFoundError,
   isFatalError,
   SystemError,
   SystemErrorCode,
@@ -50,6 +51,10 @@ export type ApplyTaskResult =
       success: false;
       error: Error;
       skipped: boolean;
+      // Meaningful only when skipped is true.
+      // "aborted": skipped because an upstream fatal error aborted the run.
+      // "not-found": skipped because the domain's config file does not exist.
+      skipReason?: "aborted" | "not-found";
     }>;
 
 export type ApplyPhaseResult = Readonly<{
@@ -223,6 +228,7 @@ function buildSkippedPhaseResult(
       success: false as const,
       error: skipError,
       skipped: true,
+      skipReason: "aborted" as const,
     })),
   };
 }
@@ -246,8 +252,21 @@ async function executeSchemaPhase(
       await deployApp({ container: containers.schema });
       results.push({ domain: task.domain, success: true });
     } catch (error) {
-      // Schema phase failure is always fatal regardless of isFatalError check.
-      // Without a deployed schema, subsequent phases cannot function correctly.
+      // A missing schema config file is a graceful skip, not a failure: the
+      // schema phase is not aborted and subsequent phases continue.
+      if (isConfigFileNotFoundError(error)) {
+        results.push({
+          domain: task.domain,
+          success: false,
+          error,
+          skipped: true,
+          skipReason: "not-found",
+        });
+        continue;
+      }
+      // Any other schema phase failure is always fatal regardless of the
+      // isFatalError check. Without a deployed schema, subsequent phases
+      // cannot function correctly.
       const err = toError(error);
       results.push({
         domain: task.domain,
@@ -275,6 +294,7 @@ async function executeStandardPhase(
         success: false,
         error: createSkipError(state),
         skipped: true,
+        skipReason: "aborted",
       });
       continue;
     }
@@ -283,6 +303,17 @@ async function executeStandardPhase(
       await task.run();
       results.push({ domain: task.domain, success: true });
     } catch (error) {
+      // A missing config file is a graceful skip, not a failure.
+      if (isConfigFileNotFoundError(error)) {
+        results.push({
+          domain: task.domain,
+          success: false,
+          error,
+          skipped: true,
+          skipReason: "not-found",
+        });
+        continue;
+      }
       const err = toError(error);
       results.push({
         domain: task.domain,

--- a/src/core/application/applyFromConfigBase.ts
+++ b/src/core/application/applyFromConfigBase.ts
@@ -15,7 +15,7 @@ export async function applyFromConfig<TParsed, TRemote>(
   const result = await config.getStorage();
   if (!result.exists) {
     throw new ValidationError(
-      ValidationErrorCode.InvalidInput,
+      ValidationErrorCode.ConfigFileNotFound,
       config.notFoundMessage,
     );
   }

--- a/src/core/application/customization/applyCustomization.ts
+++ b/src/core/application/customization/applyCustomization.ts
@@ -65,7 +65,7 @@ export async function applyCustomization({
   const result = await container.customizationStorage.get();
   if (!result.exists) {
     throw new ValidationError(
-      ValidationErrorCode.InvalidInput,
+      ValidationErrorCode.ConfigFileNotFound,
       "Customization config file not found",
     );
   }

--- a/src/core/application/error.ts
+++ b/src/core/application/error.ts
@@ -131,6 +131,7 @@ export function isForbiddenError(error: unknown): error is ForbiddenError {
 
 export const ValidationErrorCode = {
   InvalidInput: "INVALID_INPUT",
+  ConfigFileNotFound: "CONFIG_FILE_NOT_FOUND",
 } as const;
 export type ValidationErrorCode =
   (typeof ValidationErrorCode)[keyof typeof ValidationErrorCode];
@@ -149,6 +150,20 @@ export class ValidationError extends ApplicationError {
 
 export function isValidationError(error: unknown): error is ValidationError {
   return error instanceof ValidationError;
+}
+
+/**
+ * Determines whether an error indicates that a configuration file does not
+ * exist. Used by the apply orchestration and CLI to treat a missing config
+ * file as a graceful skip (not a failure) without relying on message strings.
+ */
+export function isConfigFileNotFoundError(
+  error: unknown,
+): error is ValidationError {
+  return (
+    isValidationError(error) &&
+    error.code === ValidationErrorCode.ConfigFileNotFound
+  );
 }
 
 export const SystemErrorCode = {

--- a/src/core/application/formSchema/executeMigration.ts
+++ b/src/core/application/formSchema/executeMigration.ts
@@ -60,7 +60,7 @@ export async function executeMigration({
   const result = await container.schemaStorage.get();
   if (!result.exists) {
     throw new ValidationError(
-      ValidationErrorCode.InvalidInput,
+      ValidationErrorCode.ConfigFileNotFound,
       "Schema file not found",
     );
   }

--- a/src/core/application/notification/applyNotification.ts
+++ b/src/core/application/notification/applyNotification.ts
@@ -17,7 +17,7 @@ export async function applyNotification({
   const result = await container.notificationStorage.get();
   if (!result.exists) {
     throw new ValidationError(
-      ValidationErrorCode.InvalidInput,
+      ValidationErrorCode.ConfigFileNotFound,
       "Notification config file not found",
     );
   }

--- a/src/core/application/plugin/applyPlugin.ts
+++ b/src/core/application/plugin/applyPlugin.ts
@@ -8,7 +8,7 @@ export async function applyPlugin({
   const result = await container.pluginStorage.get();
   if (!result.exists) {
     throw new ValidationError(
-      ValidationErrorCode.InvalidInput,
+      ValidationErrorCode.ConfigFileNotFound,
       "Plugin config file not found",
     );
   }

--- a/src/core/application/processManagement/applyProcessManagement.ts
+++ b/src/core/application/processManagement/applyProcessManagement.ts
@@ -13,7 +13,7 @@ export async function applyProcessManagement({
   const result = await container.processManagementStorage.get();
   if (!result.exists) {
     throw new ValidationError(
-      ValidationErrorCode.InvalidInput,
+      ValidationErrorCode.ConfigFileNotFound,
       "Process management config file not found",
     );
   }

--- a/src/core/application/seedData/upsertSeed.ts
+++ b/src/core/application/seedData/upsertSeed.ts
@@ -15,7 +15,7 @@ export async function upsertSeed({
   const result = await container.seedStorage.get();
   if (!result.exists) {
     throw new ValidationError(
-      ValidationErrorCode.InvalidInput,
+      ValidationErrorCode.ConfigFileNotFound,
       "Seed file not found",
     );
   }

--- a/src/core/application/view/applyView.ts
+++ b/src/core/application/view/applyView.ts
@@ -13,7 +13,7 @@ export async function applyView({
   const result = await container.viewStorage.get();
   if (!result.exists) {
     throw new ValidationError(
-      ValidationErrorCode.InvalidInput,
+      ValidationErrorCode.ConfigFileNotFound,
       "View config file not found",
     );
   }


### PR DESCRIPTION
## Summary
- 設定ファイルが存在しないドメインを failure ではなく `skipped (file not found)` として扱い、exit code に影響させないようにした
- 全14ドメイン（schema 含む）で一貫した挙動に統一
- どのドメインを skip したかを出力の行レベルで区別表示
- `ValidationErrorCode.ConfigFileNotFound` と `isConfigFileNotFoundError` を新設し、メッセージ文字列マッチに依存せず file-not-found を判別
- `ApplyTaskResult` に `skipReason ("aborted" | "not-found")` を導入。not-found skip は後続フェーズを中止しない
- CLI の exitCode 判定（`shouldFailApply`）とスピナーの failCount から not-found skip を除外

## Issue
Closes #179

## Implementation Plan
Based on `.issue/179/plan.md`

## Test plan

### デプロイ・動作確認方法
CLI ツールのため検証環境のサーバー起動・デプロイは不要。`pnpm dev apply [--dry-run]` で実機確認、`echo $?` で exit code を確認する（`.issue/179/testing.md` 参照）。

### 確認項目
- 設定ファイルを一部だけ置いた状態で apply → 不在ドメインが `skipped (file not found)` 表示、exit code 0
- 全ドメインの設定ファイル不在で apply → exit code 0
- 真の失敗（API エラー等）→ exit code 1
- schema ファイル不在 → graceful skip して後続継続、schema 内容エラー → 従来通り fatal abort
- `pnpm test`（2347 pass）/ `pnpm typecheck` / `pnpm lint` グリーン

## Browser Verification
- スキップ理由: Web UI なし（CLI ツールで `dev`/`start` は CLI 起動コマンド、testing.md に画面操作項目なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)