### PR TITLE
improve(apply): 設定ファイルが存在しないドメインを graceful にスキップする

### DIFF
--- a/src/cli/__tests__/applyAllOutput.test.ts
+++ b/src/cli/__tests__/applyAllOutput.test.ts
@@ -268,7 +268,6 @@ describe("printApplyAllResults", () => {
     expect(abortedLine).not.toContain("file not found");
     expect(abortedLine).not.toContain("failed");
 
-    // Summary should show both a failed and a skipped count (1 each).
     const summaryLine = messageLines[messageLines.length - 1];
     expect(summaryLine).toContain("1 failed");
     expect(summaryLine).toContain("1 skipped");
@@ -318,8 +317,8 @@ describe("printApplyAllResults", () => {
     expect(abortedLine).toContain("skipped");
     expect(abortedLine).not.toContain("file not found");
 
-    // ADR-005: the summary aggregates all skip kinds into a single "N skipped"
-    // count and must NOT break them down by kind. Assert the combined count
+    // The summary aggregates all skip kinds into a single "N skipped" count
+    // and must NOT break them down by kind. Assert the combined count
     // ("2 skipped") and that no per-kind breakdown words leak into the summary.
     const summaryLine = messageLines[messageLines.length - 1];
     expect(summaryLine).toContain("2 skipped");

--- a/src/cli/__tests__/applyAllOutput.test.ts
+++ b/src/cli/__tests__/applyAllOutput.test.ts
@@ -223,7 +223,7 @@ describe("printApplyAllResults", () => {
     );
   });
 
-  it("skipped 結果に yellow marker と skipped が表示されること", () => {
+  it("aborted skip 結果に yellow marker と skipped が表示されること", () => {
     const output: ApplyAllForAppOutput = {
       phases: [
         {
@@ -232,8 +232,19 @@ describe("printApplyAllResults", () => {
             {
               domain: "schema",
               success: false,
+              error: new Error("migration failed"),
+              skipped: false,
+            },
+          ],
+        },
+        {
+          phase: "Views & Customization",
+          results: [
+            {
+              domain: "customize",
+              success: false,
               error: new Error("Skipped due to fatal error"),
-              skipped: true,
+              skipped: "aborted",
             },
           ],
         },
@@ -244,18 +255,123 @@ describe("printApplyAllResults", () => {
     printApplyAllResults(output);
 
     const messageCalls = vi.mocked(p.log.message).mock.calls;
-    const schemaLine = messageCalls[0][0] as string;
-    expect(schemaLine).toContain("\u2298");
-    expect(schemaLine).toContain("skipped");
-    expect(schemaLine).not.toContain("failed");
+    const abortedLine = messageCalls[1][0] as string;
+    expect(abortedLine).toContain("\u2298");
+    expect(abortedLine).toContain("skipped");
+    expect(abortedLine).not.toContain("file not found");
+    expect(abortedLine).not.toContain("failed");
 
-    // Summary should show skipped count
+    // Summary should show both a failed and a skipped count
     const summaryLine = messageCalls[messageCalls.length - 1][0] as string;
-    expect(summaryLine).toContain("1");
+    expect(summaryLine).toContain("failed");
     expect(summaryLine).toContain("skipped");
 
-    // logError should NOT be called for skipped results
+    // logError should fire only for the genuine failure (schema)
+    expect(logError).toHaveBeenCalledTimes(1);
+  });
+
+  it("not-found skip \u3068 aborted skip \u304c\u884c\u30ec\u30d9\u30eb\u3067\u533a\u5225\u8868\u793a\u3055\u308c\u308b\u3053\u3068", () => {
+    const output: ApplyAllForAppOutput = {
+      phases: [
+        {
+          phase: "Schema",
+          results: [{ domain: "schema", success: false, skipped: "not-found" }],
+        },
+        {
+          phase: "Views & Customization",
+          results: [
+            {
+              domain: "customize",
+              success: false,
+              error: new Error("Skipped due to fatal error"),
+              skipped: "aborted",
+            },
+          ],
+        },
+      ],
+      deployed: false,
+    };
+
+    printApplyAllResults(output);
+
+    const messageCalls = vi.mocked(p.log.message).mock.calls;
+    const notFoundLine = messageCalls[0][0] as string;
+    const abortedLine = messageCalls[1][0] as string;
+
+    expect(notFoundLine).toContain("skipped (file not found)");
+    expect(abortedLine).toContain("skipped");
+    expect(abortedLine).not.toContain("file not found");
+
+    // Summary aggregates both skips into a single count (no breakdown)
+    const summaryLine = messageCalls[messageCalls.length - 1][0] as string;
+    expect(summaryLine).toContain("2");
+    expect(summaryLine).toContain("skipped");
+
+    // not-found has no error -> logError never fires here
     expect(logError).not.toHaveBeenCalled();
+  });
+
+  it("\u5168\u30c9\u30e1\u30a4\u30f3\u304c not-found skip \u306e\u3068\u304d\u4e2d\u7acb\u6587\u8a00\u304c\u8868\u793a\u3055\u308c 'Not deployed due to errors.' \u306f\u51fa\u306a\u3044\u3053\u3068", () => {
+    const output: ApplyAllForAppOutput = {
+      phases: [
+        {
+          phase: "Schema",
+          results: [{ domain: "schema", success: false, skipped: "not-found" }],
+        },
+        {
+          phase: "Views & Customization",
+          results: [
+            { domain: "customize", success: false, skipped: "not-found" },
+            { domain: "view", success: false, skipped: "not-found" },
+          ],
+        },
+      ],
+      deployed: false,
+    };
+
+    printApplyAllResults(output);
+
+    expect(p.log.info).toHaveBeenCalledWith(
+      "No config files found. Nothing to apply.",
+    );
+    expect(p.log.warn).not.toHaveBeenCalledWith("Not deployed due to errors.");
+  });
+
+  it("aborted skip \u6df7\u5728\uff08failed > 0\uff09\u306e\u3068\u304d\u306f\u4e2d\u7acb\u6587\u8a00\u3067\u306f\u306a\u304f 'Not deployed due to errors.' \u304c\u7dad\u6301\u3055\u308c\u308b\u3053\u3068", () => {
+    const output: ApplyAllForAppOutput = {
+      phases: [
+        {
+          phase: "Schema",
+          results: [
+            {
+              domain: "schema",
+              success: false,
+              error: new Error("migration failed"),
+              skipped: false,
+            },
+          ],
+        },
+        {
+          phase: "Views & Customization",
+          results: [
+            {
+              domain: "customize",
+              success: false,
+              error: new Error("Skipped due to fatal error"),
+              skipped: "aborted",
+            },
+          ],
+        },
+      ],
+      deployed: false,
+    };
+
+    printApplyAllResults(output);
+
+    expect(p.log.warn).toHaveBeenCalledWith("Not deployed due to errors.");
+    expect(p.log.info).not.toHaveBeenCalledWith(
+      "No config files found. Nothing to apply.",
+    );
   });
 
   it("deployed が false で deployError がある場合にエラー詳細が表示されること", () => {

--- a/src/cli/__tests__/applyAllOutput.test.ts
+++ b/src/cli/__tests__/applyAllOutput.test.ts
@@ -431,4 +431,22 @@ describe("printApplyAllResults", () => {
     const summaryLine = messageCalls[messageCalls.length - 1][0] as string;
     expect(summaryLine).toContain("No domains processed");
   });
+
+  it("空の phases（skipped === 0）のときは中立文言には入らず 'Not deployed due to errors.' が出ること", () => {
+    // skipped === 0 boundary: phases are empty, so succeeded/failed/skipped
+    // are all 0. The neutral message guard requires skipped > 0, so this
+    // case must NOT emit "No config files found. Nothing to apply." and
+    // instead falls through to the succeeded === 0 branch.
+    const output: ApplyAllForAppOutput = {
+      phases: [],
+      deployed: false,
+    };
+
+    printApplyAllResults(output);
+
+    expect(p.log.info).not.toHaveBeenCalledWith(
+      "No config files found. Nothing to apply.",
+    );
+    expect(p.log.warn).toHaveBeenCalledWith("Not deployed due to errors.");
+  });
 });

--- a/src/cli/__tests__/applyAllOutput.test.ts
+++ b/src/cli/__tests__/applyAllOutput.test.ts
@@ -254,17 +254,24 @@ describe("printApplyAllResults", () => {
 
     printApplyAllResults(output);
 
-    const messageCalls = vi.mocked(p.log.message).mock.calls;
-    const abortedLine = messageCalls[1][0] as string;
+    // p.log.message is called once per task row (phase headers use p.log.step),
+    // so find the row by its domain display name instead of a positional index
+    // to stay robust against phase-structure changes.
+    const messageLines = vi
+      .mocked(p.log.message)
+      .mock.calls.map((call) => call[0] as string);
+    const abortedLine = messageLines.find((line) =>
+      line.includes("Customization"),
+    ) as string;
     expect(abortedLine).toContain("\u2298");
     expect(abortedLine).toContain("skipped");
     expect(abortedLine).not.toContain("file not found");
     expect(abortedLine).not.toContain("failed");
 
-    // Summary should show both a failed and a skipped count
-    const summaryLine = messageCalls[messageCalls.length - 1][0] as string;
-    expect(summaryLine).toContain("failed");
-    expect(summaryLine).toContain("skipped");
+    // Summary should show both a failed and a skipped count (1 each).
+    const summaryLine = messageLines[messageLines.length - 1];
+    expect(summaryLine).toContain("1 failed");
+    expect(summaryLine).toContain("1 skipped");
 
     // logError should fire only for the genuine failure (schema)
     expect(logError).toHaveBeenCalledTimes(1);
@@ -294,18 +301,31 @@ describe("printApplyAllResults", () => {
 
     printApplyAllResults(output);
 
-    const messageCalls = vi.mocked(p.log.message).mock.calls;
-    const notFoundLine = messageCalls[0][0] as string;
-    const abortedLine = messageCalls[1][0] as string;
+    // p.log.message is called once per task row (phase headers use p.log.step),
+    // so find each row by its domain display name instead of a positional index
+    // to stay robust against phase-structure changes.
+    const messageLines = vi
+      .mocked(p.log.message)
+      .mock.calls.map((call) => call[0] as string);
+    const notFoundLine = messageLines.find((line) =>
+      line.includes("Schema"),
+    ) as string;
+    const abortedLine = messageLines.find((line) =>
+      line.includes("Customization"),
+    ) as string;
 
     expect(notFoundLine).toContain("skipped (file not found)");
     expect(abortedLine).toContain("skipped");
     expect(abortedLine).not.toContain("file not found");
 
-    // Summary aggregates both skips into a single count (no breakdown)
-    const summaryLine = messageCalls[messageCalls.length - 1][0] as string;
-    expect(summaryLine).toContain("2");
-    expect(summaryLine).toContain("skipped");
+    // ADR-005: the summary aggregates all skip kinds into a single "N skipped"
+    // count and must NOT break them down by kind. Assert the combined count
+    // ("2 skipped") and that no per-kind breakdown words leak into the summary.
+    const summaryLine = messageLines[messageLines.length - 1];
+    expect(summaryLine).toContain("2 skipped");
+    expect(summaryLine).not.toContain("not-found");
+    expect(summaryLine).not.toContain("file not found");
+    expect(summaryLine).not.toContain("aborted");
 
     // not-found has no error -> logError never fires here
     expect(logError).not.toHaveBeenCalled();

--- a/src/cli/applyAllOutput.ts
+++ b/src/cli/applyAllOutput.ts
@@ -30,7 +30,10 @@ function formatTaskResult(result: ApplyTaskResult): string {
   if (result.success) {
     return `  ${pc.green("\u2713")} ${name}`;
   }
-  if (result.skipped) {
+  if (result.skipped === "not-found") {
+    return `  ${pc.yellow("\u2298")} ${name} ${pc.dim("\u2014")} ${pc.yellow("skipped (file not found)")}`;
+  }
+  if (result.skipped === "aborted") {
     return `  ${pc.yellow("\u2298")} ${name} ${pc.dim("\u2014")} ${pc.yellow("skipped")}`;
   }
   return `  ${pc.red("\u2717")} ${name} ${pc.dim("\u2014")} ${pc.red(`failed (${formatErrorForDisplay(result.error)})`)}`;
@@ -69,6 +72,11 @@ export function printApplyAllResults(output: ApplyAllForAppOutput): void {
     p.log.warn(
       `Deployment failed: ${formatErrorForDisplay(output.deployError)}`,
     );
+  } else if (succeeded === 0 && failed === 0 && skipped > 0) {
+    // All processed domains were skipped (only "not-found" can satisfy
+    // failed === 0; aborted skips would set failed > 0 via the failing
+    // domain that triggered the abort). Nothing to deploy and no real error.
+    p.log.info("No config files found. Nothing to apply.");
   } else if (succeeded === 0) {
     p.log.warn("Not deployed due to errors.");
   } else if (failed > 0 || skipped > 0) {

--- a/src/cli/commands/__tests__/apply.test.ts
+++ b/src/cli/commands/__tests__/apply.test.ts
@@ -537,6 +537,41 @@ describe("apply command", () => {
     expect(process.exitCode).toBeUndefined();
   });
 
+  it("success がありつつ deploy 不要 (deployed:false・deployError なし) の場合は exitCode が 1 にならないこと", async () => {
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          singleApp: (app: AppEntry, config: ProjectConfig) => Promise<void>;
+        },
+      ) => {
+        await handlers.singleApp(mockApp, mockProjectConfig);
+      },
+    );
+    vi.mocked(p.confirm).mockResolvedValueOnce(true);
+    // At least one success, but no deploy was needed (deployed:false) and no
+    // deployError. Under the old `!output.deployed` rule this would have wrongly
+    // raised exitCode to 1; the new `hasFailures || output.deployError` rule
+    // must keep it unset.
+    vi.mocked(applyAllForApp).mockResolvedValueOnce({
+      phases: [
+        {
+          phase: "Schema",
+          results: [{ domain: "schema", success: false, skipped: "not-found" }],
+        },
+        {
+          phase: "Seed Data",
+          results: [{ domain: "seed", success: true }],
+        },
+      ],
+      deployed: false,
+    });
+
+    await applyCommand.run({ values: {} } as never);
+
+    expect(process.exitCode).toBeUndefined();
+  });
+
   it("一部 success だが末尾 deploy が失敗した場合は exitCode が 1 になること", async () => {
     vi.mocked(routeMultiApp).mockImplementationOnce(
       async (

--- a/src/cli/commands/__tests__/apply.test.ts
+++ b/src/cli/commands/__tests__/apply.test.ts
@@ -502,4 +502,115 @@ describe("apply command", () => {
 
     expect(process.exitCode).toBe(1);
   });
+
+  it("全ドメインが not-found skip の場合は exitCode が 1 にならないこと", async () => {
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          singleApp: (app: AppEntry, config: ProjectConfig) => Promise<void>;
+        },
+      ) => {
+        await handlers.singleApp(mockApp, mockProjectConfig);
+      },
+    );
+    vi.mocked(p.confirm).mockResolvedValueOnce(true);
+    vi.mocked(applyAllForApp).mockResolvedValueOnce({
+      phases: [
+        {
+          phase: "Schema",
+          results: [{ domain: "schema", success: false, skipped: "not-found" }],
+        },
+        {
+          phase: "Views & Customization",
+          results: [
+            { domain: "customize", success: false, skipped: "not-found" },
+            { domain: "view", success: false, skipped: "not-found" },
+          ],
+        },
+      ],
+      deployed: false,
+    });
+
+    await applyCommand.run({ values: {} } as never);
+
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("一部 success だが末尾 deploy が失敗した場合は exitCode が 1 になること", async () => {
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          singleApp: (app: AppEntry, config: ProjectConfig) => Promise<void>;
+        },
+      ) => {
+        await handlers.singleApp(mockApp, mockProjectConfig);
+      },
+    );
+    vi.mocked(p.confirm).mockResolvedValueOnce(true);
+    vi.mocked(applyAllForApp).mockResolvedValueOnce({
+      phases: [
+        {
+          phase: "Schema",
+          results: [{ domain: "schema", success: false, skipped: "not-found" }],
+        },
+        {
+          phase: "Views & Customization",
+          results: [{ domain: "customize", success: true }],
+        },
+      ],
+      deployed: false,
+      deployError: new Error("Deploy failed"),
+    });
+
+    await applyCommand.run({ values: {} } as never);
+
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("aborted skip がある場合は exitCode が 1 になること", async () => {
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          singleApp: (app: AppEntry, config: ProjectConfig) => Promise<void>;
+        },
+      ) => {
+        await handlers.singleApp(mockApp, mockProjectConfig);
+      },
+    );
+    vi.mocked(p.confirm).mockResolvedValueOnce(true);
+    vi.mocked(applyAllForApp).mockResolvedValueOnce({
+      phases: [
+        {
+          phase: "Schema",
+          results: [
+            {
+              domain: "schema",
+              success: false,
+              error: new Error("fail"),
+              skipped: false,
+            },
+          ],
+        },
+        {
+          phase: "Views & Customization",
+          results: [
+            {
+              domain: "customize",
+              success: false,
+              error: new Error("Skipped due to fatal error"),
+              skipped: "aborted",
+            },
+          ],
+        },
+      ],
+      deployed: false,
+    });
+
+    await applyCommand.run({ values: {} } as never);
+
+    expect(process.exitCode).toBe(1);
+  });
 });

--- a/src/cli/commands/__tests__/apply.test.ts
+++ b/src/cli/commands/__tests__/apply.test.ts
@@ -604,6 +604,94 @@ describe("apply command", () => {
     expect(process.exitCode).toBe(1);
   });
 
+  it("not-found skip は spinner の失敗カウント (N failed) に含まれないこと", async () => {
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          singleApp: (app: AppEntry, config: ProjectConfig) => Promise<void>;
+        },
+      ) => {
+        await handlers.singleApp(mockApp, mockProjectConfig);
+      },
+    );
+    vi.mocked(p.confirm).mockResolvedValueOnce(true);
+    // One genuine failure (counts as failed) plus two not-found skips (must NOT
+    // count as failed). If applyFailCount regressed to plain `!r.success`
+    // (without the `r.skipped !== "not-found"` exclusion) the stop message would
+    // read "(3 failed)" and this assertion would fail.
+    vi.mocked(applyAllForApp).mockResolvedValueOnce({
+      phases: [
+        {
+          phase: "Schema",
+          results: [{ domain: "schema", success: false, skipped: "not-found" }],
+        },
+        {
+          phase: "Views & Customization",
+          results: [
+            {
+              domain: "customize",
+              success: false,
+              error: new Error("fail"),
+              skipped: false,
+            },
+            { domain: "view", success: false, skipped: "not-found" },
+          ],
+        },
+      ],
+      deployed: false,
+    });
+
+    await applyCommand.run({ values: {} } as never);
+
+    // p.spinner() is called twice: [0] = diff spinner, [1] = apply spinner.
+    // Inspect the apply spinner's stop() argument (the message string).
+    const applySpinner = vi.mocked(p.spinner).mock.results[1]
+      .value as ReturnType<typeof p.spinner>;
+    const stopMessage = vi.mocked(applySpinner.stop).mock.calls[0][0] as string;
+    expect(stopMessage).toContain("(1 failed)");
+    expect(stopMessage).not.toContain("(3 failed)");
+  });
+
+  it("全ドメイン not-found skip のとき spinner に (N failed) が表示されないこと", async () => {
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          singleApp: (app: AppEntry, config: ProjectConfig) => Promise<void>;
+        },
+      ) => {
+        await handlers.singleApp(mockApp, mockProjectConfig);
+      },
+    );
+    vi.mocked(p.confirm).mockResolvedValueOnce(true);
+    // All not-found skips. If applyFailCount regressed to plain `!r.success`
+    // this would read "(2 failed)"; with the exclusion it must omit "failed".
+    vi.mocked(applyAllForApp).mockResolvedValueOnce({
+      phases: [
+        {
+          phase: "Schema",
+          results: [{ domain: "schema", success: false, skipped: "not-found" }],
+        },
+        {
+          phase: "Views & Customization",
+          results: [
+            { domain: "customize", success: false, skipped: "not-found" },
+          ],
+        },
+      ],
+      deployed: false,
+    });
+
+    await applyCommand.run({ values: {} } as never);
+
+    const applySpinner = vi.mocked(p.spinner).mock.results[1]
+      .value as ReturnType<typeof p.spinner>;
+    const stopMessage = vi.mocked(applySpinner.stop).mock.calls[0][0] as string;
+    expect(stopMessage).toBe("Apply complete.");
+    expect(stopMessage).not.toContain("failed");
+  });
+
   it("aborted skip がある場合は exitCode が 1 になること", async () => {
     vi.mocked(routeMultiApp).mockImplementationOnce(
       async (

--- a/src/cli/commands/apply.ts
+++ b/src/cli/commands/apply.ts
@@ -121,7 +121,7 @@ async function runApplyAll(
   });
   const applyFailCount = output.phases
     .flatMap((pr) => pr.results)
-    .filter((r) => !r.success).length;
+    .filter((r) => !r.success && r.skipped !== "not-found").length;
   as.stop(
     `Apply complete.${applyFailCount > 0 ? ` (${applyFailCount} failed)` : ""}`,
   );
@@ -130,13 +130,16 @@ async function runApplyAll(
   printApplyAllResults(output);
 
   // Set non-zero exit code for CI/CD pipelines.
-  // Triggered when any domain failed/skipped OR deploy was not completed.
-  // When needsDeploy is false (no Phase 2-4 successes), deployed=false
-  // but hasFailures is also true, so the condition is correct.
+  // Triggered when any domain genuinely failed (execution failure or aborted
+  // skip) or when a required deploy failed. A "not-found" skip (config file
+  // absent) is not a failure and never raises the exit code. A deploy that was
+  // simply not needed (no Phase 2-4 successes, so deployError is undefined) is
+  // not an error either, so we check output.deployError instead of
+  // !output.deployed.
   const hasFailures = output.phases
     .flatMap((pr) => pr.results)
-    .some((r) => !r.success);
-  if (hasFailures || !output.deployed) {
+    .some((r) => !r.success && r.skipped !== "not-found");
+  if (hasFailures || output.deployError) {
     process.exitCode = 1;
   }
 }

--- a/src/core/application/applyAll/__tests__/applyAllForApp.test.ts
+++ b/src/core/application/applyAll/__tests__/applyAllForApp.test.ts
@@ -5,6 +5,8 @@ import {
   SystemErrorCode,
   UnauthenticatedError,
   UnauthenticatedErrorCode,
+  ValidationError,
+  ValidationErrorCode,
 } from "@/core/application/error";
 import {
   type ApplyAllForAppInput,
@@ -732,5 +734,28 @@ describe("applyAllForApp", () => {
     }
 
     expect(output.deployed).toBe(false);
+  });
+
+  it("probe で exists:true 後に run が not-found ValidationError を throw した場合（TOCTOU）は not-found skip ではなく skipped:false の failure になること", async () => {
+    setupAllMocksToSucceed();
+    // TOCTOU: the probe sees the config file (exists:true), but it is deleted
+    // before run(), so the usecase throws a not-found ValidationError. The
+    // orchestrator only converts probe exists:false into a not-found skip;
+    // an in-run not-found throw stays a regular failure (skipped:false).
+    vi.mocked(applyCustomization).mockRejectedValue(
+      new ValidationError(
+        ValidationErrorCode.InvalidInput,
+        "Customization config file not found",
+      ),
+    );
+
+    const output = await applyAllForApp(baseArgs);
+
+    const customizeResult = output.phases[1].results[0];
+    expect(customizeResult.domain).toBe("customize");
+    expect(customizeResult.success).toBe(false);
+    if (!customizeResult.success) {
+      expect(customizeResult.skipped).toBe(false);
+    }
   });
 });

--- a/src/core/application/applyAll/__tests__/applyAllForApp.test.ts
+++ b/src/core/application/applyAll/__tests__/applyAllForApp.test.ts
@@ -45,12 +45,76 @@ import { applyReport } from "@/core/application/report/applyReport";
 import { upsertSeed } from "@/core/application/seedData/upsertSeed";
 import { applyView } from "@/core/application/view/applyView";
 
-const stubContainers = {} as ApplyAllContainers;
-
-const baseArgs: ApplyAllForAppInput = {
-  containers: stubContainers,
-  customizeBasePath: "apps/test-app",
+// Maps each ApplyDomain to the container key and storage property the
+// orchestrator probes for existence (mirrors buildPhases in applyAllForApp).
+const storageProbeMap: Record<
+  ApplyDomain,
+  { containerKey: keyof ApplyAllContainers; storageProp: string }
+> = {
+  schema: { containerKey: "schema", storageProp: "schemaStorage" },
+  customize: {
+    containerKey: "customization",
+    storageProp: "customizationStorage",
+  },
+  view: { containerKey: "view", storageProp: "viewStorage" },
+  "field-acl": {
+    containerKey: "fieldPermission",
+    storageProp: "fieldPermissionStorage",
+  },
+  "app-acl": {
+    containerKey: "appPermission",
+    storageProp: "appPermissionStorage",
+  },
+  "record-acl": {
+    containerKey: "recordPermission",
+    storageProp: "recordPermissionStorage",
+  },
+  settings: { containerKey: "settings", storageProp: "generalSettingsStorage" },
+  notification: {
+    containerKey: "notification",
+    storageProp: "notificationStorage",
+  },
+  report: { containerKey: "report", storageProp: "reportStorage" },
+  action: { containerKey: "action", storageProp: "actionStorage" },
+  process: { containerKey: "process", storageProp: "processManagementStorage" },
+  "admin-notes": {
+    containerKey: "adminNotes",
+    storageProp: "adminNotesStorage",
+  },
+  plugin: { containerKey: "plugin", storageProp: "pluginStorage" },
+  seed: { containerKey: "seed", storageProp: "seedStorage" },
 };
+
+/**
+ * Builds containers whose storage `get()` returns `{ exists: true }` for every
+ * domain. Pass `missing` to make specific domains report `{ exists: false }`.
+ */
+function makeContainers(
+  missing: ReadonlySet<ApplyDomain> = new Set(),
+): ApplyAllContainers {
+  const containers = {} as Record<string, Record<string, unknown>>;
+  for (const domain of Object.keys(storageProbeMap) as ApplyDomain[]) {
+    const { containerKey, storageProp } = storageProbeMap[domain];
+    const exists = !missing.has(domain);
+    containers[containerKey] = {
+      ...(containers[containerKey] ?? {}),
+      [storageProp]: {
+        get: async () =>
+          exists ? { exists: true, content: "stub" } : { exists: false },
+      },
+    };
+  }
+  return containers as unknown as ApplyAllContainers;
+}
+
+function makeArgs(missing?: ReadonlySet<ApplyDomain>): ApplyAllForAppInput {
+  return {
+    containers: makeContainers(missing),
+    customizeBasePath: "apps/test-app",
+  };
+}
+
+const baseArgs: ApplyAllForAppInput = makeArgs();
 
 function setupAllMocksToSucceed(): void {
   vi.mocked(executeMigration).mockResolvedValue(undefined);
@@ -171,13 +235,15 @@ describe("applyAllForApp", () => {
       expect(output.phases[0].results[0].skipped).toBe(false);
     }
 
-    // All subsequent phases should be skipped
+    // All subsequent phases should be skipped (aborted)
     for (const phase of output.phases.slice(1)) {
       for (const result of phase.results) {
         expect(result.success).toBe(false);
-        if (!result.success) {
+        if (!result.success && result.skipped === "aborted") {
           expect(result.error.message).toContain("Skipped due to fatal error");
-          expect(result.skipped).toBe(true);
+        }
+        if (!result.success) {
+          expect(result.skipped).toBe("aborted");
         }
       }
     }
@@ -201,12 +267,12 @@ describe("applyAllForApp", () => {
       expect(output.phases[0].results[0].skipped).toBe(false);
     }
 
-    // All subsequent phases should be skipped
+    // All subsequent phases should be skipped (aborted)
     for (const phase of output.phases.slice(1)) {
       for (const result of phase.results) {
         expect(result.success).toBe(false);
         if (!result.success) {
-          expect(result.skipped).toBe(true);
+          expect(result.skipped).toBe("aborted");
         }
       }
     }
@@ -273,17 +339,19 @@ describe("applyAllForApp", () => {
     }
     expect(phase3.results[1].domain).toBe("app-acl");
     expect(phase3.results[1].success).toBe(false);
-    if (!phase3.results[1].success) {
+    if (!phase3.results[1].success && phase3.results[1].skipped === "aborted") {
       expect(phase3.results[1].error.message).toContain("Skipped");
-      expect(phase3.results[1].skipped).toBe(true);
+    }
+    if (!phase3.results[1].success) {
+      expect(phase3.results[1].skipped).toBe("aborted");
     }
 
-    // Phase 4 and 5 are all skipped
+    // Phase 4 and 5 are all skipped (aborted)
     for (const phase of output.phases.slice(3)) {
       for (const result of phase.results) {
         expect(result.success).toBe(false);
         if (!result.success) {
-          expect(result.skipped).toBe(true);
+          expect(result.skipped).toBe("aborted");
         }
       }
     }
@@ -307,7 +375,7 @@ describe("applyAllForApp", () => {
       expect(phase2.results[0].skipped).toBe(false);
     }
     if (!phase2.results[1].success) {
-      expect(phase2.results[1].skipped).toBe(true);
+      expect(phase2.results[1].skipped).toBe("aborted");
     }
 
     // All Phase 3, 4, 5 are skipped
@@ -514,14 +582,155 @@ describe("applyAllForApp", () => {
       expect(output.phases[1].results[1].skipped).toBe(false);
     }
 
-    // Phase 3+ should be skipped (including Phase 5 Seed)
+    // Phase 3+ should be skipped (aborted, including Phase 5 Seed)
     for (const phase of output.phases.slice(2)) {
       for (const result of phase.results) {
         expect(result.success).toBe(false);
         if (!result.success) {
-          expect(result.skipped).toBe(true);
+          expect(result.skipped).toBe("aborted");
         }
       }
     }
+  });
+
+  it("特定ドメインの設定ファイルが無い場合はそのドメインのみ not-found skip され、他は成功・abort しないこと", async () => {
+    setupAllMocksToSucceed();
+
+    const output = await applyAllForApp(makeArgs(new Set(["view", "report"])));
+
+    const allResults = output.phases.flatMap((ph) => ph.results);
+    for (const result of allResults) {
+      if (result.domain === "view" || result.domain === "report") {
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(result.skipped).toBe("not-found");
+        }
+      } else {
+        expect(result.success).toBe(true);
+      }
+    }
+
+    // not-found skip does not abort: deploy still runs for the successes
+    expect(output.deployed).toBe(true);
+    expect(output.deployError).toBeUndefined();
+  });
+
+  it("schema が not-found skip でも abort せず、Phase 2-4 の success により末尾 deploy が 1 回走ること", async () => {
+    setupAllMocksToSucceed();
+    const deployCount = { count: 0 };
+    vi.mocked(deployApp).mockImplementation(async () => {
+      deployCount.count++;
+    });
+
+    const output = await applyAllForApp(makeArgs(new Set(["schema"])));
+
+    // schema is skipped as not-found
+    const schemaResult = output.phases[0].results[0];
+    expect(schemaResult.success).toBe(false);
+    if (!schemaResult.success) {
+      expect(schemaResult.skipped).toBe("not-found");
+    }
+
+    // Phase 2-4 still succeed
+    expect(output.phases[1].results.every((r) => r.success)).toBe(true);
+
+    // Schema phase does not deploy; only the trailing batch deploy runs once
+    expect(deployCount.count).toBe(1);
+    expect(output.deployed).toBe(true);
+    expect(output.deployError).toBeUndefined();
+  });
+
+  it("schema が not-found skip かつ Phase 2-4 success がゼロの場合は deploy せず deployError も無いこと", async () => {
+    setupAllMocksToSucceed();
+
+    // schema missing + every Phase 2-4 domain missing -> no successes to deploy
+    const output = await applyAllForApp(
+      makeArgs(
+        new Set([
+          "schema",
+          "customize",
+          "view",
+          "field-acl",
+          "app-acl",
+          "record-acl",
+          "settings",
+          "notification",
+          "report",
+          "action",
+          "process",
+          "admin-notes",
+          "plugin",
+        ]),
+      ),
+    );
+
+    expect(output.deployed).toBe(false);
+    expect(output.deployError).toBeUndefined();
+    expect(vi.mocked(deployApp)).not.toHaveBeenCalled();
+  });
+
+  it("全ドメインの設定ファイルが無い場合は全て not-found skip・deploy 無し・deployError 無しになること", async () => {
+    setupAllMocksToSucceed();
+
+    const allDomains = new Set<ApplyDomain>([
+      "schema",
+      "customize",
+      "view",
+      "field-acl",
+      "app-acl",
+      "record-acl",
+      "settings",
+      "notification",
+      "report",
+      "action",
+      "process",
+      "admin-notes",
+      "plugin",
+      "seed",
+    ]);
+
+    const output = await applyAllForApp(makeArgs(allDomains));
+
+    const allResults = output.phases.flatMap((ph) => ph.results);
+    expect(allResults).toHaveLength(14);
+    for (const result of allResults) {
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.skipped).toBe("not-found");
+      }
+    }
+
+    expect(output.deployed).toBe(false);
+    expect(output.deployError).toBeUndefined();
+    expect(vi.mocked(deployApp)).not.toHaveBeenCalled();
+  });
+
+  it("schema ファイルが存在し run が fatal 失敗した場合は schema=failure・後続=aborted（同一出力に not-found と aborted が並ぶ）", async () => {
+    setupAllMocksToSucceed();
+    // schema exists but run fails fatally; mark "view" as not-found
+    vi.mocked(executeMigration).mockRejectedValue(
+      new SystemError(SystemErrorCode.ExternalApiError, "Schema run failed"),
+    );
+
+    const output = await applyAllForApp(makeArgs(new Set(["view"])));
+
+    // schema actually ran and failed -> skipped: false (failure)
+    const schemaResult = output.phases[0].results[0];
+    expect(schemaResult.success).toBe(false);
+    if (!schemaResult.success) {
+      expect(schemaResult.skipped).toBe(false);
+    }
+
+    // Subsequent domains are aborted. view would have been not-found, but the
+    // abort short-circuits before its probe, so it is recorded as aborted.
+    const phase2 = output.phases[1];
+    for (const result of phase2.results) {
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.skipped).toBe("aborted");
+      }
+    }
+
+    expect(output.deployed).toBe(false);
   });
 });

--- a/src/core/application/applyAll/__tests__/applyAllForApp.test.ts
+++ b/src/core/application/applyAll/__tests__/applyAllForApp.test.ts
@@ -758,4 +758,37 @@ describe("applyAllForApp", () => {
       expect(customizeResult.skipped).toBe(false);
     }
   });
+
+  it("標準フェーズで probe が exists:true でも run が内容エラーで失敗する場合は not-found skip ではなく skipped:false の failure になること", async () => {
+    setupAllMocksToSucceed();
+    // AC-4: the config file exists (probe exists:true), but the usecase fails
+    // with an ordinary content error (e.g. parse failure). This stays a regular
+    // failure (skipped:false) and must not be confused with a not-found skip.
+    // It is also non-fatal, so other domains keep running.
+    vi.mocked(applyCustomization).mockRejectedValue(
+      new ValidationError(
+        ValidationErrorCode.InvalidInput,
+        "Customization config is invalid",
+      ),
+    );
+
+    const output = await applyAllForApp(baseArgs);
+
+    // customize ran and failed -> skipped: false (failure), not not-found
+    const customizeResult = output.phases[1].results[0];
+    expect(customizeResult.domain).toBe("customize");
+    expect(customizeResult.success).toBe(false);
+    if (!customizeResult.success) {
+      expect(customizeResult.skipped).toBe(false);
+    }
+
+    // The failure is non-fatal: other domains still succeed and deploy runs
+    const otherResults = output.phases
+      .flatMap((ph) => ph.results)
+      .filter((r) => r.domain !== "customize");
+    for (const result of otherResults) {
+      expect(result.success).toBe(true);
+    }
+    expect(output.deployed).toBe(true);
+  });
 });

--- a/src/core/application/applyAll/__tests__/applyAllForApp.test.ts
+++ b/src/core/application/applyAll/__tests__/applyAllForApp.test.ts
@@ -626,14 +626,12 @@ describe("applyAllForApp", () => {
 
     const output = await applyAllForApp(makeArgs(new Set(["schema"])));
 
-    // schema is skipped as not-found
     const schemaResult = output.phases[0].results[0];
     expect(schemaResult.success).toBe(false);
     if (!schemaResult.success) {
       expect(schemaResult.skipped).toBe("not-found");
     }
 
-    // Phase 2-4 still succeed
     expect(output.phases[1].results.every((r) => r.success)).toBe(true);
 
     // Schema phase does not deploy; only the trailing batch deploy runs once
@@ -761,7 +759,7 @@ describe("applyAllForApp", () => {
 
   it("標準フェーズで probe が exists:true でも run が内容エラーで失敗する場合は not-found skip ではなく skipped:false の failure になること", async () => {
     setupAllMocksToSucceed();
-    // AC-4: the config file exists (probe exists:true), but the usecase fails
+    // The config file exists (probe exists:true), but the usecase fails
     // with an ordinary content error (e.g. parse failure). This stays a regular
     // failure (skipped:false) and must not be confused with a not-found skip.
     // It is also non-fatal, so other domains keep running.

--- a/src/core/application/applyAll/applyAllForApp.ts
+++ b/src/core/application/applyAll/applyAllForApp.ts
@@ -325,6 +325,9 @@ async function executeStandardPhase(
     }
 
     // When the config file is absent, skip gracefully without aborting.
+    // This probe double-reads with the get() inside task.run(), but a shared
+    // domain-agnostic probe structurally guarantees consistent not-found skip
+    // across all domains and the extra I/O is negligible (ADR-001).
     if (!(await task.storageExists())) {
       results.push({
         domain: task.domain,

--- a/src/core/application/applyAll/applyAllForApp.ts
+++ b/src/core/application/applyAll/applyAllForApp.ts
@@ -327,7 +327,7 @@ async function executeStandardPhase(
     // When the config file is absent, skip gracefully without aborting.
     // This probe double-reads with the get() inside task.run(), but a shared
     // domain-agnostic probe structurally guarantees consistent not-found skip
-    // across all domains and the extra I/O is negligible (ADR-001).
+    // across all domains and the extra I/O is negligible.
     if (!(await task.storageExists())) {
       results.push({
         domain: task.domain,

--- a/src/core/application/applyAll/applyAllForApp.ts
+++ b/src/core/application/applyAll/applyAllForApp.ts
@@ -45,11 +45,18 @@ export type ApplyPhaseName =
 
 export type ApplyTaskResult =
   | Readonly<{ domain: ApplyDomain; success: true }>
+  | Readonly<{ domain: ApplyDomain; success: false; skipped: "not-found" }>
   | Readonly<{
       domain: ApplyDomain;
       success: false;
       error: Error;
-      skipped: boolean;
+      skipped: "aborted";
+    }>
+  | Readonly<{
+      domain: ApplyDomain;
+      success: false;
+      error: Error;
+      skipped: false;
     }>;
 
 export type ApplyPhaseResult = Readonly<{
@@ -70,6 +77,7 @@ export type ApplyAllForAppInput = Readonly<{
 
 type ApplyTask = {
   readonly domain: ApplyDomain;
+  readonly storageExists: () => Promise<boolean>;
   readonly run: () => Promise<void>;
 };
 
@@ -87,6 +95,8 @@ function buildPhases(args: ApplyAllForAppInput): readonly PhaseDefinition[] {
       tasks: [
         {
           domain: "schema",
+          storageExists: async () =>
+            (await c.schema.schemaStorage.get()).exists,
           run: async () => {
             await executeMigration({ container: c.schema });
           },
@@ -98,6 +108,8 @@ function buildPhases(args: ApplyAllForAppInput): readonly PhaseDefinition[] {
       tasks: [
         {
           domain: "customize",
+          storageExists: async () =>
+            (await c.customization.customizationStorage.get()).exists,
           run: async () => {
             await applyCustomization({
               container: c.customization,
@@ -107,6 +119,7 @@ function buildPhases(args: ApplyAllForAppInput): readonly PhaseDefinition[] {
         },
         {
           domain: "view",
+          storageExists: async () => (await c.view.viewStorage.get()).exists,
           run: async () => {
             await applyView({ container: c.view });
           },
@@ -118,18 +131,24 @@ function buildPhases(args: ApplyAllForAppInput): readonly PhaseDefinition[] {
       tasks: [
         {
           domain: "field-acl",
+          storageExists: async () =>
+            (await c.fieldPermission.fieldPermissionStorage.get()).exists,
           run: async () => {
             await applyFieldPermission({ container: c.fieldPermission });
           },
         },
         {
           domain: "app-acl",
+          storageExists: async () =>
+            (await c.appPermission.appPermissionStorage.get()).exists,
           run: async () => {
             await applyAppPermission({ container: c.appPermission });
           },
         },
         {
           domain: "record-acl",
+          storageExists: async () =>
+            (await c.recordPermission.recordPermissionStorage.get()).exists,
           run: async () => {
             await applyRecordPermission({ container: c.recordPermission });
           },
@@ -141,42 +160,56 @@ function buildPhases(args: ApplyAllForAppInput): readonly PhaseDefinition[] {
       tasks: [
         {
           domain: "settings",
+          storageExists: async () =>
+            (await c.settings.generalSettingsStorage.get()).exists,
           run: async () => {
             await applyGeneralSettings({ container: c.settings });
           },
         },
         {
           domain: "notification",
+          storageExists: async () =>
+            (await c.notification.notificationStorage.get()).exists,
           run: async () => {
             await applyNotification({ container: c.notification });
           },
         },
         {
           domain: "report",
+          storageExists: async () =>
+            (await c.report.reportStorage.get()).exists,
           run: async () => {
             await applyReport({ container: c.report });
           },
         },
         {
           domain: "action",
+          storageExists: async () =>
+            (await c.action.actionStorage.get()).exists,
           run: async () => {
             await applyAction({ container: c.action });
           },
         },
         {
           domain: "process",
+          storageExists: async () =>
+            (await c.process.processManagementStorage.get()).exists,
           run: async () => {
             await applyProcessManagement({ container: c.process });
           },
         },
         {
           domain: "admin-notes",
+          storageExists: async () =>
+            (await c.adminNotes.adminNotesStorage.get()).exists,
           run: async () => {
             await applyAdminNotes({ container: c.adminNotes });
           },
         },
         {
           domain: "plugin",
+          storageExists: async () =>
+            (await c.plugin.pluginStorage.get()).exists,
           run: async () => {
             await applyPlugin({ container: c.plugin });
           },
@@ -188,6 +221,7 @@ function buildPhases(args: ApplyAllForAppInput): readonly PhaseDefinition[] {
       tasks: [
         {
           domain: "seed",
+          storageExists: async () => (await c.seed.seedStorage.get()).exists,
           run: async () => {
             await upsertSeed({ container: c.seed, input: {} });
           },
@@ -222,7 +256,7 @@ function buildSkippedPhaseResult(
       domain: task.domain,
       success: false as const,
       error: skipError,
-      skipped: true,
+      skipped: "aborted" as const,
     })),
   };
 }
@@ -241,6 +275,17 @@ async function executeSchemaPhase(
 ): Promise<ApplyPhaseResult> {
   const results: ApplyTaskResult[] = [];
   for (const task of phase.tasks) {
+    // When the schema config file is absent, skip gracefully without
+    // deploying or aborting subsequent phases (each domain decides on its own).
+    if (!(await task.storageExists())) {
+      results.push({
+        domain: task.domain,
+        success: false,
+        skipped: "not-found",
+      });
+      continue;
+    }
+
     try {
       await task.run();
       await deployApp({ container: containers.schema });
@@ -274,7 +319,17 @@ async function executeStandardPhase(
         domain: task.domain,
         success: false,
         error: createSkipError(state),
-        skipped: true,
+        skipped: "aborted",
+      });
+      continue;
+    }
+
+    // When the config file is absent, skip gracefully without aborting.
+    if (!(await task.storageExists())) {
+      results.push({
+        domain: task.domain,
+        success: false,
+        skipped: "not-found",
       });
       continue;
     }


### PR DESCRIPTION
## Summary
- 設定ファイルが存在しないドメインを failure ではなく `skipped (file not found)` として扱い、exit code に影響させないようにした
- 「全14ドメインで一貫」を、オーケストレーター `applyAllForApp` が各ユースケース実行前に `storage.get().exists` を probe する**共通の仕組み**で構造的に担保（ドメインごとの分岐なし）
- `ApplyTaskResult.skipped` を `false | "aborted" | "not-found"` の3値判別共用体に変更し、skip 種別を型で区別
- `executeSchemaPhase` / `executeStandardPhase` で not-found を skip（**abort しない**＝部分管理プロジェクトが完走）
- CLI の exit code 判定を `hasFailures || output.deployError` に確定（`!output.deployed` を撤廃）し、not-found skip を失敗カウント・exit code から除外
- not-found / aborted を行レベルで区別表示、全ドメイン not-found（`succeeded===0 && failed===0 && skipped>0`）時は「Not deployed due to errors.」ではなく中立文言を表示

## Issue
Closes #179

## アプローチ（前回 PR #180 からの変更）
前回 attempt は「ユースケースが投げる例外に新サブコード `ConfigFileNotFound` を載せて事後判別」する方式だったが、本 PR は**ゼロベースで再設計**。全ドメインが共通の `StorageResult`（`{exists}`）ポートを持つことを利用し、実行前 probe で判定を1箇所に集約。エラー型・判別関数を増やさず「全ドメイン一貫」を構造的に保証する。判断記録は `.issue/179/adr.md`。

## Implementation Plan
Based on `.issue/179/plan.md`

## Test plan

### デプロイ・動作確認方法
CLI ツールのため検証環境のサーバー起動・デプロイは不要。実機確認は `pnpm dev apply [--dry-run]` を実行し `echo $?` で exit code を確認する（`.issue/179/testing.md` 参照）。

### 確認項目
- 設定ファイルを一部だけ置いた状態で apply → 不在ドメインが `skipped (file not found)` 表示・exit code 0
- 全ドメインの設定ファイル不在で apply → exit code 0・中立文言表示
- schema ファイル不在 → graceful skip して後続継続、Phase 2-4 success があれば末尾 deploy 1回
- 真の失敗（API エラー・内容エラー）→ 従来通り exit code 1
- `pnpm test`（2345 pass）/ `pnpm typecheck`（OK）/ `pnpm lint`（warning 2件は本変更と無関係の既存箇所）

## Browser Verification
- スキップ理由: Web UI なし（`dev`=`tsx src/cli/index.ts` / `start`=`node dist/index.mjs` の CLI 起動コマンド、UI ファイル不在、testing.md に画面操作項目なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)