### PR TITLE
fix(cli): make multi-app failure warning deploy-model agnostic

### DIFF
--- a/src/cli/__tests__/projectConfig.test.ts
+++ b/src/cli/__tests__/projectConfig.test.ts
@@ -189,4 +189,53 @@ describe("runMultiAppWithFailCheck", () => {
 
     expect(p.log.success).not.toHaveBeenCalled();
   });
+
+  it("一部成功・一部失敗時、deploy モデル非依存の警告文言で warn が呼ばれる", async () => {
+    const plan = makePlan([makeApp("App1"), makeApp("App2")]);
+    vi.mocked(executeMultiApp).mockResolvedValue({
+      results: [
+        { name: "App1" as AppName, status: "succeeded" },
+        {
+          name: "App2" as AppName,
+          status: "failed",
+          error: new Error("fail"),
+        },
+      ],
+      hasFailure: true,
+    });
+
+    await expect(runMultiAppWithFailCheck(plan, vi.fn())).rejects.toThrow(
+      expect.objectContaining({ code: "EXECUTION_ERROR" }),
+    );
+
+    expect(p.log.warn).toHaveBeenCalledTimes(1);
+    const warnMessage = vi.mocked(p.log.warn).mock.calls[0][0];
+    expect(warnMessage).toContain(
+      "1 app(s) completed before execution stopped",
+    );
+    // The wording must stay deploy-model agnostic: this warning also fires for
+    // read-only and per-app-deploy commands, where "preview"/"deployed" is wrong.
+    expect(warnMessage).not.toContain("preview");
+    expect(warnMessage).not.toContain("deployed");
+  });
+
+  it("成功 app が無い失敗時は、当該の警告は出ない", async () => {
+    const plan = makePlan([makeApp("App1")]);
+    vi.mocked(executeMultiApp).mockResolvedValue({
+      results: [
+        {
+          name: "App1" as AppName,
+          status: "failed",
+          error: new Error("fail"),
+        },
+      ],
+      hasFailure: true,
+    });
+
+    await expect(runMultiAppWithFailCheck(plan, vi.fn())).rejects.toThrow(
+      expect.objectContaining({ code: "EXECUTION_ERROR" }),
+    );
+
+    expect(p.log.warn).not.toHaveBeenCalled();
+  });
 });

--- a/src/cli/__tests__/projectConfig.test.ts
+++ b/src/cli/__tests__/projectConfig.test.ts
@@ -210,8 +210,10 @@ describe("runMultiAppWithFailCheck", () => {
 
     expect(p.log.warn).toHaveBeenCalledTimes(1);
     const warnMessage = vi.mocked(p.log.warn).mock.calls[0][0];
-    expect(warnMessage).toContain(
-      "1 app(s) completed before execution stopped",
+    // Pin the full message so any drift (including a regression to the old
+    // preview/deploy wording) is caught.
+    expect(warnMessage).toBe(
+      "1 app(s) completed before execution stopped. Check their status in kintone.",
     );
     // The wording must stay deploy-model agnostic: this warning also fires for
     // read-only and per-app-deploy commands, where "preview"/"deployed" is wrong.

--- a/src/cli/projectConfig.ts
+++ b/src/cli/projectConfig.ts
@@ -288,7 +288,7 @@ export async function runMultiAppWithFailCheck(
     ).length;
     if (succeededCount > 0) {
       p.log.warn(
-        `${succeededCount} app(s) were applied to preview but may not have been deployed. Check their status in kintone.`,
+        `${succeededCount} app(s) completed before execution stopped. Check their status in kintone.`,
       );
     }
     throw new SystemError(


### PR DESCRIPTION
## Summary
- `runMultiAppWithFailCheck`（`src/cli/projectConfig.ts`）のマルチアプリ失敗時 `succeededCount > 0` 警告を、deploy モデル非依存の汎用文言に変更
  - 旧: `N app(s) were applied to preview but may not have been deployed. Check their status in kintone.`
  - 新: `N app(s) completed before execution stopped. Check their status in kintone.`
- 旧文言は schema 系の preview→deploy モデル前提だったが、この共有警告は `apply --all`（app 内で deploy 完結）や read-only コマンド（diff/capture/dump 等）の失敗時にも発火するため、preview/deploy を前提とした表現が誤解を招いていた
- 文言を固定する単体テストを `projectConfig.test.ts` に追加（新文言を含む / `preview`・`deployed` を含まない / `succeededCount === 0` では警告なし）

挙動（fail-fast・per-app status・exit code）は #182（PR #183）で整合済みのため一切変更していない。本PRは表示文言の正確性のみが対象。

## Issue
Closes #184

## Implementation Plan
Based on `.issue/184/plan.md`（設計判断は `.issue/184/adr.md` ADR-001: 汎用文言一本化 vs コマンド別出し分け → 汎用文言を採用）

## Test plan

### デプロイ・動作確認方法
CLI ツールのため Web サーバー・ブラウザは不要。

- 単体テスト: `pnpm test src/cli/__tests__/projectConfig.test.ts`
- 型チェック: `pnpm typecheck`
- 全テスト回帰: `pnpm test`（2365 tests passed）

### 確認項目
- マルチアプリ失敗かつ `succeededCount > 0` で新文言の警告が出る（`preview`/`deployed` を含まない）
- `succeededCount === 0` の失敗時は当該警告が出ない
- 失敗時 throw（EXECUTION_ERROR）・exit code が回帰していない（`src/cli/commands/__tests__/apply.test.ts` の #182 マルチ経路ケース緑のまま）

## Browser Verification
- スキップ理由: CLI ツールで Web UI なし（`pnpm dev` は `tsx src/cli/index.ts` の CLI 実行、Web サーバー・UIファイル不在を確認）。testing.md に画面操作項目は 0 件。検証は単体テストで担保。

🤖 Generated with [Claude Code](https://claude.com/claude-code)