### PR TITLE
fix(apply): multi-app apply (--all) で per-app のドメイン失敗を fail-fast・status 集計に反映

### DIFF
--- a/src/cli/__tests__/projectConfig.test.ts
+++ b/src/cli/__tests__/projectConfig.test.ts
@@ -134,11 +134,9 @@ describe("runMultiAppWithFailCheck", () => {
   });
 
   it("executor が {ok:false} を返す場合、実体の executeMultiApp 経由で EXECUTION_ERROR の SystemError をスローする", async () => {
-    // Integration path: do NOT mock executeMultiApp's verdict. Delegate to the
-    // real implementation so the full wiring is exercised — executor returns
-    // { ok: false } → executeMultiApp sets status "failed" → hasFailure true →
-    // runMultiAppWithFailCheck throws. This binds the seam the other (mocked)
-    // case leaves untested.
+    // Integration path: use the real executeMultiApp (not the mocked verdict) so
+    // the full wiring { ok: false } → "failed" → throw is exercised. Binds the
+    // seam the other (mocked) case leaves untested.
     const { executeMultiApp: realExecuteMultiApp } = await vi.importActual<
       typeof import("@/core/application/projectConfig/executeMultiApp")
     >("@/core/application/projectConfig/executeMultiApp");

--- a/src/cli/__tests__/projectConfig.test.ts
+++ b/src/cli/__tests__/projectConfig.test.ts
@@ -33,6 +33,7 @@ vi.mock("@/core/application/projectConfig/executeMultiApp", () => ({
 
 import * as p from "@clack/prompts";
 import { executeMultiApp } from "@/core/application/projectConfig/executeMultiApp";
+import { printMultiAppResult } from "../output";
 import {
   runMultiAppWithFailCheck,
   validateExclusiveArgs,
@@ -155,6 +156,13 @@ describe("runMultiAppWithFailCheck", () => {
         code: "EXECUTION_ERROR",
       }),
     );
+
+    // Closes the misclassification gap end-to-end: the result handed to
+    // printMultiAppResult (called before the throw) must mark the app "failed",
+    // not "succeeded" (AC-1, Issue's core "status misclassification").
+    const multiResult = vi.mocked(printMultiAppResult).mock.calls[0][0];
+    expect(multiResult.results[0].status).toBe("failed");
+    expect(multiResult.results[0].status).not.toBe("succeeded");
   });
 
   it("executor が {ok:true} を返す場合、実体の executeMultiApp 経由でスローせず正常完了する", async () => {

--- a/src/cli/__tests__/projectConfig.test.ts
+++ b/src/cli/__tests__/projectConfig.test.ts
@@ -132,6 +132,46 @@ describe("runMultiAppWithFailCheck", () => {
     );
   });
 
+  it("executor が {ok:false} を返す場合、実体の executeMultiApp 経由で EXECUTION_ERROR の SystemError をスローする", async () => {
+    // Integration path: do NOT mock executeMultiApp's verdict. Delegate to the
+    // real implementation so the full wiring is exercised — executor returns
+    // { ok: false } → executeMultiApp sets status "failed" → hasFailure true →
+    // runMultiAppWithFailCheck throws. This binds the seam the other (mocked)
+    // case leaves untested.
+    const { executeMultiApp: realExecuteMultiApp } = await vi.importActual<
+      typeof import("@/core/application/projectConfig/executeMultiApp")
+    >("@/core/application/projectConfig/executeMultiApp");
+    vi.mocked(executeMultiApp).mockImplementation(realExecuteMultiApp);
+
+    const plan = makePlan([makeApp("App1")]);
+
+    await expect(
+      runMultiAppWithFailCheck(plan, async () => ({
+        ok: false,
+        error: new Error("fail"),
+      })),
+    ).rejects.toThrow(
+      expect.objectContaining({
+        code: "EXECUTION_ERROR",
+      }),
+    );
+  });
+
+  it("executor が {ok:true} を返す場合、実体の executeMultiApp 経由でスローせず正常完了する", async () => {
+    // Integration mirror: real executeMultiApp with an { ok: true } executor must
+    // NOT throw (fail-fast not erroneously triggered).
+    const { executeMultiApp: realExecuteMultiApp } = await vi.importActual<
+      typeof import("@/core/application/projectConfig/executeMultiApp")
+    >("@/core/application/projectConfig/executeMultiApp");
+    vi.mocked(executeMultiApp).mockImplementation(realExecuteMultiApp);
+
+    const plan = makePlan([makeApp("App1"), makeApp("App2")]);
+
+    await expect(
+      runMultiAppWithFailCheck(plan, async () => ({ ok: true })),
+    ).resolves.toBeUndefined();
+  });
+
   it("successMessage が指定されていない場合、成功ログは出力されない", async () => {
     const plan = makePlan([makeApp("App1")]);
     vi.mocked(executeMultiApp).mockResolvedValue({

--- a/src/cli/commands/__tests__/apply.test.ts
+++ b/src/cli/commands/__tests__/apply.test.ts
@@ -407,6 +407,125 @@ describe("apply command", () => {
     expect(capturedOutcome).toEqual({ ok: true });
   });
 
+  it("multiApp で --dry-run の早期 return のとき executor が {ok:true} を return すること（fail-fast 誤発火しない・AC-6）", async () => {
+    const plan: ExecutionPlan = { orderedApps: [mockApp] };
+
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          multiApp: (
+            plan: ExecutionPlan,
+            config: ProjectConfig,
+          ) => Promise<void>;
+        },
+      ) => {
+        await handlers.multiApp(plan, mockProjectConfig);
+      },
+    );
+
+    // Capture the dry-run early-return outcome. A regression that returns
+    // { ok: false } for dry-run would make executeMultiApp mark this app failed
+    // and fail-fast the rest; pinning { ok: true } prevents that (AC-6).
+    let capturedOutcome: unknown;
+    vi.mocked(runMultiAppWithFailCheck).mockImplementationOnce(
+      async (_plan, executor) => {
+        capturedOutcome = await executor(mockApp);
+      },
+    );
+
+    await applyCommand.run({ values: { "dry-run": true } } as never);
+
+    expect(applyAllForApp).not.toHaveBeenCalled();
+    expect(capturedOutcome).toEqual({ ok: true });
+  });
+
+  it("multiApp で確認キャンセルの早期 return のとき executor が {ok:true} を return すること（fail-fast 誤発火しない・AC-6）", async () => {
+    const plan: ExecutionPlan = { orderedApps: [mockApp] };
+
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          multiApp: (
+            plan: ExecutionPlan,
+            config: ProjectConfig,
+          ) => Promise<void>;
+        },
+      ) => {
+        await handlers.multiApp(plan, mockProjectConfig);
+      },
+    );
+
+    // Capture the confirm-cancel early-return outcome. Cancelling is not a
+    // failure, so the executor must return { ok: true }; a regression to
+    // { ok: false } would trigger spurious fail-fast in multiApp (AC-6).
+    let capturedOutcome: unknown;
+    vi.mocked(runMultiAppWithFailCheck).mockImplementationOnce(
+      async (_plan, executor) => {
+        capturedOutcome = await executor(mockApp);
+      },
+    );
+
+    vi.mocked(p.confirm).mockResolvedValueOnce(false);
+
+    await applyCommand.run({ values: {} } as never);
+
+    expect(applyAllForApp).not.toHaveBeenCalled();
+    expect(capturedOutcome).toEqual({ ok: true });
+  });
+
+  it("multiApp で全ドメイン not-found skip のとき executor が {ok:true} を return すること（fail-fast を誘発しない・AC-5）", async () => {
+    const plan: ExecutionPlan = { orderedApps: [mockApp] };
+
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          multiApp: (
+            plan: ExecutionPlan,
+            config: ProjectConfig,
+          ) => Promise<void>;
+        },
+      ) => {
+        await handlers.multiApp(plan, mockProjectConfig);
+      },
+    );
+
+    // #179 graceful skip × multi crossing: an app whose config files are all
+    // absent produces not-found-only output (skipped:"not-found", no genuine
+    // failure). runApplyAll's hasFailures excludes not-found, so the executor
+    // must return { ok: true } and not induce fail-fast for the rest (AC-5).
+    let capturedOutcome: unknown;
+    vi.mocked(runMultiAppWithFailCheck).mockImplementationOnce(
+      async (_plan, executor) => {
+        capturedOutcome = await executor(mockApp);
+      },
+    );
+
+    vi.mocked(p.confirm).mockResolvedValueOnce(true);
+    vi.mocked(applyAllForApp).mockResolvedValueOnce({
+      phases: [
+        {
+          phase: "Schema",
+          results: [{ domain: "schema", success: false, skipped: "not-found" }],
+        },
+        {
+          phase: "Views & Customization",
+          results: [
+            { domain: "customize", success: false, skipped: "not-found" },
+            { domain: "view", success: false, skipped: "not-found" },
+          ],
+        },
+      ],
+      deployed: false,
+    });
+
+    await applyCommand.run({ values: {} } as never);
+
+    expect(capturedOutcome).toEqual({ ok: true });
+  });
+
   it("エラー発生時に handleCliError が呼ばれること", async () => {
     const testError = new Error("test error");
     vi.mocked(routeMultiApp).mockRejectedValueOnce(testError);

--- a/src/cli/commands/__tests__/apply.test.ts
+++ b/src/cli/commands/__tests__/apply.test.ts
@@ -314,9 +314,8 @@ describe("apply command", () => {
 
     await applyCommand.run({ values: {} } as never);
 
-    // The executor must passthrough runApplyAll's { ok: false } unchanged. With
-    // no deployError this exercises the `?? new SystemError(...)` branch, so the
-    // error is an app-named ExecutionError SystemError (deployError absent).
+    // With no deployError, the `?? new SystemError(...)` branch produces an
+    // app-named ExecutionError SystemError.
     expect(capturedOutcome).toMatchObject({
       ok: false,
       error: expect.objectContaining({

--- a/src/cli/commands/__tests__/apply.test.ts
+++ b/src/cli/commands/__tests__/apply.test.ts
@@ -293,7 +293,8 @@ describe("apply command", () => {
     );
 
     vi.mocked(p.confirm).mockResolvedValueOnce(true);
-    // Failure output (aborted skip) so runApplyAll yields { ok: false }.
+    // Genuine execution failure (success:false, skipped:false) so runApplyAll's
+    // hasFailures is true and it yields { ok: false }.
     vi.mocked(applyAllForApp).mockResolvedValueOnce({
       phases: [
         {
@@ -313,7 +314,97 @@ describe("apply command", () => {
 
     await applyCommand.run({ values: {} } as never);
 
+    // The executor must passthrough runApplyAll's { ok: false } unchanged. With
+    // no deployError this exercises the `?? new SystemError(...)` branch, so the
+    // error is an app-named ExecutionError SystemError (deployError absent).
+    expect(capturedOutcome).toMatchObject({
+      ok: false,
+      error: expect.objectContaining({
+        code: "EXECUTION_ERROR",
+        message: expect.stringContaining("test-app"),
+      }),
+    });
+  });
+
+  it("multiApp で deployError がある場合 executor が runApplyAll の {ok:false} に deployError を透過すること", async () => {
+    const plan: ExecutionPlan = { orderedApps: [mockApp] };
+
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          multiApp: (
+            plan: ExecutionPlan,
+            config: ProjectConfig,
+          ) => Promise<void>;
+        },
+      ) => {
+        await handlers.multiApp(plan, mockProjectConfig);
+      },
+    );
+
+    let capturedOutcome: unknown;
+    vi.mocked(runMultiAppWithFailCheck).mockImplementationOnce(
+      async (_plan, executor) => {
+        capturedOutcome = await executor(mockApp);
+      },
+    );
+
+    vi.mocked(p.confirm).mockResolvedValueOnce(true);
+    // Success output but a failed deploy: runApplyAll must put the SAME
+    // deployError reference into the outcome's error (the left-hand branch of
+    // `output.deployError ?? new SystemError(...)`). A regression that swaps it
+    // for a fresh SystemError (swallowing deployError) would be caught here.
+    const deployError = new Error("Deploy failed");
+    vi.mocked(applyAllForApp).mockResolvedValueOnce({
+      phases: [
+        {
+          phase: "Schema",
+          results: [{ domain: "schema", success: true }],
+        },
+      ],
+      deployed: false,
+      deployError,
+    });
+
+    await applyCommand.run({ values: {} } as never);
+
     expect(capturedOutcome).toMatchObject({ ok: false });
+    expect((capturedOutcome as { error: unknown }).error).toBe(deployError);
+  });
+
+  it("multiApp で先頭 app が成功のとき executor が runApplyAll の {ok:true} をそのまま return すること", async () => {
+    const plan: ExecutionPlan = { orderedApps: [mockApp] };
+
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          multiApp: (
+            plan: ExecutionPlan,
+            config: ProjectConfig,
+          ) => Promise<void>;
+        },
+      ) => {
+        await handlers.multiApp(plan, mockProjectConfig);
+      },
+    );
+
+    // Mirror of the AC-4(b) failure passthrough: with the default success
+    // output (no failures, no deployError) the executor must return { ok: true }
+    // so fail-fast is not erroneously triggered in the apply context (AC-3).
+    let capturedOutcome: unknown;
+    vi.mocked(runMultiAppWithFailCheck).mockImplementationOnce(
+      async (_plan, executor) => {
+        capturedOutcome = await executor(mockApp);
+      },
+    );
+
+    vi.mocked(p.confirm).mockResolvedValueOnce(true);
+
+    await applyCommand.run({ values: {} } as never);
+
+    expect(capturedOutcome).toEqual({ ok: true });
   });
 
   it("エラー発生時に handleCliError が呼ばれること", async () => {

--- a/src/cli/commands/__tests__/apply.test.ts
+++ b/src/cli/commands/__tests__/apply.test.ts
@@ -265,6 +265,57 @@ describe("apply command", () => {
     expect(applyAllForApp).toHaveBeenCalled();
   });
 
+  it("multiApp で先頭 app がドメイン失敗のとき executor が runApplyAll の {ok:false} をそのまま return すること", async () => {
+    const plan: ExecutionPlan = { orderedApps: [mockApp] };
+
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          multiApp: (
+            plan: ExecutionPlan,
+            config: ProjectConfig,
+          ) => Promise<void>;
+        },
+      ) => {
+        await handlers.multiApp(plan, mockProjectConfig);
+      },
+    );
+
+    // Capture the executor passed to runMultiAppWithFailCheck and invoke it
+    // directly to observe its return value (exit/process termination is out of
+    // scope here — that lives behind the mocked boundary).
+    let capturedOutcome: unknown;
+    vi.mocked(runMultiAppWithFailCheck).mockImplementationOnce(
+      async (_plan, executor) => {
+        capturedOutcome = await executor(mockApp);
+      },
+    );
+
+    vi.mocked(p.confirm).mockResolvedValueOnce(true);
+    // Failure output (aborted skip) so runApplyAll yields { ok: false }.
+    vi.mocked(applyAllForApp).mockResolvedValueOnce({
+      phases: [
+        {
+          phase: "Schema",
+          results: [
+            {
+              domain: "schema",
+              success: false,
+              error: new Error("fail"),
+              skipped: false,
+            },
+          ],
+        },
+      ],
+      deployed: false,
+    });
+
+    await applyCommand.run({ values: {} } as never);
+
+    expect(capturedOutcome).toMatchObject({ ok: false });
+  });
+
   it("エラー発生時に handleCliError が呼ばれること", async () => {
     const testError = new Error("test error");
     vi.mocked(routeMultiApp).mockRejectedValueOnce(testError);

--- a/src/cli/commands/apply.ts
+++ b/src/cli/commands/apply.ts
@@ -4,6 +4,8 @@ import { define } from "gunshi";
 import { applyAllForApp } from "@/core/application/applyAll/applyAllForApp";
 import { createCliApplyAllContainers } from "@/core/application/container/applyAllCli";
 import { diffAllForApp } from "@/core/application/diffAll/diffAllForApp";
+import { SystemError, SystemErrorCode } from "@/core/application/error";
+import type { AppExecutionOutcome } from "@/core/application/projectConfig/executeMultiApp";
 import { printApplyAllResults } from "../applyAllOutput";
 import { confirmArgs, kintoneArgs, multiAppArgs } from "../config";
 import { printDiffAllResults } from "../diffAllOutput";
@@ -50,7 +52,7 @@ async function runApplyAll(
   },
   appName: string,
   options: { skipConfirm: boolean; dryRun: boolean },
-): Promise<void> {
+): Promise<AppExecutionOutcome> {
   const { containers, diffContainers, paths } = createCliApplyAllContainers({
     ...cliConfig,
     appName:
@@ -97,7 +99,7 @@ async function runApplyAll(
         "Note: Seed data would still be upserted when running without --dry-run.",
       );
     }
-    return;
+    return { ok: true };
   }
 
   // Step 3: Confirm
@@ -108,7 +110,7 @@ async function runApplyAll(
 
     if (p.isCancel(shouldContinue) || !shouldContinue) {
       p.cancel("Apply cancelled.");
-      return;
+      return { ok: true };
     }
   }
 
@@ -129,19 +131,31 @@ async function runApplyAll(
   // Step 5: Print results
   printApplyAllResults(output);
 
-  // Set non-zero exit code for CI/CD pipelines.
-  // Triggered when any domain genuinely failed (execution failure or aborted
-  // skip) or when a required deploy failed. A "not-found" skip (config file
-  // absent) is not a failure and never raises the exit code. A deploy that was
-  // simply not needed (no Phase 2-4 successes, so deployError is undefined) is
-  // not an error either, so we check output.deployError instead of
-  // !output.deployed.
+  // Compute the failure truth value for this app and return it as the outcome.
+  // The caller (single-app handler or multi-app executor) decides how to turn
+  // this into an exit code; runApplyAll never writes process.exitCode directly.
+  //
+  // A failure is any domain that genuinely failed (execution failure or aborted
+  // skip) or a required deploy that failed. A "not-found" skip (config file
+  // absent) is not a failure. A deploy that was simply not needed (no Phase 2-4
+  // successes, so deployError is undefined) is not an error either, so we check
+  // output.deployError instead of !output.deployed.
   const hasFailures = output.phases
     .flatMap((pr) => pr.results)
     .some((r) => !r.success && r.skipped !== "not-found");
   if (hasFailures || output.deployError) {
-    process.exitCode = 1;
+    return {
+      ok: false,
+      error:
+        output.deployError ??
+        new SystemError(
+          SystemErrorCode.ExecutionError,
+          `Apply failed for ${appName}.`,
+        ),
+    };
   }
+
+  return { ok: true };
 }
 
 export default define({
@@ -164,13 +178,19 @@ export default define({
         },
         singleApp: async (app, projectConfig) => {
           const cliConfig = resolveAppCliConfig(app, projectConfig, values);
-          await runApplyAll(cliConfig, app.name, { skipConfirm, dryRun });
+          const outcome = await runApplyAll(cliConfig, app.name, {
+            skipConfirm,
+            dryRun,
+          });
+          if (!outcome.ok) {
+            process.exitCode = 1;
+          }
         },
         multiApp: async (plan, projectConfig) => {
           await runMultiAppWithFailCheck(plan, async (app) => {
             const cliConfig = resolveAppCliConfig(app, projectConfig, values);
             printAppHeader(app.name, app.appId);
-            await runApplyAll(cliConfig, app.name, { skipConfirm, dryRun });
+            return runApplyAll(cliConfig, app.name, { skipConfirm, dryRun });
           });
         },
       });

--- a/src/cli/commands/apply.ts
+++ b/src/cli/commands/apply.ts
@@ -131,15 +131,14 @@ async function runApplyAll(
   // Step 5: Print results
   printApplyAllResults(output);
 
-  // Compute the failure truth value for this app and return it as the outcome.
-  // The caller (single-app handler or multi-app executor) decides how to turn
-  // this into an exit code; runApplyAll never writes process.exitCode directly.
+  // Return the failure verdict as an outcome; the caller decides how to map it
+  // to an exit code. runApplyAll never writes process.exitCode directly.
   //
   // A failure is any domain that genuinely failed (execution failure or aborted
   // skip) or a required deploy that failed. A "not-found" skip (config file
-  // absent) is not a failure. A deploy that was simply not needed (no Phase 2-4
-  // successes, so deployError is undefined) is not an error either, so we check
-  // output.deployError instead of !output.deployed.
+  // absent) is not a failure. A deploy that was simply not needed leaves
+  // deployError undefined, so we check output.deployError rather than
+  // !output.deployed.
   const hasFailures = output.phases
     .flatMap((pr) => pr.results)
     .some((r) => !r.success && r.skipped !== "not-found");

--- a/src/cli/projectConfig.ts
+++ b/src/cli/projectConfig.ts
@@ -263,7 +263,7 @@ export async function runMultiAppWithHeaders(
     plan,
     async (app) => {
       printAppHeader(app.name, app.appId);
-      await executor(app);
+      return executor(app);
     },
     successMessage,
   );

--- a/src/core/application/projectConfig/__tests__/executeMultiApp.test.ts
+++ b/src/core/application/projectConfig/__tests__/executeMultiApp.test.ts
@@ -79,4 +79,48 @@ describe("executeMultiApp", () => {
     expect(result.hasFailure).toBe(false);
     expect(result.results).toHaveLength(0);
   });
+
+  it("treats { ok: false } return as failure and fail-fasts remaining apps", async () => {
+    const plan = makePlan(["a", "b", "c"]);
+    const executed: string[] = [];
+
+    const result = await executeMultiApp(plan, async (app) => {
+      executed.push(app.name);
+      if (app.name === "a") {
+        return { ok: false, error: new Error("a failed") };
+      }
+      return { ok: true };
+    });
+
+    // Fail-fast: executor must not be called for apps after the failure (AC-2).
+    expect(executed).toEqual(["a"]);
+    expect(result.hasFailure).toBe(true);
+    // The failed app is "failed" and explicitly NOT "succeeded" (AC-1 misclassification guard).
+    expect(result.results[0].status).toBe("failed");
+    expect(result.results[0].status).not.toBe("succeeded");
+    expect(result.results[0].error).toBeDefined();
+    expect(result.results[1].status).toBe("skipped");
+    expect(result.results[2].status).toBe("skipped");
+  });
+
+  it("treats { ok: true } return as success", async () => {
+    const plan = makePlan(["a", "b"]);
+
+    const result = await executeMultiApp(plan, async () => {
+      return { ok: true };
+    });
+
+    expect(result.hasFailure).toBe(false);
+    expect(result.results.every((r) => r.status === "succeeded")).toBe(true);
+  });
+
+  it("treats async void return as success (backward compatibility)", async () => {
+    const plan = makePlan(["a", "b"]);
+
+    // Mirrors real executors: `await someAsyncWork()` then implicit return undefined.
+    const result = await executeMultiApp(plan, async () => {});
+
+    expect(result.hasFailure).toBe(false);
+    expect(result.results.every((r) => r.status === "succeeded")).toBe(true);
+  });
 });

--- a/src/core/application/projectConfig/__tests__/executeMultiApp.test.ts
+++ b/src/core/application/projectConfig/__tests__/executeMultiApp.test.ts
@@ -103,6 +103,26 @@ describe("executeMultiApp", () => {
     expect(result.results[2].status).toBe("skipped");
   });
 
+  it("treats { ok: false } with omitted error as failure with undefined error", async () => {
+    const plan = makePlan(["a", "b"]);
+
+    // Type contract boundary: `error` is optional on `{ ok: false }`. An executor
+    // may omit it; the use-case layer does NOT fabricate a fallback Error (it has
+    // no context). The app must still be "failed" / hasFailure, with error undefined.
+    const result = await executeMultiApp(plan, async (app) => {
+      if (app.name === "a") {
+        return { ok: false };
+      }
+      return { ok: true };
+    });
+
+    expect(result.hasFailure).toBe(true);
+    expect(result.results[0].status).toBe("failed");
+    expect(result.results[0].status).not.toBe("succeeded");
+    expect(result.results[0].error).toBeUndefined();
+    expect(result.results[1].status).toBe("skipped");
+  });
+
   it("treats { ok: true } return as success", async () => {
     const plan = makePlan(["a", "b"]);
 

--- a/src/core/application/projectConfig/executeMultiApp.ts
+++ b/src/core/application/projectConfig/executeMultiApp.ts
@@ -7,37 +7,29 @@ import type {
 import { MultiAppResult as MultiAppResultFactory } from "@/core/domain/projectConfig/entity";
 
 /**
- * Input DTO carrying the success/failure of a single app from an executor back
- * to `executeMultiApp`. This is a 2-value outcome (ok / not ok) that the
- * executor reports about itself; it is NOT the domain `AppExecutionResult`
- * (a 3-value `succeeded`/`failed`/`skipped` status that `executeMultiApp`
- * produces as output, where `skipped` is assigned by fail-fast and cannot be
- * expressed by an executor). See ADR-001.
+ * 2-value outcome (ok / not ok) an executor reports about a single app back to
+ * `executeMultiApp`. Distinct from the domain `AppExecutionResult`, whose 3rd
+ * status `skipped` is assigned by fail-fast and cannot be expressed by an
+ * executor. See ADR-001.
  *
- * For `{ ok: false }`, supplying `error` is the executor's responsibility: only
- * the executor has the context to describe why the app failed. When omitted,
- * the resulting `AppExecutionResult.error` is `undefined` (a "failed" app with
- * no reason). This use-case layer deliberately does NOT fabricate a generic
- * fallback `Error`, since it lacks that context. This is asymmetric with the
- * throw path (which always carries the caught real `Error`), and the asymmetry
- * is intentional: the responsibility for the failure reason stays with the
- * party that has it.
+ * On `{ ok: false }`, `error` is the executor's responsibility — only it has the
+ * context to describe the failure. When omitted, `AppExecutionResult.error` is
+ * `undefined`; this use-case layer deliberately does NOT fabricate a fallback
+ * `Error`. This is intentionally asymmetric with the throw path (which always
+ * carries the caught real `Error`).
  */
 export type AppExecutionOutcome =
   | { readonly ok: true }
   | { readonly ok: false; readonly error?: Error };
 
 /**
- * Executor return value is `AppExecutionOutcome | void`. A `void` (undefined)
- * return is treated as success, preserving the legacy contract (throw = failure,
- * normal return = success) so existing executors keep working unchanged.
+ * A `void` (undefined) return is treated as success, preserving the legacy
+ * contract (throw = failure, normal return = success) so existing executors that
+ * return nothing keep working unchanged. See ADR-001.
  */
-// `void` in the union is the intentional backward-compatibility contract
-// (void return = success) required for existing executors that return nothing.
-// See ADR-001.
 export type MultiAppExecutor = (
   app: AppEntry,
-  // biome-ignore lint/suspicious/noConfusingVoidType: see note above.
+  // biome-ignore lint/suspicious/noConfusingVoidType: void return = success, see type doc above.
 ) => Promise<AppExecutionOutcome | void>;
 
 export async function executeMultiApp(
@@ -58,8 +50,8 @@ export async function executeMultiApp(
     // as skipped rather than letting the error propagate and abort the loop.
     try {
       const outcome = await executor(app);
-      // `void`/undefined return = success (backward compatibility); an explicit
-      // `{ ok: false }` outcome is a failure even though no exception was thrown.
+      // An explicit `{ ok: false }` is a failure even though nothing was thrown;
+      // `void`/undefined stays success (backward compatibility).
       if (outcome && outcome.ok === false) {
         results.push({
           name: app.name,

--- a/src/core/application/projectConfig/executeMultiApp.ts
+++ b/src/core/application/projectConfig/executeMultiApp.ts
@@ -6,7 +6,30 @@ import type {
 } from "@/core/domain/projectConfig/entity";
 import { MultiAppResult as MultiAppResultFactory } from "@/core/domain/projectConfig/entity";
 
-export type MultiAppExecutor = (app: AppEntry) => Promise<void>;
+/**
+ * Input DTO carrying the success/failure of a single app from an executor back
+ * to `executeMultiApp`. This is a 2-value outcome (ok / not ok) that the
+ * executor reports about itself; it is NOT the domain `AppExecutionResult`
+ * (a 3-value `succeeded`/`failed`/`skipped` status that `executeMultiApp`
+ * produces as output, where `skipped` is assigned by fail-fast and cannot be
+ * expressed by an executor). See ADR-001.
+ */
+export type AppExecutionOutcome =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly error?: Error };
+
+/**
+ * Executor return value is `AppExecutionOutcome | void`. A `void` (undefined)
+ * return is treated as success, preserving the legacy contract (throw = failure,
+ * normal return = success) so existing executors keep working unchanged.
+ */
+// `void` in the union is the intentional backward-compatibility contract
+// (void return = success) required for existing executors that return nothing.
+// See ADR-001.
+export type MultiAppExecutor = (
+  app: AppEntry,
+  // biome-ignore lint/suspicious/noConfusingVoidType: see note above.
+) => Promise<AppExecutionOutcome | void>;
 
 export async function executeMultiApp(
   plan: ExecutionPlan,
@@ -25,8 +48,19 @@ export async function executeMultiApp(
     // so that the result of each app is recorded and remaining apps are marked
     // as skipped rather than letting the error propagate and abort the loop.
     try {
-      await executor(app);
-      results.push({ name: app.name, status: "succeeded" });
+      const outcome = await executor(app);
+      // `void`/undefined return = success (backward compatibility); an explicit
+      // `{ ok: false }` outcome is a failure even though no exception was thrown.
+      if (outcome && outcome.ok === false) {
+        results.push({
+          name: app.name,
+          status: "failed",
+          error: outcome.error,
+        });
+        failed = true;
+      } else {
+        results.push({ name: app.name, status: "succeeded" });
+      }
     } catch (error) {
       results.push({
         name: app.name,

--- a/src/core/application/projectConfig/executeMultiApp.ts
+++ b/src/core/application/projectConfig/executeMultiApp.ts
@@ -13,6 +13,15 @@ import { MultiAppResult as MultiAppResultFactory } from "@/core/domain/projectCo
  * (a 3-value `succeeded`/`failed`/`skipped` status that `executeMultiApp`
  * produces as output, where `skipped` is assigned by fail-fast and cannot be
  * expressed by an executor). See ADR-001.
+ *
+ * For `{ ok: false }`, supplying `error` is the executor's responsibility: only
+ * the executor has the context to describe why the app failed. When omitted,
+ * the resulting `AppExecutionResult.error` is `undefined` (a "failed" app with
+ * no reason). This use-case layer deliberately does NOT fabricate a generic
+ * fallback `Error`, since it lacks that context. This is asymmetric with the
+ * throw path (which always carries the caught real `Error`), and the asymmetry
+ * is intentional: the responsibility for the failure reason stays with the
+ * party that has it.
  */
 export type AppExecutionOutcome =
   | { readonly ok: true }


### PR DESCRIPTION
## Summary
- `MultiAppExecutor` の成否検知を「executor の throw 依存」から「executor の戻り値 `AppExecutionOutcome`（`{ ok: true } | { ok: false; error? }`）依存」へ変更。`void` 返却は従来どおり成功とみなし後方互換を維持
- `runApplyAll` が `process.exitCode` 直書きをやめ、成否を戻り値で返す。単一 app はハンドラ側で exit code を立て、マルチ app は `executeMultiApp` が `hasFailure` を立て `SystemError` throw → `handleCliError` の既存経路に乗せて exit code とレポートを一本化
- これにより `apply --all` で per-app のドメイン失敗時に (1) fail-fast（後続 app を skip）が発火し、(2) per-app status が実態と一致（失敗 app を `succeeded` と誤集計しない）、(3) exit code とレポートが整合する

## Issue
Closes #182

## Implementation Plan
Based on `.issue/182/plan.md`（設計判断は `.issue/182/adr.md`）

## Test plan

### デプロイ・動作確認方法
CLI ツール（常駐サーバー・デプロイなし）。確認は自動テストで担保:
- `pnpm typecheck` — `MultiAppExecutor` 型変更の全コマンド波及をコンパイル確認
- `pnpm test` — 全スイート green（222 files / 2355 tests）
- `pnpm lint:fix` / `pnpm format`

### 確認項目
- `executeMultiApp` 単体: `{ ok: false }` → 当該 app `failed`（`succeeded` でない）+ 後続 `skipped`（fail-fast）+ `hasFailure=true`、`{ ok: true }` / `void`（暗黙 void）→ `succeeded`（後方互換の生命線）
- `apply.test.ts`: multiApp で先頭 app ドメイン失敗時、executor が `runApplyAll` の `{ ok: false }` をそのまま return
- `projectConfig.test.ts`: `hasFailure=true` → `EXECUTION_ERROR` SystemError throw（既存ケースが型変更後も green）
- 非回帰: 単一 app 失敗 → `process.exitCode=1`、全 not-found → 成功扱い（#179 graceful skip）、dry-run / 確認キャンセル → 失敗扱いしない

## Browser Verification
- スキップ理由: CLI ツールで Web UI なし（`package.json` の dev/start は CLI 実行用、UI ファイル不在）。testing.md に画面操作項目が 1 件もないため

🤖 Generated with [Claude Code](https://claude.com/claude-code)