### PR TITLE
improve(cli): multi-app apply の確認プロンプトを一括化

### DIFF
--- a/src/cli/commands/__tests__/apply.test.ts
+++ b/src/cli/commands/__tests__/apply.test.ts
@@ -60,8 +60,11 @@ const { mockSeedStorageGet } = vi.hoisted(() => ({
 }));
 
 vi.mock("@/core/application/container/applyAllCli", () => ({
-  createCliApplyAllContainers: vi.fn(() => ({
+  createCliApplyAllContainers: vi.fn((config: { appName?: string }) => ({
     containers: {
+      // Tag containers with the app name so per-app applyAllForApp calls can be
+      // identified by argument and their order asserted (AC-3).
+      appName: config?.appName,
       seed: { seedStorage: { get: mockSeedStorageGet } },
     },
     diffContainers: {},
@@ -320,6 +323,86 @@ describe("apply command", () => {
     expect(printAppHeader).toHaveBeenCalledWith("test-app-2", "456");
     // Both apps applied in dependency order.
     expect(applyAllForApp).toHaveBeenCalledTimes(2);
+
+    // Assert the actual apply order is the dependency order (test-app first,
+    // then test-app-2), not just that apply ran twice. The container is tagged
+    // with the app name in Phase 1, so each applyAllForApp call carries the app
+    // it applies — the order of those calls is the real apply order.
+    const appliedOrder = vi
+      .mocked(applyAllForApp)
+      .mock.calls.map(
+        ([arg]) => (arg.containers as { appName?: string }).appName,
+      );
+    expect(appliedOrder).toEqual(["test-app", "test-app-2"]);
+
+    // printAppHeader (Phase 1 collection) likewise runs in dependency order.
+    const headerOrder = vi
+      .mocked(printAppHeader)
+      .mock.calls.map(([name]) => name);
+    expect(headerOrder).toEqual(["test-app", "test-app-2"]);
+  });
+
+  it("multiApp で先頭 app が失敗したら後続 app は apply されないこと（fail-fast・AC-4）", async () => {
+    const plan: ExecutionPlan = { orderedApps: [mockApp, mockApp2] };
+
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          multiApp: (
+            plan: ExecutionPlan,
+            config: ProjectConfig,
+          ) => Promise<void>;
+        },
+      ) => {
+        await handlers.multiApp(plan, mockMultiProjectConfig);
+      },
+    );
+
+    // Mirror real executeMultiApp fail-fast semantics at the CLI boundary: stop
+    // invoking executors once one returns { ok: false }. This exercises the
+    // genuine path where the apply command's executor reports a failure and the
+    // following app is skipped (never applied).
+    vi.mocked(runMultiAppWithFailCheck).mockImplementationOnce(
+      async (_plan, executor) => {
+        for (const app of plan.orderedApps) {
+          const outcome = await executor(app);
+          if (outcome && outcome.ok === false) {
+            break;
+          }
+        }
+      },
+    );
+
+    vi.mocked(p.confirm).mockResolvedValueOnce(true);
+    // First app genuinely fails so its executor returns { ok: false }.
+    vi.mocked(applyAllForApp).mockResolvedValueOnce({
+      phases: [
+        {
+          phase: "Schema",
+          results: [
+            {
+              domain: "schema",
+              success: false,
+              error: new Error("fail"),
+              skipped: false,
+            },
+          ],
+        },
+      ],
+      deployed: false,
+    });
+
+    await applyCommand.run({ values: {} } as never);
+
+    // Only the first app was applied; fail-fast prevented the second app's apply.
+    expect(applyAllForApp).toHaveBeenCalledTimes(1);
+    const appliedOrder = vi
+      .mocked(applyAllForApp)
+      .mock.calls.map(
+        ([arg]) => (arg.containers as { appName?: string }).appName,
+      );
+    expect(appliedOrder).toEqual(["test-app"]);
   });
 
   it("multiApp で --yes の場合は confirm をスキップして全アプリを apply すること（AC-5）", async () => {
@@ -379,6 +462,134 @@ describe("apply command", () => {
     expect(p.log.info).toHaveBeenCalledWith(
       "Dry run complete. No changes will be applied.",
     );
+  });
+
+  it("multiApp で --dry-run のとき diff 変更なし+seed ありのアプリには seed 注記を表示すること（N-001）", async () => {
+    const plan: ExecutionPlan = { orderedApps: [mockApp, mockApp2] };
+
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          multiApp: (
+            plan: ExecutionPlan,
+            config: ProjectConfig,
+          ) => Promise<void>;
+        },
+      ) => {
+        await handlers.multiApp(plan, mockMultiProjectConfig);
+      },
+    );
+
+    // app1: diff changes (default). app2: empty diff but seed exists, so the
+    // Phase 3 seed note branch (!hasChanges && seedExists) fires.
+    vi.mocked(diffAllForApp)
+      .mockResolvedValueOnce([
+        {
+          domain: "schema",
+          success: true,
+          result: {
+            isEmpty: false,
+            entries: [],
+            schemaFields: [],
+            summary: { added: 1, modified: 0, deleted: 0, total: 1 },
+            hasLayoutChanges: false,
+          },
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          domain: "schema",
+          success: true,
+          result: {
+            isEmpty: true,
+            entries: [],
+            schemaFields: [],
+            summary: { added: 0, modified: 0, deleted: 0, total: 0 },
+            hasLayoutChanges: false,
+          },
+        },
+      ]);
+    // Both apps have seed (default exists:true), but only app2 has no diff
+    // changes, so it is the one driving the dry-run seed note.
+    mockSeedStorageGet
+      .mockResolvedValueOnce({ exists: true, content: "records: []" })
+      .mockResolvedValueOnce({ exists: true, content: "records: []" });
+
+    await applyCommand.run({ values: { "dry-run": true } } as never);
+
+    expect(p.log.info).toHaveBeenCalledWith(
+      "Dry run complete. No changes will be applied.",
+    );
+    expect(p.log.info).toHaveBeenCalledWith(
+      "Note: Seed data would still be upserted when running without --dry-run.",
+    );
+    expect(runMultiAppWithFailCheck).not.toHaveBeenCalled();
+    expect(applyAllForApp).not.toHaveBeenCalled();
+  });
+
+  it("multiApp で --dry-run かつ全アプリ変更なし・seed なしのとき 'No changes' の後に 'Dry run complete.' も表示すること（W-001）", async () => {
+    const plan: ExecutionPlan = { orderedApps: [mockApp, mockApp2] };
+
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          multiApp: (
+            plan: ExecutionPlan,
+            config: ProjectConfig,
+          ) => Promise<void>;
+        },
+      ) => {
+        await handlers.multiApp(plan, mockMultiProjectConfig);
+      },
+    );
+
+    // Both apps: empty diff and no seed.
+    vi.mocked(diffAllForApp)
+      .mockResolvedValueOnce([
+        {
+          domain: "schema",
+          success: true,
+          result: {
+            isEmpty: true,
+            entries: [],
+            schemaFields: [],
+            summary: { added: 0, modified: 0, deleted: 0, total: 0 },
+            hasLayoutChanges: false,
+          },
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          domain: "schema",
+          success: true,
+          result: {
+            isEmpty: true,
+            entries: [],
+            schemaFields: [],
+            summary: { added: 0, modified: 0, deleted: 0, total: 0 },
+            hasLayoutChanges: false,
+          },
+        },
+      ]);
+    mockSeedStorageGet
+      .mockResolvedValueOnce({ exists: false, content: "" })
+      .mockResolvedValueOnce({ exists: false, content: "" });
+
+    await applyCommand.run({ values: { "dry-run": true } } as never);
+
+    // Matches single mode: the no-changes message is emitted first, then the
+    // dry-run summary line is still surfaced.
+    expect(p.log.success).toHaveBeenCalledWith(
+      "No changes detected in any app.",
+    );
+    expect(p.log.info).toHaveBeenCalledWith(
+      "Dry run complete. No changes will be applied.",
+    );
+    expect(p.confirm).not.toHaveBeenCalled();
+    expect(runMultiAppWithFailCheck).not.toHaveBeenCalled();
+    expect(applyAllForApp).not.toHaveBeenCalled();
   });
 
   it("multiApp で confirm をキャンセルした場合は apply されないこと", async () => {

--- a/src/cli/commands/__tests__/apply.test.ts
+++ b/src/cli/commands/__tests__/apply.test.ts
@@ -232,6 +232,20 @@ describe("apply command", () => {
     expect(applyAllForApp).not.toHaveBeenCalled();
   });
 
+  const mockApp2: AppEntry = {
+    name: "test-app-2" as AppName,
+    appId: "456",
+    dependsOn: ["test-app" as AppName],
+  };
+
+  const mockMultiProjectConfig: ProjectConfig = {
+    domain: "example.kintone.com",
+    apps: new Map([
+      ["test-app" as AppName, mockApp],
+      ["test-app-2" as AppName, mockApp2],
+    ]),
+  };
+
   it("multiApp では runMultiAppWithFailCheck が呼ばれ printAppHeader が表示されること", async () => {
     const plan: ExecutionPlan = { orderedApps: [mockApp] };
 
@@ -263,6 +277,310 @@ describe("apply command", () => {
     expect(printAppHeader).toHaveBeenCalledWith("test-app", "123");
     expect(diffAllForApp).toHaveBeenCalled();
     expect(applyAllForApp).toHaveBeenCalled();
+  });
+
+  it("multiApp では全アプリの diff を先に収集し、confirm は1回だけ・依存順に apply されること（AC-1/AC-2/AC-3）", async () => {
+    const plan: ExecutionPlan = { orderedApps: [mockApp, mockApp2] };
+
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          multiApp: (
+            plan: ExecutionPlan,
+            config: ProjectConfig,
+          ) => Promise<void>;
+        },
+      ) => {
+        await handlers.multiApp(plan, mockMultiProjectConfig);
+      },
+    );
+
+    // Phase 5 runs the executor for each app in dependency order.
+    vi.mocked(runMultiAppWithFailCheck).mockImplementationOnce(
+      async (_plan, executor) => {
+        for (const app of plan.orderedApps) {
+          await executor(app);
+        }
+      },
+    );
+
+    vi.mocked(p.confirm).mockResolvedValueOnce(true);
+    // applyAllForApp resolves with the module-factory default for both apps.
+
+    await applyCommand.run({ values: {} } as never);
+
+    // Diffs collected for both apps before any apply, confirm exactly once.
+    expect(diffAllForApp).toHaveBeenCalledTimes(2);
+    expect(p.confirm).toHaveBeenCalledTimes(1);
+    expect(p.confirm).toHaveBeenCalledWith({
+      message: "Apply these changes to all apps?",
+    });
+    expect(printAppHeader).toHaveBeenCalledWith("test-app", "123");
+    expect(printAppHeader).toHaveBeenCalledWith("test-app-2", "456");
+    // Both apps applied in dependency order.
+    expect(applyAllForApp).toHaveBeenCalledTimes(2);
+  });
+
+  it("multiApp で --yes の場合は confirm をスキップして全アプリを apply すること（AC-5）", async () => {
+    const plan: ExecutionPlan = { orderedApps: [mockApp, mockApp2] };
+
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          multiApp: (
+            plan: ExecutionPlan,
+            config: ProjectConfig,
+          ) => Promise<void>;
+        },
+      ) => {
+        await handlers.multiApp(plan, mockMultiProjectConfig);
+      },
+    );
+
+    vi.mocked(runMultiAppWithFailCheck).mockImplementationOnce(
+      async (_plan, executor) => {
+        for (const app of plan.orderedApps) {
+          await executor(app);
+        }
+      },
+    );
+
+    await applyCommand.run({ values: { yes: true } } as never);
+
+    expect(p.confirm).not.toHaveBeenCalled();
+    expect(applyAllForApp).toHaveBeenCalledTimes(2);
+  });
+
+  it("multiApp で --dry-run の場合は全アプリ diff 表示後、confirm も apply も行わないこと（AC-6）", async () => {
+    const plan: ExecutionPlan = { orderedApps: [mockApp, mockApp2] };
+
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          multiApp: (
+            plan: ExecutionPlan,
+            config: ProjectConfig,
+          ) => Promise<void>;
+        },
+      ) => {
+        await handlers.multiApp(plan, mockMultiProjectConfig);
+      },
+    );
+
+    await applyCommand.run({ values: { "dry-run": true } } as never);
+
+    expect(diffAllForApp).toHaveBeenCalledTimes(2);
+    expect(p.confirm).not.toHaveBeenCalled();
+    expect(runMultiAppWithFailCheck).not.toHaveBeenCalled();
+    expect(applyAllForApp).not.toHaveBeenCalled();
+    expect(p.log.info).toHaveBeenCalledWith(
+      "Dry run complete. No changes will be applied.",
+    );
+  });
+
+  it("multiApp で confirm をキャンセルした場合は apply されないこと", async () => {
+    const plan: ExecutionPlan = { orderedApps: [mockApp, mockApp2] };
+
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          multiApp: (
+            plan: ExecutionPlan,
+            config: ProjectConfig,
+          ) => Promise<void>;
+        },
+      ) => {
+        await handlers.multiApp(plan, mockMultiProjectConfig);
+      },
+    );
+
+    vi.mocked(p.confirm).mockResolvedValueOnce(false);
+
+    await applyCommand.run({ values: {} } as never);
+
+    expect(p.cancel).toHaveBeenCalled();
+    expect(runMultiAppWithFailCheck).not.toHaveBeenCalled();
+    expect(applyAllForApp).not.toHaveBeenCalled();
+  });
+
+  it("multiApp で全アプリ変更なし・seed なしの場合は 'No changes detected in any app.' を表示し apply しないこと（AC-7）", async () => {
+    const plan: ExecutionPlan = { orderedApps: [mockApp, mockApp2] };
+
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          multiApp: (
+            plan: ExecutionPlan,
+            config: ProjectConfig,
+          ) => Promise<void>;
+        },
+      ) => {
+        await handlers.multiApp(plan, mockMultiProjectConfig);
+      },
+    );
+
+    // Both apps: empty diff and no seed.
+    vi.mocked(diffAllForApp)
+      .mockResolvedValueOnce([
+        {
+          domain: "schema",
+          success: true,
+          result: {
+            isEmpty: true,
+            entries: [],
+            schemaFields: [],
+            summary: { added: 0, modified: 0, deleted: 0, total: 0 },
+            hasLayoutChanges: false,
+          },
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          domain: "schema",
+          success: true,
+          result: {
+            isEmpty: true,
+            entries: [],
+            schemaFields: [],
+            summary: { added: 0, modified: 0, deleted: 0, total: 0 },
+            hasLayoutChanges: false,
+          },
+        },
+      ]);
+    mockSeedStorageGet
+      .mockResolvedValueOnce({ exists: false, content: "" })
+      .mockResolvedValueOnce({ exists: false, content: "" });
+
+    await applyCommand.run({ values: {} } as never);
+
+    expect(p.log.success).toHaveBeenCalledWith(
+      "No changes detected in any app.",
+    );
+    expect(p.confirm).not.toHaveBeenCalled();
+    expect(runMultiAppWithFailCheck).not.toHaveBeenCalled();
+    expect(applyAllForApp).not.toHaveBeenCalled();
+  });
+
+  it("multiApp で seed ありアプリは diff 変更なしでも apply されること（AC-8）", async () => {
+    const plan: ExecutionPlan = { orderedApps: [mockApp] };
+
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          multiApp: (
+            plan: ExecutionPlan,
+            config: ProjectConfig,
+          ) => Promise<void>;
+        },
+      ) => {
+        await handlers.multiApp(plan, mockProjectConfig);
+      },
+    );
+
+    // Empty diff but seed exists (default mockSeedStorageGet returns exists:true).
+    vi.mocked(diffAllForApp).mockResolvedValueOnce([
+      {
+        domain: "schema",
+        success: true,
+        result: {
+          isEmpty: true,
+          entries: [],
+          schemaFields: [],
+          summary: { added: 0, modified: 0, deleted: 0, total: 0 },
+          hasLayoutChanges: false,
+        },
+      },
+    ]);
+
+    vi.mocked(runMultiAppWithFailCheck).mockImplementationOnce(
+      async (_plan, executor) => {
+        await executor(mockApp);
+      },
+    );
+
+    vi.mocked(p.confirm).mockResolvedValueOnce(true);
+
+    await applyCommand.run({ values: {} } as never);
+
+    expect(p.log.info).toHaveBeenCalledWith(
+      "Note: Seed data will be upserted (no diff preview available).",
+    );
+    expect(applyAllForApp).toHaveBeenCalled();
+  });
+
+  it("multiApp で変更なし・seed なしのアプリは executor 内で skip され {ok:true} を返すこと", async () => {
+    const plan: ExecutionPlan = { orderedApps: [mockApp, mockApp2] };
+
+    vi.mocked(routeMultiApp).mockImplementationOnce(
+      async (
+        _values: unknown,
+        handlers: {
+          multiApp: (
+            plan: ExecutionPlan,
+            config: ProjectConfig,
+          ) => Promise<void>;
+        },
+      ) => {
+        await handlers.multiApp(plan, mockMultiProjectConfig);
+      },
+    );
+
+    // app1: has diff changes + seed; app2: empty diff + no seed (skipped).
+    vi.mocked(diffAllForApp)
+      .mockResolvedValueOnce([
+        {
+          domain: "schema",
+          success: true,
+          result: {
+            isEmpty: false,
+            entries: [],
+            schemaFields: [],
+            summary: { added: 1, modified: 0, deleted: 0, total: 1 },
+            hasLayoutChanges: false,
+          },
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          domain: "schema",
+          success: true,
+          result: {
+            isEmpty: true,
+            entries: [],
+            schemaFields: [],
+            summary: { added: 0, modified: 0, deleted: 0, total: 0 },
+            hasLayoutChanges: false,
+          },
+        },
+      ]);
+    // app1 seed exists, app2 seed absent.
+    mockSeedStorageGet
+      .mockResolvedValueOnce({ exists: true, content: "records: []" })
+      .mockResolvedValueOnce({ exists: false, content: "" });
+
+    const outcomes: unknown[] = [];
+    vi.mocked(runMultiAppWithFailCheck).mockImplementationOnce(
+      async (_plan, executor) => {
+        for (const app of plan.orderedApps) {
+          outcomes.push(await executor(app));
+        }
+      },
+    );
+
+    vi.mocked(p.confirm).mockResolvedValueOnce(true);
+
+    await applyCommand.run({ values: {} } as never);
+
+    // Only app1 applied; app2 skipped but returns { ok: true }.
+    expect(applyAllForApp).toHaveBeenCalledTimes(1);
+    expect(p.log.info).toHaveBeenCalledWith("No changes. Skipping.");
+    expect(outcomes[1]).toEqual({ ok: true });
   });
 
   it("multiApp で先頭 app がドメイン失敗のとき executor が runApplyAll の {ok:false} をそのまま return すること", async () => {
@@ -403,74 +721,6 @@ describe("apply command", () => {
 
     await applyCommand.run({ values: {} } as never);
 
-    expect(capturedOutcome).toEqual({ ok: true });
-  });
-
-  it("multiApp で --dry-run の早期 return のとき executor が {ok:true} を return すること（fail-fast 誤発火しない・AC-6）", async () => {
-    const plan: ExecutionPlan = { orderedApps: [mockApp] };
-
-    vi.mocked(routeMultiApp).mockImplementationOnce(
-      async (
-        _values: unknown,
-        handlers: {
-          multiApp: (
-            plan: ExecutionPlan,
-            config: ProjectConfig,
-          ) => Promise<void>;
-        },
-      ) => {
-        await handlers.multiApp(plan, mockProjectConfig);
-      },
-    );
-
-    // Capture the dry-run early-return outcome. A regression that returns
-    // { ok: false } for dry-run would make executeMultiApp mark this app failed
-    // and fail-fast the rest; pinning { ok: true } prevents that (AC-6).
-    let capturedOutcome: unknown;
-    vi.mocked(runMultiAppWithFailCheck).mockImplementationOnce(
-      async (_plan, executor) => {
-        capturedOutcome = await executor(mockApp);
-      },
-    );
-
-    await applyCommand.run({ values: { "dry-run": true } } as never);
-
-    expect(applyAllForApp).not.toHaveBeenCalled();
-    expect(capturedOutcome).toEqual({ ok: true });
-  });
-
-  it("multiApp で確認キャンセルの早期 return のとき executor が {ok:true} を return すること（fail-fast 誤発火しない・AC-6）", async () => {
-    const plan: ExecutionPlan = { orderedApps: [mockApp] };
-
-    vi.mocked(routeMultiApp).mockImplementationOnce(
-      async (
-        _values: unknown,
-        handlers: {
-          multiApp: (
-            plan: ExecutionPlan,
-            config: ProjectConfig,
-          ) => Promise<void>;
-        },
-      ) => {
-        await handlers.multiApp(plan, mockProjectConfig);
-      },
-    );
-
-    // Capture the confirm-cancel early-return outcome. Cancelling is not a
-    // failure, so the executor must return { ok: true }; a regression to
-    // { ok: false } would trigger spurious fail-fast in multiApp (AC-6).
-    let capturedOutcome: unknown;
-    vi.mocked(runMultiAppWithFailCheck).mockImplementationOnce(
-      async (_plan, executor) => {
-        capturedOutcome = await executor(mockApp);
-      },
-    );
-
-    vi.mocked(p.confirm).mockResolvedValueOnce(false);
-
-    await applyCommand.run({ values: {} } as never);
-
-    expect(applyAllForApp).not.toHaveBeenCalled();
     expect(capturedOutcome).toEqual({ ok: true });
   });
 

--- a/src/cli/commands/apply.ts
+++ b/src/cli/commands/apply.ts
@@ -2,10 +2,13 @@ import { dirname, resolve } from "node:path";
 import * as p from "@clack/prompts";
 import { define } from "gunshi";
 import { applyAllForApp } from "@/core/application/applyAll/applyAllForApp";
+import type { ApplyAllContainers } from "@/core/application/container/applyAll";
 import { createCliApplyAllContainers } from "@/core/application/container/applyAllCli";
 import { diffAllForApp } from "@/core/application/diffAll/diffAllForApp";
 import { SystemError, SystemErrorCode } from "@/core/application/error";
 import type { AppExecutionOutcome } from "@/core/application/projectConfig/executeMultiApp";
+import type { AppEntry } from "@/core/domain/projectConfig/entity";
+import type { AppName } from "@/core/domain/projectConfig/valueObject";
 import { printApplyAllResults } from "../applyAllOutput";
 import { confirmArgs, kintoneArgs, multiAppArgs } from "../config";
 import { printDiffAllResults } from "../diffAllOutput";
@@ -41,27 +44,45 @@ type ApplyCliValues = MultiAppCliValues & {
   "dry-run"?: boolean;
 };
 
-async function runApplyAll(
-  cliConfig: {
-    baseUrl: string;
-    auth:
-      | { type: "apiToken"; apiToken: string | string[] }
-      | { type: "password"; username: string; password: string };
-    appId: string;
-    guestSpaceId?: string;
-  },
+type CliConfig = {
+  baseUrl: string;
+  auth:
+    | { type: "apiToken"; apiToken: string | string[] }
+    | { type: "password"; username: string; password: string };
+  appId: string;
+  guestSpaceId?: string;
+};
+
+/**
+ * Result of the diff phase carried into the apply phase. `containers` and
+ * `customizeBasePath` are reused so the apply phase does not regenerate them
+ * (the diff/apply containers share the same client). `hasChanges` is diff-based;
+ * `seedExists` is tracked separately because seed never appears in the diff
+ * preview yet still drives whether apply is required (see ADR-002).
+ */
+type ApplyDiffPhaseResult = {
+  containers: ApplyAllContainers;
+  customizeBasePath: string;
+  seedExists: boolean;
+  hasChanges: boolean;
+};
+
+/**
+ * Diff phase: generate containers, run the diff preview, print results, emit the
+ * seed note, and report whether there are changes. Does not print the dry-run
+ * note — the caller decides when to surface it.
+ */
+async function runApplyDiffPhase(
+  cliConfig: CliConfig,
   appName: string,
-  options: { skipConfirm: boolean; dryRun: boolean },
-): Promise<AppExecutionOutcome> {
+): Promise<ApplyDiffPhaseResult> {
   const { containers, diffContainers, paths } = createCliApplyAllContainers({
     ...cliConfig,
-    appName:
-      appName as import("@/core/domain/projectConfig/valueObject").AppName,
+    appName: appName as AppName,
   });
 
   const customizeBasePath = dirname(resolve(paths.customize));
 
-  // Step 1: Diff preview
   const ds = p.spinner();
   ds.start(`Comparing all domains for ${appName}...`);
   const diffResults = await diffAllForApp({
@@ -81,40 +102,26 @@ async function runApplyAll(
     p.log.info("Note: Seed data will be upserted (no diff preview available).");
   }
 
-  // Check if there are any changes
   const hasChanges = diffResults.some((r) => r.success && !r.result.isEmpty);
-  if (!hasChanges) {
-    p.log.success(
-      seedExists
-        ? "No changes detected. Seed data will still be upserted."
-        : "No changes detected.",
-    );
-  }
 
-  // Step 2: Dry run exits here
-  if (options.dryRun) {
-    p.log.info("Dry run complete. No changes will be applied.");
-    if (!hasChanges && seedExists) {
-      p.log.info(
-        "Note: Seed data would still be upserted when running without --dry-run.",
-      );
-    }
-    return { ok: true };
-  }
+  return { containers, customizeBasePath, seedExists, hasChanges };
+}
 
-  // Step 3: Confirm
-  if (!options.skipConfirm) {
-    const shouldContinue = await p.confirm({
-      message: "Apply these changes?",
-    });
-
-    if (p.isCancel(shouldContinue) || !shouldContinue) {
-      p.cancel("Apply cancelled.");
-      return { ok: true };
-    }
-  }
-
-  // Step 4: Apply all domains
+/**
+ * Apply phase: run apply for one app, print results, and compute the
+ * `AppExecutionOutcome`. Deploy stays embedded in `applyAllForApp`, so this
+ * preserves per-app dependency-ordered deploy even when called per app from the
+ * multi-app flow.
+ */
+async function runApplyExecutePhase({
+  containers,
+  customizeBasePath,
+  appName,
+}: {
+  containers: ApplyAllContainers;
+  customizeBasePath: string;
+  appName: string;
+}): Promise<AppExecutionOutcome> {
   const as = p.spinner();
   as.start(`Applying all domains for ${appName}...`);
   const output = await applyAllForApp({
@@ -128,11 +135,10 @@ async function runApplyAll(
     `Apply complete.${applyFailCount > 0 ? ` (${applyFailCount} failed)` : ""}`,
   );
 
-  // Step 5: Print results
   printApplyAllResults(output);
 
   // Return the failure verdict as an outcome; the caller decides how to map it
-  // to an exit code. runApplyAll never writes process.exitCode directly.
+  // to an exit code. This never writes process.exitCode directly.
   //
   // A failure is any domain that genuinely failed (execution failure or aborted
   // skip) or a required deploy that failed. A "not-found" skip (config file
@@ -155,6 +161,54 @@ async function runApplyAll(
   }
 
   return { ok: true };
+}
+
+/**
+ * Single-app wrapper that runs the diff and apply phases in sequence, preserving
+ * the original single-mode flow (diff → dry-run early return → confirm → apply).
+ * Multi-app does not use this wrapper; it inserts a single cross-app confirm
+ * between the phases instead.
+ */
+async function runApplyAll(
+  cliConfig: CliConfig,
+  appName: string,
+  options: { skipConfirm: boolean; dryRun: boolean },
+): Promise<AppExecutionOutcome> {
+  const { containers, customizeBasePath, seedExists, hasChanges } =
+    await runApplyDiffPhase(cliConfig, appName);
+
+  if (!hasChanges) {
+    p.log.success(
+      seedExists
+        ? "No changes detected. Seed data will still be upserted."
+        : "No changes detected.",
+    );
+  }
+
+  // Dry run exits here
+  if (options.dryRun) {
+    p.log.info("Dry run complete. No changes will be applied.");
+    if (!hasChanges && seedExists) {
+      p.log.info(
+        "Note: Seed data would still be upserted when running without --dry-run.",
+      );
+    }
+    return { ok: true };
+  }
+
+  // Confirm
+  if (!options.skipConfirm) {
+    const shouldContinue = await p.confirm({
+      message: "Apply these changes?",
+    });
+
+    if (p.isCancel(shouldContinue) || !shouldContinue) {
+      p.cancel("Apply cancelled.");
+      return { ok: true };
+    }
+  }
+
+  return runApplyExecutePhase({ containers, customizeBasePath, appName });
 }
 
 export default define({
@@ -186,10 +240,84 @@ export default define({
           }
         },
         multiApp: async (plan, projectConfig) => {
-          await runMultiAppWithFailCheck(plan, async (app) => {
+          // Mirrors applyCommandFactory's multiApp+diffPreview pattern: collect
+          // every app's diff first, confirm once, then apply in dependency
+          // order. Unlike the factory, deploy stays inside applyAllForApp
+          // (per-app dependency-ordered deploy is required here), so apply runs
+          // via runMultiAppWithFailCheck rather than an outer confirmAndDeploy.
+          // See ADR-001.
+
+          // Phase 1: Collect diffs for all apps (in dependency order). The apply
+          // container is generated once here and reused in Phase 5.
+          const appDiffResults: Array<
+            { app: AppEntry } & ApplyDiffPhaseResult
+          > = [];
+          for (const app of plan.orderedApps) {
             const cliConfig = resolveAppCliConfig(app, projectConfig, values);
             printAppHeader(app.name, app.appId);
-            return runApplyAll(cliConfig, app.name, { skipConfirm, dryRun });
+            const diff = await runApplyDiffPhase(cliConfig, app.name);
+            appDiffResults.push({ app, ...diff });
+          }
+
+          // Phase 2: Cross-app change detection. seed counts as "changes" even
+          // without a diff entry, so an app with only seed still triggers apply
+          // (see ADR-002).
+          const hasAnyChanges = appDiffResults.some(
+            (a) => a.hasChanges || a.seedExists,
+          );
+          if (!hasAnyChanges) {
+            p.log.success("No changes detected in any app.");
+            return;
+          }
+
+          // Phase 3: Dry run exits here — diffs are already shown above.
+          if (dryRun) {
+            p.log.info("Dry run complete. No changes will be applied.");
+            if (appDiffResults.some((a) => !a.hasChanges && a.seedExists)) {
+              p.log.info(
+                "Note: Seed data would still be upserted when running without --dry-run.",
+              );
+            }
+            return;
+          }
+
+          // Phase 4: Single confirm for all apps.
+          if (!skipConfirm) {
+            const shouldContinue = await p.confirm({
+              message: "Apply these changes to all apps?",
+            });
+
+            if (p.isCancel(shouldContinue) || !shouldContinue) {
+              p.cancel("Apply cancelled.");
+              return;
+            }
+          }
+
+          // Phase 5: Apply in dependency order. Headers were already printed in
+          // Phase 1, so use runMultiAppWithFailCheck (no headers) to avoid a
+          // duplicate header per app. Each executor reuses the Phase 1 container
+          // and returns the AppExecutionOutcome verbatim to preserve fail-fast.
+          await runMultiAppWithFailCheck(plan, async (app) => {
+            const entry = appDiffResults.find((a) => a.app.name === app.name);
+            if (!entry) {
+              throw new SystemError(
+                SystemErrorCode.InternalServerError,
+                `App diff result not found for "${app.name}"`,
+              );
+            }
+
+            // Skip apps with neither diff changes nor seed (ADR-002); returning
+            // { ok: true } keeps them from inducing fail-fast.
+            if (!entry.hasChanges && !entry.seedExists) {
+              p.log.info("No changes. Skipping.");
+              return { ok: true };
+            }
+
+            return runApplyExecutePhase({
+              containers: entry.containers,
+              customizeBasePath: entry.customizeBasePath,
+              appName: app.name,
+            });
           });
         },
       });

--- a/src/cli/commands/apply.ts
+++ b/src/cli/commands/apply.ts
@@ -267,10 +267,12 @@ export default define({
           );
           if (!hasAnyChanges) {
             p.log.success("No changes detected in any app.");
-            return;
           }
 
-          // Phase 3: Dry run exits here — diffs are already shown above.
+          // Phase 3: Dry run exits here — diffs are already shown above. Mirror
+          // single mode (runApplyAll): emit the no-changes message above first,
+          // then always surface "Dry run complete." so a --dry-run invoker gets
+          // explicit dry-run confirmation even when nothing changed.
           if (dryRun) {
             p.log.info("Dry run complete. No changes will be applied.");
             if (appDiffResults.some((a) => !a.hasChanges && a.seedExists)) {
@@ -278,6 +280,11 @@ export default define({
                 "Note: Seed data would still be upserted when running without --dry-run.",
               );
             }
+            return;
+          }
+
+          // Without dry-run, no changes anywhere means there is nothing to apply.
+          if (!hasAnyChanges) {
             return;
           }
 


### PR DESCRIPTION
## Summary
- multi-app `apply` を「全アプリの diff を一括表示 → 1回の確認 (\"Apply these changes to all apps?\") → 依存順で一括適用」フローに変更（従来は per-app confirm）
- `runApplyAll` を `runApplyDiffPhase`（diff）/ `runApplyExecutePhase`（apply）に分割。single モードは両フェーズを順に呼ぶ薄いラッパとして挙動・メッセージを完全維持
- multiApp ハンドラを `applyCommandFactory.ts` の multiApp+diffPreview パターンに準拠（全アプリ diff 収集 → 横断 hasChanges 判定 → dry-run 早期 return → 単一 confirm → `runMultiAppWithFailCheck` で依存順 apply）
- deploy は per-app 依存順序保証のため `applyAllForApp` 内包のまま維持（ADR-001）。seed ありアプリは diff 変更なしでも apply（ADR-002）

## Issue
Closes #155

## Implementation Plan
Based on `.issue/155/plan.md`（ADR: `.issue/155/adr.md`）

## Test plan

### デプロイ・動作確認方法
- 自動テスト: \`pnpm test\`（\`apply.test.ts\` 含む。2370 tests pass）
- 開発モード手動確認: \`pnpm dev apply --all\` / \`--all --dry-run\` / \`--all --yes\`（multi-app 用の \`kintone-migrator.yaml\` と実 kintone 環境が必要）

### 確認項目
- 全アプリ diff が依存順に一括表示され、confirm は1回だけ（AC-1/2）
- 確認後、依存順に一括適用・per-app deploy 順序維持（AC-3）／fail-fast 維持（AC-4）
- \`--yes\` で確認スキップ（AC-5）／\`--dry-run\` で diff のみ（AC-6）
- 全アプリ変更なし & seed なしで "No changes detected in any app."（AC-7）／seed ありは変更なしでも upsert（AC-8）
- single-app / single-legacy は挙動・メッセージ不変（AC-9）

## Browser Verification
- スキップ理由: 本リポジトリは CLI ツールで Web UI がなく（\`package.json\` の bin は CLI、dev サーバーなし）、testing.md に画面操作項目が1件もないため。代わりに \`pnpm test\`（2370 件 pass）で受け入れ基準を担保

🤖 Generated with [Claude Code](https://claude.com/claude-code)