### PR TITLE
feat(schema): pull/push 双方向同期（base スナップショット + 3-way merge）

### DIFF
--- a/src/cli/__tests__/config.test.ts
+++ b/src/cli/__tests__/config.test.ts
@@ -18,6 +18,7 @@ describe("resolveConfig", () => {
       auth: { type: "password", username: "user", password: "pass" },
       appId: "42",
       schemaFilePath: "schema.yaml",
+      stateSchemaFilePath: "state/schema.yaml",
     });
   });
 
@@ -32,6 +33,7 @@ describe("resolveConfig", () => {
       auth: { type: "apiToken", apiToken: "my-token" },
       appId: "42",
       schemaFilePath: "schema.yaml",
+      stateSchemaFilePath: "state/schema.yaml",
     });
   });
 
@@ -130,6 +132,7 @@ describe("resolveConfig", () => {
       auth: { type: "password", username: "cli-user", password: "cli-pass" },
       appId: "99",
       schemaFilePath: "custom.yaml",
+      stateSchemaFilePath: "state/schema.yaml",
     });
   });
 });

--- a/src/cli/commands/schema/__tests__/diff.test.ts
+++ b/src/cli/commands/schema/__tests__/diff.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { DetectDiffOutput } from "@/core/application/formSchema/dto";
+import type { DetectThreeWayDiffOutput } from "@/core/application/formSchema/dto";
 import type { FieldCode } from "@/core/domain/formSchema/valueObject";
 
 vi.mock("@clack/prompts", () => ({
@@ -23,6 +23,7 @@ vi.mock("@/cli/config", () => ({
     password: "pass",
     appId: "1",
     schemaFilePath: "schema.yaml",
+    stateSchemaFilePath: "state/schema.yaml",
   })),
 }));
 
@@ -45,10 +46,10 @@ vi.mock("@/core/application/container/cli", () => ({
   createCliContainer: vi.fn(() => ({})),
 }));
 
-vi.mock("@/core/application/formSchema/detectDiff");
+vi.mock("@/core/application/formSchema/detectThreeWayDiff");
 
 vi.mock("@/cli/output", () => ({
-  printDiffResult: vi.fn(),
+  printThreeWayDiffResult: vi.fn(),
   printAppHeader: vi.fn(),
   printMultiAppResult: vi.fn(),
 }));
@@ -58,76 +59,69 @@ vi.mock("@/cli/handleError", () => ({
 }));
 
 import { handleCliError } from "@/cli/handleError";
-import { printDiffResult } from "@/cli/output";
-import { detectDiff } from "@/core/application/formSchema/detectDiff";
+import { printThreeWayDiffResult } from "@/cli/output";
+import { detectThreeWayDiff } from "@/core/application/formSchema/detectThreeWayDiff";
 import command from "../diff";
 
 afterEach(() => {
   vi.clearAllMocks();
 });
 
-function emptyDiffResult(): DetectDiffOutput {
+function twoWayResult(): DetectThreeWayDiffOutput {
   return {
-    entries: [],
-    schemaFields: [],
-    summary: { added: 0, modified: 0, deleted: 0, total: 0 },
-    isEmpty: true,
-    hasLayoutChanges: false,
+    mode: "two-way",
+    diff: {
+      entries: [],
+      schemaFields: [],
+      summary: { added: 0, modified: 0, deleted: 0, total: 0 },
+      isEmpty: true,
+      hasLayoutChanges: false,
+    },
+  };
+}
+
+function threeWayResult(): DetectThreeWayDiffOutput {
+  return {
+    mode: "three-way",
+    localChanges: [
+      { fieldCode: "name" as FieldCode, fieldLabel: "名前", kind: "localOnly" },
+    ],
+    remoteDrift: [],
+    conflicts: [],
+    layoutLocalChanged: false,
+    layoutRemoteChanged: false,
+    layoutConflict: false,
+    isEmpty: false,
   };
 }
 
 describe("diff コマンド", () => {
-  it("スキーマとフォームの差分を検出し結果を表示する", async () => {
-    const mockResult = emptyDiffResult();
-    vi.mocked(detectDiff).mockResolvedValue(mockResult);
+  it("state がない場合、2-way 結果が printer に渡される", async () => {
+    const mockResult = twoWayResult();
+    vi.mocked(detectThreeWayDiff).mockResolvedValue(mockResult);
 
     await command.run({ values: {} } as never);
 
-    expect(detectDiff).toHaveBeenCalled();
-    expect(printDiffResult).toHaveBeenCalledWith(mockResult);
+    expect(detectThreeWayDiff).toHaveBeenCalled();
+    expect(printThreeWayDiffResult).toHaveBeenCalledWith(mockResult);
   });
 
-  it("差分がある場合もprintDiffResultに結果が渡される", async () => {
-    const mockResult: DetectDiffOutput = {
-      entries: [
-        {
-          type: "added",
-          fieldCode: "name" as FieldCode,
-          fieldLabel: "名前",
-          details: "新規追加",
-          after: {
-            code: "name" as FieldCode,
-            type: "SINGLE_LINE_TEXT",
-            label: "名前",
-            properties: {},
-          },
-        },
-      ],
-      schemaFields: [
-        {
-          fieldCode: "name" as FieldCode,
-          fieldLabel: "名前",
-          fieldType: "SINGLE_LINE_TEXT",
-        },
-      ],
-      summary: { added: 1, modified: 0, deleted: 0, total: 1 },
-      isEmpty: false,
-      hasLayoutChanges: false,
-    };
-    vi.mocked(detectDiff).mockResolvedValue(mockResult);
+  it("state がある場合、3-way 結果が printer に渡される", async () => {
+    const mockResult = threeWayResult();
+    vi.mocked(detectThreeWayDiff).mockResolvedValue(mockResult);
 
     await command.run({ values: {} } as never);
 
-    expect(printDiffResult).toHaveBeenCalledWith(mockResult);
+    expect(printThreeWayDiffResult).toHaveBeenCalledWith(mockResult);
   });
 
   it("エラー発生時にhandleCliErrorで処理される", async () => {
     const error = new Error("API connection failed");
-    vi.mocked(detectDiff).mockRejectedValue(error);
+    vi.mocked(detectThreeWayDiff).mockRejectedValue(error);
 
     await command.run({ values: {} } as never);
 
     expect(handleCliError).toHaveBeenCalledWith(error);
-    expect(printDiffResult).not.toHaveBeenCalled();
+    expect(printThreeWayDiffResult).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/commands/schema/__tests__/pull.test.ts
+++ b/src/cli/commands/schema/__tests__/pull.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ValidationError } from "@/core/application/error";
+import type { PullSchemaOutput } from "@/core/application/formSchema/dto";
+import type {
+  FieldCode,
+  FormSchemaThreeWayMerge,
+} from "@/core/domain/formSchema/valueObject";
+
+vi.mock("@clack/prompts", () => ({
+  spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn() })),
+  log: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+  outro: vi.fn(),
+  select: vi.fn(),
+  isCancel: vi.fn(),
+  cancel: vi.fn(),
+}));
+
+vi.mock("@/cli/config", () => ({
+  kintoneArgs: {},
+  multiAppArgs: {},
+  resolveConfig: vi.fn(() => ({
+    baseUrl: "https://test.cybozu.com",
+    appId: "1",
+    schemaFilePath: "schema.yaml",
+    stateSchemaFilePath: "state/schema.yaml",
+  })),
+}));
+
+vi.mock("@/cli/projectConfig", () => ({
+  resolveTarget: vi.fn(() => ({ mode: "single-legacy" })),
+  printAvailableApps: vi.fn(),
+  resolveAppCliConfig: vi.fn(),
+  routeMultiApp: vi.fn(
+    async (
+      values: { all?: boolean },
+      handlers: {
+        singleLegacy: () => Promise<void>;
+        multiApp: () => Promise<void>;
+      },
+    ) => {
+      if (values.all) {
+        await handlers.multiApp();
+        return;
+      }
+      await handlers.singleLegacy();
+    },
+  ),
+}));
+
+vi.mock("@/core/application/container/cli", () => ({
+  createCliContainer: vi.fn(() => ({})),
+}));
+
+vi.mock("@/core/application/formSchema/pullSchema", () => ({
+  pullSchema: vi.fn(),
+  applyPulledMerge: vi.fn(),
+}));
+
+vi.mock("@/cli/output", () => ({
+  printAppHeader: vi.fn(),
+  printMultiAppResult: vi.fn(),
+}));
+
+vi.mock("@/cli/handleError", () => ({
+  handleCliError: vi.fn(),
+}));
+
+import * as p from "@clack/prompts";
+import { handleCliError } from "@/cli/handleError";
+import {
+  applyPulledMerge,
+  pullSchema,
+} from "@/core/application/formSchema/pullSchema";
+import command from "../pull";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(p.isCancel).mockReturnValue(false);
+});
+
+function noConflictMerge(): FormSchemaThreeWayMerge {
+  return {
+    fieldEntries: [],
+    fieldConflicts: [],
+    layoutConflict: false,
+    baseLayout: [],
+    localLayout: [],
+    remoteLayout: [],
+    hasConflict: false,
+    baseFields: new Map(),
+    localFields: new Map(),
+    remoteFields: new Map(),
+  };
+}
+
+function conflictMerge(): FormSchemaThreeWayMerge {
+  const entry = {
+    key: "name" as FieldCode,
+    change: { kind: "conflict" as const },
+  };
+  return {
+    fieldEntries: [entry],
+    fieldConflicts: [entry],
+    layoutConflict: false,
+    baseLayout: [],
+    localLayout: [],
+    remoteLayout: [],
+    hasConflict: true,
+    baseFields: new Map(),
+    localFields: new Map(),
+    remoteFields: new Map(),
+  };
+}
+
+function mergedOutput(
+  merge: FormSchemaThreeWayMerge,
+): Extract<PullSchemaOutput, { mode: "merged" }> {
+  return {
+    mode: "merged",
+    merge,
+    remoteRevision: "5",
+    // remoteSchema is opaque to the CLI; cast a minimal stub.
+    remoteSchema: {} as never,
+  };
+}
+
+describe("pull コマンド", () => {
+  it("--force のとき force:true で pull する", async () => {
+    vi.mocked(pullSchema).mockResolvedValue({
+      mode: "force",
+      schemaText: "x",
+    });
+
+    await command.run({ values: { force: true } } as never);
+
+    expect(pullSchema).toHaveBeenCalledWith({
+      container: {},
+      input: { force: true },
+    });
+  });
+
+  it("conflict なしの merged は applyPulledMerge が呼ばれる", async () => {
+    vi.mocked(pullSchema).mockResolvedValue(mergedOutput(noConflictMerge()));
+
+    await command.run({ values: {} } as never);
+
+    expect(applyPulledMerge).toHaveBeenCalled();
+  });
+
+  it("--ours で conflict を local 一括解決する", async () => {
+    vi.mocked(pullSchema).mockResolvedValue(mergedOutput(conflictMerge()));
+
+    await command.run({ values: { ours: true } } as never);
+
+    expect(p.select).not.toHaveBeenCalled();
+    const call = vi.mocked(applyPulledMerge).mock.calls[0]?.[0];
+    expect(call?.input.resolution.fields.get("name" as FieldCode)).toBe(
+      "local",
+    );
+  });
+
+  it("--theirs で conflict を remote 一括解決する", async () => {
+    vi.mocked(pullSchema).mockResolvedValue(mergedOutput(conflictMerge()));
+
+    await command.run({ values: { theirs: true } } as never);
+
+    const call = vi.mocked(applyPulledMerge).mock.calls[0]?.[0];
+    expect(call?.input.resolution.fields.get("name" as FieldCode)).toBe(
+      "remote",
+    );
+  });
+
+  it("インタラクティブ選択で conflict を解決する", async () => {
+    vi.mocked(pullSchema).mockResolvedValue(mergedOutput(conflictMerge()));
+    vi.mocked(p.select).mockResolvedValue("remote" as never);
+
+    await command.run({ values: {} } as never);
+
+    expect(p.select).toHaveBeenCalled();
+    expect(applyPulledMerge).toHaveBeenCalled();
+  });
+
+  it("conflict 解決を中断（isCancel）した場合 applyPulledMerge を呼ばない（AC-15）", async () => {
+    vi.mocked(pullSchema).mockResolvedValue(mergedOutput(conflictMerge()));
+    vi.mocked(p.select).mockResolvedValue(Symbol.for("cancel") as never);
+    vi.mocked(p.isCancel).mockReturnValue(true);
+
+    await command.run({ values: {} } as never);
+
+    expect(applyPulledMerge).not.toHaveBeenCalled();
+    expect(p.cancel).toHaveBeenCalledWith(expect.stringContaining("unchanged"));
+  });
+
+  it("--ours と --theirs の併用はエラー", async () => {
+    await command.run({ values: { ours: true, theirs: true } } as never);
+
+    const handled = vi.mocked(handleCliError).mock.calls[0]?.[0];
+    expect(handled).toBeInstanceOf(ValidationError);
+    expect(pullSchema).not.toHaveBeenCalled();
+  });
+
+  it("--all は未対応エラーになる", async () => {
+    await command.run({ values: { all: true } } as never);
+
+    const handled = vi.mocked(handleCliError).mock.calls[0]?.[0];
+    expect(handled).toBeInstanceOf(ValidationError);
+    expect((handled as ValidationError).message).toContain("--all");
+    expect(pullSchema).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/commands/schema/__tests__/push.test.ts
+++ b/src/cli/commands/schema/__tests__/push.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ConflictError,
+  ConflictErrorCode,
+  ValidationError,
+} from "@/core/application/error";
+import { PUSH_DRIFT_MESSAGE } from "@/core/application/formSchema/pushSchema";
+
+vi.mock("@clack/prompts", () => ({
+  spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn() })),
+  log: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+  outro: vi.fn(),
+  confirm: vi.fn(),
+  isCancel: vi.fn(),
+  cancel: vi.fn(),
+}));
+
+vi.mock("@/cli/config", () => ({
+  kintoneArgs: {},
+  multiAppArgs: {},
+  confirmArgs: {},
+  resolveConfig: vi.fn(() => ({
+    baseUrl: "https://test.cybozu.com",
+    appId: "1",
+    schemaFilePath: "schema.yaml",
+    stateSchemaFilePath: "state/schema.yaml",
+  })),
+}));
+
+vi.mock("@/cli/projectConfig", () => ({
+  resolveTarget: vi.fn(() => ({ mode: "single-legacy" })),
+  printAvailableApps: vi.fn(),
+  resolveAppCliConfig: vi.fn(),
+  routeMultiApp: vi.fn(
+    async (
+      values: { all?: boolean },
+      handlers: {
+        singleLegacy: () => Promise<void>;
+        multiApp: () => Promise<void>;
+      },
+    ) => {
+      if (values.all) {
+        await handlers.multiApp();
+        return;
+      }
+      await handlers.singleLegacy();
+    },
+  ),
+}));
+
+vi.mock("@/core/application/container/cli", () => ({
+  createCliContainer: vi.fn(() => ({})),
+}));
+
+vi.mock("@/core/application/formSchema/pushSchema", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/core/application/formSchema/pushSchema")
+  >("@/core/application/formSchema/pushSchema");
+  return { ...actual, pushSchema: vi.fn() };
+});
+
+vi.mock("@/cli/output", () => ({
+  confirmAndDeploy: vi.fn(),
+  printAppHeader: vi.fn(),
+  printMultiAppResult: vi.fn(),
+}));
+
+vi.mock("@/cli/handleError", () => ({
+  handleCliError: vi.fn(),
+}));
+
+import * as p from "@clack/prompts";
+import { handleCliError } from "@/cli/handleError";
+import { confirmAndDeploy } from "@/cli/output";
+import { pushSchema } from "@/core/application/formSchema/pushSchema";
+import command from "../push";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(p.isCancel).mockReturnValue(false);
+});
+
+describe("push コマンド", () => {
+  it("確認後に push し、その後 confirmAndDeploy が呼ばれる（AC-14）", async () => {
+    vi.mocked(p.confirm).mockResolvedValue(true);
+    vi.mocked(pushSchema).mockResolvedValue({ mode: "push", revision: "2" });
+
+    await command.run({ values: {} } as never);
+
+    expect(pushSchema).toHaveBeenCalledWith({
+      container: {},
+      input: { force: false },
+    });
+    expect(confirmAndDeploy).toHaveBeenCalled();
+  });
+
+  it("ユーザーがキャンセルした場合 push しない", async () => {
+    vi.mocked(p.confirm).mockResolvedValue(false);
+
+    await command.run({ values: {} } as never);
+
+    expect(pushSchema).not.toHaveBeenCalled();
+    expect(confirmAndDeploy).not.toHaveBeenCalled();
+  });
+
+  it("--force のとき force:true で push する", async () => {
+    vi.mocked(p.confirm).mockResolvedValue(true);
+    vi.mocked(pushSchema).mockResolvedValue({ mode: "push", revision: "2" });
+
+    await command.run({ values: { force: true } } as never);
+
+    expect(pushSchema).toHaveBeenCalledWith({
+      container: {},
+      input: { force: true },
+    });
+  });
+
+  it("drift 由来 ConflictError はそのままのメッセージで処理される", async () => {
+    vi.mocked(p.confirm).mockResolvedValue(true);
+    const driftError = new ConflictError(
+      ConflictErrorCode.Conflict,
+      PUSH_DRIFT_MESSAGE,
+    );
+    vi.mocked(pushSchema).mockRejectedValue(driftError);
+
+    await command.run({ values: {} } as never);
+
+    expect(handleCliError).toHaveBeenCalledWith(driftError);
+  });
+
+  it("API 楽観ロック由来 ConflictError は TOCTOU メッセージに再ラップされる（ADR-008）", async () => {
+    vi.mocked(p.confirm).mockResolvedValue(true);
+    const apiError = new ConflictError(
+      ConflictErrorCode.Conflict,
+      "... (revision conflict — GAIA_CO02). Please retry the operation.",
+    );
+    vi.mocked(pushSchema).mockRejectedValue(apiError);
+
+    await command.run({ values: {} } as never);
+
+    const handled = vi.mocked(handleCliError).mock.calls[0]?.[0];
+    expect(handled).toBeInstanceOf(ConflictError);
+    expect((handled as ConflictError).message).toContain(
+      "適用中に実環境が変更されました",
+    );
+    expect((handled as ConflictError).message).not.toBe(PUSH_DRIFT_MESSAGE);
+  });
+
+  it("--all は未対応エラーになる", async () => {
+    await command.run({ values: { all: true } } as never);
+
+    const handled = vi.mocked(handleCliError).mock.calls[0]?.[0];
+    expect(handled).toBeInstanceOf(ValidationError);
+    expect((handled as ValidationError).message).toContain("--all");
+    expect(pushSchema).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/commands/schema/__tests__/push.test.ts
+++ b/src/cli/commands/schema/__tests__/push.test.ts
@@ -120,10 +120,10 @@ describe("push コマンド", () => {
     });
   });
 
-  it("drift 由来 ConflictError はそのままのメッセージで処理される", async () => {
+  it("drift 由来 ConflictError（SchemaDrift）はそのままのメッセージで処理される", async () => {
     vi.mocked(p.confirm).mockResolvedValue(true);
     const driftError = new ConflictError(
-      ConflictErrorCode.Conflict,
+      ConflictErrorCode.SchemaDrift,
       PUSH_DRIFT_MESSAGE,
     );
     vi.mocked(pushSchema).mockRejectedValue(driftError);
@@ -145,8 +145,8 @@ describe("push コマンド", () => {
 
     const handled = vi.mocked(handleCliError).mock.calls[0]?.[0];
     expect(handled).toBeInstanceOf(ConflictError);
-    expect((handled as ConflictError).message).toContain(
-      "適用中に実環境が変更されました",
+    expect((handled as ConflictError).message).toBe(
+      "The remote changed while applying. Run `schema pull` and retry.",
     );
     expect((handled as ConflictError).message).not.toBe(PUSH_DRIFT_MESSAGE);
   });

--- a/src/cli/commands/schema/diff.ts
+++ b/src/cli/commands/schema/diff.ts
@@ -2,10 +2,10 @@ import * as p from "@clack/prompts";
 import { define } from "gunshi";
 import { createCliContainer } from "@/core/application/container/cli";
 import type { FormSchemaContainer } from "@/core/application/container/formSchema";
-import { detectDiff } from "@/core/application/formSchema/detectDiff";
+import { detectThreeWayDiff } from "@/core/application/formSchema/detectThreeWayDiff";
 import { kintoneArgs, multiAppArgs, resolveConfig } from "../../config";
 import { handleCliError } from "../../handleError";
-import { printAppHeader, printDiffResult } from "../../output";
+import { printAppHeader, printThreeWayDiffResult } from "../../output";
 import {
   resolveAppCliConfig,
   routeMultiApp,
@@ -15,16 +15,16 @@ import {
 async function runDiff(container: FormSchemaContainer): Promise<void> {
   const s = p.spinner();
   s.start("Comparing schema...");
-  let result: Awaited<ReturnType<typeof detectDiff>>;
+  let result: Awaited<ReturnType<typeof detectThreeWayDiff>>;
   try {
-    result = await detectDiff({ container });
+    result = await detectThreeWayDiff({ container });
   } catch (error) {
     s.stop("Comparison failed.");
     throw error;
   }
   s.stop("Comparison complete.");
 
-  printDiffResult(result);
+  printThreeWayDiffResult(result);
 }
 
 export default define({

--- a/src/cli/commands/schema/index.ts
+++ b/src/cli/commands/schema/index.ts
@@ -4,6 +4,8 @@ import diffCommand from "./diff";
 import dumpCommand from "./dump";
 import migrateCommand from "./migrate";
 import overrideCommand from "./override";
+import pullCommand from "./pull";
+import pushCommand from "./push";
 import validateCommand from "./validate";
 
 export default define({
@@ -16,6 +18,8 @@ export default define({
     capture: captureCommand,
     validate: validateCommand,
     dump: dumpCommand,
+    pull: pullCommand,
+    push: pushCommand,
   },
   run: () => {},
 });

--- a/src/cli/commands/schema/pull.ts
+++ b/src/cli/commands/schema/pull.ts
@@ -1,0 +1,219 @@
+import * as p from "@clack/prompts";
+import { define } from "gunshi";
+import pc from "picocolors";
+import { createCliContainer } from "@/core/application/container/cli";
+import type { FormSchemaContainer } from "@/core/application/container/formSchema";
+import { ValidationError, ValidationErrorCode } from "@/core/application/error";
+import {
+  applyPulledMerge,
+  pullSchema,
+} from "@/core/application/formSchema/pullSchema";
+import type {
+  FieldCode,
+  FormSchemaThreeWayMerge,
+  MergeResolution,
+} from "@/core/domain/formSchema/valueObject";
+import { kintoneArgs, multiAppArgs, resolveConfig } from "../../config";
+import { handleCliError } from "../../handleError";
+import { resolveAppCliConfig, routeMultiApp } from "../../projectConfig";
+
+type PullOptions = {
+  readonly force: boolean;
+  readonly ours: boolean;
+  readonly theirs: boolean;
+};
+
+// Result of conflict resolution; `undefined` means the user aborted (Ctrl-C).
+async function resolveConflicts(
+  merge: FormSchemaThreeWayMerge,
+  options: PullOptions,
+): Promise<MergeResolution | undefined> {
+  const fields = new Map<FieldCode, "local" | "remote">();
+
+  for (const conflict of merge.fieldConflicts) {
+    let choice: "local" | "remote";
+    if (options.ours) {
+      choice = "local";
+    } else if (options.theirs) {
+      choice = "remote";
+    } else {
+      const selected = await p.select({
+        message: `Conflict on field "${conflict.key}". Keep which side?`,
+        options: [
+          { value: "local", label: "local (ours)" },
+          { value: "remote", label: "remote (theirs)" },
+        ],
+      });
+      if (p.isCancel(selected)) {
+        return undefined;
+      }
+      choice = selected as "local" | "remote";
+    }
+    fields.set(conflict.key, choice);
+  }
+
+  let layout: MergeResolution["layout"] = "noConflict";
+  if (merge.layoutConflict) {
+    if (options.ours) {
+      layout = "local";
+    } else if (options.theirs) {
+      layout = "remote";
+    } else {
+      const selected = await p.select({
+        message: "Conflict on layout. Keep which side?",
+        options: [
+          { value: "local", label: "local (ours)" },
+          { value: "remote", label: "remote (theirs)" },
+        ],
+      });
+      if (p.isCancel(selected)) {
+        return undefined;
+      }
+      layout = selected as "local" | "remote";
+    }
+  }
+
+  return { fields, layout };
+}
+
+async function runPull(
+  container: FormSchemaContainer,
+  schemaFilePath: string,
+  options: PullOptions,
+): Promise<void> {
+  const s = p.spinner();
+  s.start("Pulling schema from kintone...");
+  const result = await pullSchema({
+    container,
+    input: { force: options.force },
+  });
+  s.stop("Schema pulled.");
+
+  if (result.mode === "force") {
+    p.log.success(
+      `Local schema overwritten from remote: ${pc.cyan(schemaFilePath)}`,
+    );
+    return;
+  }
+
+  if (result.mode === "firstTime") {
+    p.log.warn(
+      "No base snapshot found. Initialized state from remote (one-way pull).",
+    );
+    p.log.success(`Local schema written: ${pc.cyan(schemaFilePath)}`);
+    return;
+  }
+
+  // merged
+  const { merge } = result;
+  if (!merge.hasConflict) {
+    const resolution: MergeResolution = {
+      fields: new Map(),
+      layout: "noConflict",
+    };
+    await applyPulledMerge({
+      container,
+      input: {
+        merge,
+        resolution,
+        remoteRevision: result.remoteRevision,
+        remoteSchema: result.remoteSchema,
+      },
+    });
+    p.log.success(
+      `Local schema merged and written: ${pc.cyan(schemaFilePath)}`,
+    );
+    return;
+  }
+
+  if (options.ours) {
+    p.log.info("Resolving all conflicts in favor of local (--ours).");
+  } else if (options.theirs) {
+    p.log.info("Resolving all conflicts in favor of remote (--theirs).");
+  }
+
+  const resolution = await resolveConflicts(merge, options);
+  if (resolution === undefined) {
+    // Aborted: do not touch local YAML or state (AC-15).
+    p.cancel("Pull cancelled. Local schema and state were left unchanged.");
+    return;
+  }
+
+  await applyPulledMerge({
+    container,
+    input: {
+      merge,
+      resolution,
+      remoteRevision: result.remoteRevision,
+      remoteSchema: result.remoteSchema,
+    },
+  });
+  p.log.success(
+    `Conflicts resolved. Local schema written: ${pc.cyan(schemaFilePath)}`,
+  );
+}
+
+export default define({
+  name: "pull",
+  description:
+    "Pull remote form schema into the local schema file (3-way merge)",
+  args: {
+    ...kintoneArgs,
+    ...multiAppArgs,
+    force: {
+      type: "boolean" as const,
+      description: "Overwrite local with remote (capture-equivalent)",
+    },
+    ours: {
+      type: "boolean" as const,
+      description: "Resolve all conflicts in favor of local",
+    },
+    theirs: {
+      type: "boolean" as const,
+      description: "Resolve all conflicts in favor of remote",
+    },
+  },
+  run: async (ctx) => {
+    try {
+      if (ctx.values.all === true) {
+        throw new ValidationError(
+          ValidationErrorCode.InvalidInput,
+          "schema pull does not support --all yet. Use --app <name> or a single app.",
+        );
+      }
+
+      const options: PullOptions = {
+        force: ctx.values.force === true,
+        ours: ctx.values.ours === true,
+        theirs: ctx.values.theirs === true,
+      };
+      if (options.ours && options.theirs) {
+        throw new ValidationError(
+          ValidationErrorCode.InvalidInput,
+          "--ours and --theirs cannot be used together",
+        );
+      }
+
+      await routeMultiApp(ctx.values, {
+        singleLegacy: async () => {
+          const config = resolveConfig(ctx.values);
+          const container = createCliContainer(config);
+          await runPull(container, config.schemaFilePath, options);
+        },
+        singleApp: async (app, projectConfig) => {
+          const config = resolveAppCliConfig(app, projectConfig, ctx.values);
+          const container = createCliContainer(config);
+          await runPull(container, config.schemaFilePath, options);
+        },
+        multiApp: async () => {
+          throw new ValidationError(
+            ValidationErrorCode.InvalidInput,
+            "schema pull does not support --all yet. Use --app <name> or a single app.",
+          );
+        },
+      });
+    } catch (error) {
+      handleCliError(error);
+    }
+  },
+});

--- a/src/cli/commands/schema/pull.ts
+++ b/src/cli/commands/schema/pull.ts
@@ -104,7 +104,6 @@ async function runPull(
     return;
   }
 
-  // merged
   const { merge } = result;
   if (!merge.hasConflict) {
     const resolution: MergeResolution = {

--- a/src/cli/commands/schema/push.ts
+++ b/src/cli/commands/schema/push.ts
@@ -9,10 +9,7 @@ import {
   ValidationError,
   ValidationErrorCode,
 } from "@/core/application/error";
-import {
-  PUSH_DRIFT_MESSAGE,
-  pushSchema,
-} from "@/core/application/formSchema/pushSchema";
+import { pushSchema } from "@/core/application/formSchema/pushSchema";
 import {
   confirmArgs,
   kintoneArgs,
@@ -27,7 +24,7 @@ import { resolveAppCliConfig, routeMultiApp } from "../../projectConfig";
 // re-wrapped with a TOCTOU-specific message, distinct from the snapshot-drift
 // rejection message (ADR-008).
 const PUSH_TOCTOU_MESSAGE =
-  "適用中に実環境が変更されました。`schema pull` 後に再実行してください。";
+  "The remote changed while applying. Run `schema pull` and retry.";
 
 async function runPush(
   container: FormSchemaContainer,
@@ -48,12 +45,18 @@ async function runPush(
 
   const s = p.spinner();
   s.start("Pushing schema to kintone...");
+  let result: Awaited<ReturnType<typeof pushSchema>>;
   try {
-    await pushSchema({ container, input: { force } });
+    result = await pushSchema({ container, input: { force } });
   } catch (error) {
     s.stop("Push failed.");
-    // Distinguish API optimistic-lock (TOCTOU) conflicts from snapshot drift.
-    if (isConflictError(error) && error.message !== PUSH_DRIFT_MESSAGE) {
+    // Distinguish API optimistic-lock (TOCTOU) conflicts from snapshot drift by
+    // error code (ADR-008): pushSchema tags snapshot drift with SchemaDrift,
+    // while the kintone adapter uses Conflict for API 409 (revision) conflicts.
+    if (
+      isConflictError(error) &&
+      error.code !== ConflictErrorCode.SchemaDrift
+    ) {
       throw new ConflictError(
         ConflictErrorCode.Conflict,
         PUSH_TOCTOU_MESSAGE,
@@ -64,8 +67,17 @@ async function runPush(
   }
   s.stop("Schema pushed to preview.");
 
+  if (result.mode === "firstTime") {
+    p.log.warn(
+      "No base snapshot found. Applied without drift guard and initialized state.",
+    );
+  }
   p.log.success("Push completed successfully.");
 
+  // confirmAndDeploy is intentionally outside the try above: a 409 during deploy
+  // is a separate concurrency event from the push apply, so it should surface as
+  // the adapter's standard ConflictError rather than be re-wrapped as a push
+  // apply TOCTOU.
   await confirmAndDeploy([container], skipConfirm);
 }
 

--- a/src/cli/commands/schema/push.ts
+++ b/src/cli/commands/schema/push.ts
@@ -1,0 +1,118 @@
+import * as p from "@clack/prompts";
+import { define } from "gunshi";
+import { createCliContainer } from "@/core/application/container/cli";
+import type { FormSchemaContainer } from "@/core/application/container/formSchema";
+import {
+  ConflictError,
+  ConflictErrorCode,
+  isConflictError,
+  ValidationError,
+  ValidationErrorCode,
+} from "@/core/application/error";
+import {
+  PUSH_DRIFT_MESSAGE,
+  pushSchema,
+} from "@/core/application/formSchema/pushSchema";
+import {
+  confirmArgs,
+  kintoneArgs,
+  multiAppArgs,
+  resolveConfig,
+} from "../../config";
+import { handleCliError } from "../../handleError";
+import { confirmAndDeploy } from "../../output";
+import { resolveAppCliConfig, routeMultiApp } from "../../projectConfig";
+
+// API optimistic-lock conflicts (applied just as the remote changed) are
+// re-wrapped with a TOCTOU-specific message, distinct from the snapshot-drift
+// rejection message (ADR-008).
+const PUSH_TOCTOU_MESSAGE =
+  "適用中に実環境が変更されました。`schema pull` 後に再実行してください。";
+
+async function runPush(
+  container: FormSchemaContainer,
+  force: boolean,
+  skipConfirm: boolean,
+): Promise<void> {
+  if (!skipConfirm) {
+    const shouldContinue = await p.confirm({
+      message: force
+        ? "Force-push local schema to kintone (overwrite remote)?"
+        : "Push local schema to kintone?",
+    });
+    if (p.isCancel(shouldContinue) || !shouldContinue) {
+      p.cancel("Push cancelled.");
+      return;
+    }
+  }
+
+  const s = p.spinner();
+  s.start("Pushing schema to kintone...");
+  try {
+    await pushSchema({ container, input: { force } });
+  } catch (error) {
+    s.stop("Push failed.");
+    // Distinguish API optimistic-lock (TOCTOU) conflicts from snapshot drift.
+    if (isConflictError(error) && error.message !== PUSH_DRIFT_MESSAGE) {
+      throw new ConflictError(
+        ConflictErrorCode.Conflict,
+        PUSH_TOCTOU_MESSAGE,
+        error,
+      );
+    }
+    throw error;
+  }
+  s.stop("Schema pushed to preview.");
+
+  p.log.success("Push completed successfully.");
+
+  await confirmAndDeploy([container], skipConfirm);
+}
+
+export default define({
+  name: "push",
+  description: "Push the local schema file to kintone (with drift detection)",
+  args: {
+    ...kintoneArgs,
+    ...multiAppArgs,
+    ...confirmArgs,
+    force: {
+      type: "boolean" as const,
+      description: "Skip drift detection and overwrite remote",
+    },
+  },
+  run: async (ctx) => {
+    try {
+      if (ctx.values.all === true) {
+        throw new ValidationError(
+          ValidationErrorCode.InvalidInput,
+          "schema push does not support --all yet. Use --app <name> or a single app.",
+        );
+      }
+
+      const force = ctx.values.force === true;
+      const skipConfirm = ctx.values.yes === true;
+
+      await routeMultiApp(ctx.values, {
+        singleLegacy: async () => {
+          const config = resolveConfig(ctx.values);
+          const container = createCliContainer(config);
+          await runPush(container, force, skipConfirm);
+        },
+        singleApp: async (app, projectConfig) => {
+          const config = resolveAppCliConfig(app, projectConfig, ctx.values);
+          const container = createCliContainer(config);
+          await runPush(container, force, skipConfirm);
+        },
+        multiApp: async () => {
+          throw new ValidationError(
+            ValidationErrorCode.InvalidInput,
+            "schema push does not support --all yet. Use --app <name> or a single app.",
+          );
+        },
+      });
+    } catch (error) {
+      handleCliError(error);
+    }
+  },
+});

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -1,6 +1,7 @@
 import * as v from "valibot";
 import type { KintoneAuth } from "@/core/application/container/cli";
 import { ValidationError, ValidationErrorCode } from "@/core/application/error";
+import { buildLegacyStateFilePath } from "@/core/domain/projectConfig/appFilePaths";
 
 export {
   buildKintoneAuth,
@@ -23,6 +24,7 @@ export type CliConfig = {
   appId: string;
   guestSpaceId?: string;
   schemaFilePath: string;
+  stateSchemaFilePath: string;
 };
 
 export const kintoneArgs = {
@@ -161,6 +163,7 @@ export function resolveConfig(cliValues: {
     appId: output.KINTONE_APP_ID,
     guestSpaceId: output.KINTONE_GUEST_SPACE_ID,
     schemaFilePath: output.SCHEMA_FILE_PATH,
+    stateSchemaFilePath: buildLegacyStateFilePath(),
   };
 }
 

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -5,7 +5,10 @@ import type { AdminNotesDiffEntry } from "@/core/application/adminNotes/detectAd
 import type { AppPermissionDiffEntry } from "@/core/application/appPermission/detectAppPermissionDiff";
 import type { CustomizationDiffEntry } from "@/core/application/customization/detectCustomizationDiff";
 import type { FieldPermissionDiffEntry } from "@/core/application/fieldPermission/detectFieldPermissionDiff";
-import type { DetectDiffOutput } from "@/core/application/formSchema/dto";
+import type {
+  DetectDiffOutput,
+  DetectThreeWayDiffOutput,
+} from "@/core/application/formSchema/dto";
 import type { GeneralSettingsDiffEntry } from "@/core/application/generalSettings/detectGeneralSettingsDiff";
 import type { NotificationDiffEntry } from "@/core/application/notification/detectNotificationDiff";
 import type { PluginDiffEntry } from "@/core/application/plugin/detectPluginDiff";
@@ -150,6 +153,59 @@ export function printDiffResult(result: DetectDiffOutput): void {
   });
 
   p.note(lines.join("\n"), "Diff Details", { format: (v) => v });
+}
+
+// Prints a 3-way diff (state-aware) distinguishing local changes, remote drift,
+// and conflicts. Falls back to the 2-way printer when no state exists.
+export function printThreeWayDiffResult(
+  result: DetectThreeWayDiffOutput,
+): void {
+  if (result.mode === "two-way") {
+    p.log.info("No base snapshot found (2-way comparison).");
+    printDiffResult(result.diff);
+    return;
+  }
+
+  if (result.isEmpty) {
+    p.log.info("No changes detected (local, remote, and base are in sync).");
+    return;
+  }
+
+  const lines: string[] = [];
+  for (const e of result.localChanges) {
+    lines.push(
+      `${pc.green("L")} ${pc.dim("[")}${pc.green(e.fieldCode)}${pc.dim("]")} ${e.fieldLabel}${pc.dim(":")} local change`,
+    );
+  }
+  for (const e of result.remoteDrift) {
+    lines.push(
+      `${pc.yellow("R")} ${pc.dim("[")}${pc.yellow(e.fieldCode)}${pc.dim("]")} ${e.fieldLabel}${pc.dim(":")} remote drift`,
+    );
+  }
+  for (const e of result.conflicts) {
+    lines.push(
+      `${pc.red("C")} ${pc.dim("[")}${pc.red(e.fieldCode)}${pc.dim("]")} ${e.fieldLabel}${pc.dim(":")} conflict`,
+    );
+  }
+  if (result.layoutConflict) {
+    lines.push(`${pc.red("C")} ${pc.red("layout")}${pc.dim(":")} conflict`);
+  } else if (result.layoutLocalChanged && !result.layoutRemoteChanged) {
+    lines.push(
+      `${pc.green("L")} ${pc.green("layout")}${pc.dim(":")} local change`,
+    );
+  } else if (result.layoutRemoteChanged && !result.layoutLocalChanged) {
+    lines.push(
+      `${pc.yellow("R")} ${pc.yellow("layout")}${pc.dim(":")} remote drift`,
+    );
+  } else if (result.layoutLocalChanged && result.layoutRemoteChanged) {
+    // Both changed to the same value (auto-merged); still report as changed.
+    lines.push(`${pc.green("L")} ${pc.green("layout")}${pc.dim(":")} change`);
+  }
+
+  p.log.info(
+    `${pc.green("L")}=local  ${pc.yellow("R")}=remote drift  ${pc.red("C")}=conflict`,
+  );
+  p.note(lines.join("\n"), "3-way Diff Details", { format: (v) => v });
 }
 
 export function printFieldPermissionDiffResult(

--- a/src/cli/projectConfig.ts
+++ b/src/cli/projectConfig.ts
@@ -13,7 +13,10 @@ import type { MultiAppExecutor } from "@/core/application/projectConfig/executeM
 import { executeMultiApp } from "@/core/application/projectConfig/executeMultiApp";
 import { loadProjectConfig } from "@/core/application/projectConfig/loadProjectConfig";
 import { resolveExecutionPlan } from "@/core/application/projectConfig/resolveExecutionPlan";
-import { buildAppFilePaths } from "@/core/domain/projectConfig/appFilePaths";
+import {
+  buildAppFilePaths,
+  buildStateFilePath,
+} from "@/core/domain/projectConfig/appFilePaths";
 import type {
   AppEntry,
   AuthConfig,
@@ -152,6 +155,7 @@ export function resolveAppCliConfig(
       process.env.SCHEMA_FILE_PATH ??
       app.schemaFile ??
       buildAppFilePaths(app.name).schema,
+    stateSchemaFilePath: buildStateFilePath(app.name),
   };
 }
 

--- a/src/core/adapters/kintone/__tests__/formConfigurator.test.ts
+++ b/src/core/adapters/kintone/__tests__/formConfigurator.test.ts
@@ -2,6 +2,7 @@ import type { KintoneRestAPIClient } from "@kintone/rest-api-client";
 import { KintoneRestAPIError } from "@kintone/rest-api-client";
 import { describe, expect, it, vi } from "vitest";
 import { ConflictError, SystemError } from "@/core/application/error";
+import { SKIP_REVISION_CHECK } from "@/core/domain/formSchema/ports/formConfigurator";
 import type {
   FieldCode,
   FieldDefinition,
@@ -2081,6 +2082,156 @@ describe("KintoneFormConfigurator", () => {
       expect(refTable).not.toHaveProperty("filterCond");
       expect(refTable).not.toHaveProperty("sort");
       expect(refTable).not.toHaveProperty("size");
+    });
+  });
+
+  // AC-2 (W-001): getRevision reads the current preview revision in a single
+  // API call and throws a SystemError when the API omits the revision.
+  describe("getRevision", () => {
+    it("preview: true で現在の revision を取得する", async () => {
+      const client = createMockClient({
+        getFormFields: () =>
+          Promise.resolve({ properties: {}, revision: "42" }),
+      });
+      const adapter = new KintoneFormConfigurator(client, APP_ID);
+
+      const revision = await adapter.getRevision();
+
+      expect(revision).toBe("42");
+      expect(client.app.getFormFields).toHaveBeenCalledWith({
+        app: APP_ID,
+        preview: true,
+      });
+    });
+
+    it("revision が欠落している場合 SystemError をスローする", async () => {
+      const client = createMockClient({
+        getFormFields: () => Promise.resolve({ properties: {} }),
+      });
+      const adapter = new KintoneFormConfigurator(client, APP_ID);
+
+      await expect(adapter.getRevision()).rejects.toThrow(SystemError);
+    });
+
+    it("取得した revision は tracker に track され後続 mutation に渡される", async () => {
+      const client = createMockClient({
+        getFormFields: () =>
+          Promise.resolve({ properties: {}, revision: "42" }),
+      });
+      const adapter = new KintoneFormConfigurator(client, APP_ID);
+
+      await adapter.getRevision();
+      await adapter.addFields([]);
+
+      expect(client.app.addFormFields).toHaveBeenCalledWith(
+        expect.objectContaining({ revision: "42" }),
+      );
+    });
+  });
+
+  // B-001 (ADR-005 / ADR-013): the expected revision must be resolved against
+  // the real adapter's mutation path, not just the in-memory fake. These tests
+  // exercise resolveMutationRevision through the kintone client mock so a
+  // regression where the monotonic tracker (max-採用) overrides the fixed
+  // expected revision — or where SKIP_REVISION_CHECK falls back to the tracker —
+  // is actually caught.
+  describe("expectedRevision の送出（B-001）", () => {
+    function addFieldsRevision(client: KintoneRestAPIClient): unknown {
+      const calls = (client.app.addFormFields as ReturnType<typeof vi.fn>).mock
+        .calls;
+      const lastArg = calls[calls.length - 1][0] as Record<string, unknown>;
+      return "revision" in lastArg ? lastArg.revision : undefined;
+    }
+
+    it("push 非force相当: 固定 revision 文字列は tracker が別 revision を track しても上書きされない", async () => {
+      // getFields tracks a LARGER revision ("99") after the push observed "7".
+      // The monotonic RevisionTracker would advance to 99, but the explicit
+      // expected revision "7" must take precedence (no max-tracker fallback).
+      const client = createMockClient({
+        getFormFields: () =>
+          Promise.resolve({ properties: {}, revision: "99" }),
+      });
+      const adapter = new KintoneFormConfigurator(client, APP_ID);
+
+      // Simulate the push flow: drift snapshot fetch tracks "99"...
+      await adapter.getFields();
+      // ...then the apply sends the fixed observed revision "7".
+      await adapter.addFields([], "7");
+
+      expect(addFieldsRevision(client)).toBe("7");
+    });
+
+    it("push 非force相当: updateLayout も固定 revision を送り tracker に引っ張られない", async () => {
+      const client = createMockClient({
+        getFormFields: () =>
+          Promise.resolve({ properties: {}, revision: "99" }),
+      });
+      const adapter = new KintoneFormConfigurator(client, APP_ID);
+
+      await adapter.getFields();
+      await adapter.updateLayout([], "7");
+
+      expect(client.app.updateFormLayout).toHaveBeenCalledWith(
+        expect.objectContaining({ revision: 7 }),
+      );
+    });
+
+    it("--force相当 (SKIP_REVISION_CHECK): field mutation は revision を送らない (tracker にフォールバックしない)", async () => {
+      // The tracker is populated with a current revision by the drift snapshot
+      // fetch. SKIP_REVISION_CHECK must NOT fall back to it, otherwise force
+      // could 409 when the remote drifted (B-001).
+      const client = createMockClient({
+        getFormFields: () =>
+          Promise.resolve({ properties: {}, revision: "99" }),
+      });
+      const adapter = new KintoneFormConfigurator(client, APP_ID);
+
+      await adapter.getFields(); // tracker now holds "99"
+      await adapter.addFields([], SKIP_REVISION_CHECK);
+      await adapter.updateFields([], SKIP_REVISION_CHECK);
+      await adapter.deleteFields(["x" as FieldCode], SKIP_REVISION_CHECK);
+
+      const addArg = (client.app.addFormFields as ReturnType<typeof vi.fn>).mock
+        .calls[0][0] as Record<string, unknown>;
+      const updArg = (client.app.updateFormFields as ReturnType<typeof vi.fn>)
+        .mock.calls[0][0] as Record<string, unknown>;
+      const delArg = (client.app.deleteFormFields as ReturnType<typeof vi.fn>)
+        .mock.calls[0][0] as Record<string, unknown>;
+      expect(addArg).not.toHaveProperty("revision");
+      expect(updArg).not.toHaveProperty("revision");
+      expect(delArg).not.toHaveProperty("revision");
+    });
+
+    it("--force相当 (SKIP_REVISION_CHECK): updateLayout は -1 を送る (tracker にフォールバックしない)", async () => {
+      const client = createMockClient({
+        getFormFields: () =>
+          Promise.resolve({ properties: {}, revision: "99" }),
+      });
+      const adapter = new KintoneFormConfigurator(client, APP_ID);
+
+      await adapter.getFields(); // tracker now holds "99"
+      await adapter.updateLayout([], SKIP_REVISION_CHECK);
+
+      expect(client.app.updateFormLayout).toHaveBeenCalledWith(
+        expect.objectContaining({ revision: -1 }),
+      );
+    });
+
+    it("migrate相当 (undefined): 従来どおり tracker 既定値が送られる", async () => {
+      const client = createMockClient({
+        getFormFields: () =>
+          Promise.resolve({ properties: {}, revision: "12" }),
+      });
+      const adapter = new KintoneFormConfigurator(client, APP_ID);
+
+      await adapter.getFields(); // tracker holds "12"
+      await adapter.addFields([]); // undefined => fall back to tracker
+      await adapter.updateLayout([]);
+
+      expect(addFieldsRevision(client)).toBe("12");
+      expect(client.app.updateFormLayout).toHaveBeenCalledWith(
+        expect.objectContaining({ revision: 12 }),
+      );
     });
   });
 });

--- a/src/core/adapters/kintone/formConfigurator.ts
+++ b/src/core/adapters/kintone/formConfigurator.ts
@@ -8,7 +8,11 @@ import type {
   ReferenceTableLayoutItem,
   SubtableLayoutItem,
 } from "@/core/domain/formSchema/entity";
-import type { FormConfigurator } from "@/core/domain/formSchema/ports/formConfigurator";
+import type {
+  ExpectedRevision,
+  FormConfigurator,
+} from "@/core/domain/formSchema/ports/formConfigurator";
+import { SKIP_REVISION_CHECK } from "@/core/domain/formSchema/ports/formConfigurator";
 import type {
   ElementSize,
   FieldCode,
@@ -581,19 +585,29 @@ export class KintoneFormConfigurator implements FormConfigurator {
     }
   }
 
-  // Resolves the revision to send to a mutation API. When an explicit expected
-  // revision is provided (push, ADR-005), it takes precedence over the
-  // monotonic tracker so the observed remote revision is sent as-is. When
-  // omitted, fall back to the tracked revision (existing migrate behaviour).
+  // Resolves the revision to send to a mutation API, distinguishing the three
+  // ExpectedRevision states (ADR-005 / ADR-010):
+  // - SKIP_REVISION_CHECK (--force push / first run): skip the revision check
+  //   entirely. Returns `null`, meaning "send no revision" (kintone treats the
+  //   absence / -1 as skip). This must NOT fall back to the tracker, otherwise
+  //   force could 409 when the remote drifted (B-001).
+  // - a revision string (push non-force, ADR-005): send it as-is, taking
+  //   precedence over the monotonic tracker so the observed remote revision is
+  //   enforced.
+  // - undefined (migrate): fall back to the tracked revision (existing
+  //   behaviour). When the tracker has nothing, returns `null` (skip).
   private resolveMutationRevision(
-    expectedRevision: string | undefined,
-  ): string | undefined {
-    return expectedRevision ?? this.revisionTracker.current;
+    expectedRevision: ExpectedRevision,
+  ): string | null {
+    if (expectedRevision === SKIP_REVISION_CHECK) {
+      return null;
+    }
+    return expectedRevision ?? this.revisionTracker.current ?? null;
   }
 
   async addFields(
     fields: readonly FieldDefinition[],
-    expectedRevision?: string,
+    expectedRevision?: ExpectedRevision,
   ): Promise<void> {
     try {
       const properties: Record<string, Record<string, unknown>> = {};
@@ -604,7 +618,7 @@ export class KintoneFormConfigurator implements FormConfigurator {
       const response = await this.client.app.addFormFields({
         app: this.appId,
         properties,
-        ...(revision !== undefined ? { revision } : {}),
+        ...(revision !== null ? { revision } : {}),
       });
       if (response.revision) {
         this.revisionTracker.track(response.revision);
@@ -616,7 +630,7 @@ export class KintoneFormConfigurator implements FormConfigurator {
 
   async updateFields(
     fields: readonly FieldDefinition[],
-    expectedRevision?: string,
+    expectedRevision?: ExpectedRevision,
   ): Promise<void> {
     try {
       const properties: Record<string, Record<string, unknown>> = {};
@@ -627,7 +641,7 @@ export class KintoneFormConfigurator implements FormConfigurator {
       const response = await this.client.app.updateFormFields({
         app: this.appId,
         properties,
-        ...(revision !== undefined ? { revision } : {}),
+        ...(revision !== null ? { revision } : {}),
       });
       if (response.revision) {
         this.revisionTracker.track(response.revision);
@@ -639,7 +653,7 @@ export class KintoneFormConfigurator implements FormConfigurator {
 
   async deleteFields(
     fieldCodes: readonly FieldCode[],
-    expectedRevision?: string,
+    expectedRevision?: ExpectedRevision,
   ): Promise<void> {
     try {
       const revision = this.resolveMutationRevision(expectedRevision);
@@ -649,7 +663,7 @@ export class KintoneFormConfigurator implements FormConfigurator {
       const response = (await this.client.app.deleteFormFields({
         app: this.appId,
         fields: fieldCodes.map((code) => code as string),
-        ...(revision !== undefined ? { revision } : {}),
+        ...(revision !== null ? { revision } : {}),
       })) as { revision?: string };
       if (response.revision) {
         this.revisionTracker.track(response.revision);
@@ -679,7 +693,7 @@ export class KintoneFormConfigurator implements FormConfigurator {
 
   async updateLayout(
     layout: FormLayout,
-    expectedRevision?: string,
+    expectedRevision?: ExpectedRevision,
   ): Promise<void> {
     try {
       const kintoneLayout = layout.map(toKintoneLayoutItem);
@@ -689,10 +703,9 @@ export class KintoneFormConfigurator implements FormConfigurator {
         layout: kintoneLayout as Parameters<
           typeof this.client.app.updateFormLayout
         >[0]["layout"],
-        // kintone API treats revision=-1 as "skip revision check", used as
-        // fallback when no expected/tracked revision is available (e.g. first
-        // layout update, or --force push which sends no expected revision).
-        revision: revision !== undefined ? Number(revision) : -1,
+        // kintone API treats revision=-1 as "skip revision check". `null` here
+        // means skip (--force push / first run, or no tracked revision yet).
+        revision: revision !== null ? Number(revision) : -1,
       });
       if (response.revision) {
         this.revisionTracker.track(response.revision);

--- a/src/core/adapters/kintone/formConfigurator.ts
+++ b/src/core/adapters/kintone/formConfigurator.ts
@@ -562,18 +562,49 @@ export class KintoneFormConfigurator implements FormConfigurator {
     }
   }
 
-  async addFields(fields: readonly FieldDefinition[]): Promise<void> {
+  async getRevision(): Promise<string> {
+    try {
+      const { revision } = await this.client.app.getFormFields({
+        app: this.appId,
+        preview: true,
+      });
+      if (!revision) {
+        throw new SystemError(
+          SystemErrorCode.ExternalApiError,
+          "kintone API did not return a form revision",
+        );
+      }
+      this.revisionTracker.track(revision);
+      return revision;
+    } catch (error) {
+      throw wrapKintoneError(error, "Failed to get form revision");
+    }
+  }
+
+  // Resolves the revision to send to a mutation API. When an explicit expected
+  // revision is provided (push, ADR-005), it takes precedence over the
+  // monotonic tracker so the observed remote revision is sent as-is. When
+  // omitted, fall back to the tracked revision (existing migrate behaviour).
+  private resolveMutationRevision(
+    expectedRevision: string | undefined,
+  ): string | undefined {
+    return expectedRevision ?? this.revisionTracker.current;
+  }
+
+  async addFields(
+    fields: readonly FieldDefinition[],
+    expectedRevision?: string,
+  ): Promise<void> {
     try {
       const properties: Record<string, Record<string, unknown>> = {};
       for (const field of fields) {
         properties[field.code as string] = toKintoneProperty(field);
       }
+      const revision = this.resolveMutationRevision(expectedRevision);
       const response = await this.client.app.addFormFields({
         app: this.appId,
         properties,
-        ...(this.revisionTracker.current !== undefined
-          ? { revision: this.revisionTracker.current }
-          : {}),
+        ...(revision !== undefined ? { revision } : {}),
       });
       if (response.revision) {
         this.revisionTracker.track(response.revision);
@@ -583,18 +614,20 @@ export class KintoneFormConfigurator implements FormConfigurator {
     }
   }
 
-  async updateFields(fields: readonly FieldDefinition[]): Promise<void> {
+  async updateFields(
+    fields: readonly FieldDefinition[],
+    expectedRevision?: string,
+  ): Promise<void> {
     try {
       const properties: Record<string, Record<string, unknown>> = {};
       for (const field of fields) {
         properties[field.code as string] = toKintoneProperty(field);
       }
+      const revision = this.resolveMutationRevision(expectedRevision);
       const response = await this.client.app.updateFormFields({
         app: this.appId,
         properties,
-        ...(this.revisionTracker.current !== undefined
-          ? { revision: this.revisionTracker.current }
-          : {}),
+        ...(revision !== undefined ? { revision } : {}),
       });
       if (response.revision) {
         this.revisionTracker.track(response.revision);
@@ -604,17 +637,19 @@ export class KintoneFormConfigurator implements FormConfigurator {
     }
   }
 
-  async deleteFields(fieldCodes: readonly FieldCode[]): Promise<void> {
+  async deleteFields(
+    fieldCodes: readonly FieldCode[],
+    expectedRevision?: string,
+  ): Promise<void> {
     try {
+      const revision = this.resolveMutationRevision(expectedRevision);
       // The SDK's type definition for deleteFormFields() does not include the `revision`
       // property in its return type, but the kintone API does return it at runtime.
       // We cast to access the revision for optimistic concurrency tracking.
       const response = (await this.client.app.deleteFormFields({
         app: this.appId,
         fields: fieldCodes.map((code) => code as string),
-        ...(this.revisionTracker.current !== undefined
-          ? { revision: this.revisionTracker.current }
-          : {}),
+        ...(revision !== undefined ? { revision } : {}),
       })) as { revision?: string };
       if (response.revision) {
         this.revisionTracker.track(response.revision);
@@ -642,20 +677,22 @@ export class KintoneFormConfigurator implements FormConfigurator {
     }
   }
 
-  async updateLayout(layout: FormLayout): Promise<void> {
+  async updateLayout(
+    layout: FormLayout,
+    expectedRevision?: string,
+  ): Promise<void> {
     try {
       const kintoneLayout = layout.map(toKintoneLayoutItem);
+      const revision = this.resolveMutationRevision(expectedRevision);
       const response = await this.client.app.updateFormLayout({
         app: this.appId,
         layout: kintoneLayout as Parameters<
           typeof this.client.app.updateFormLayout
         >[0]["layout"],
         // kintone API treats revision=-1 as "skip revision check", used as
-        // fallback when no prior revision is tracked (e.g. first layout update).
-        revision:
-          this.revisionTracker.current !== undefined
-            ? Number(this.revisionTracker.current)
-            : -1,
+        // fallback when no expected/tracked revision is available (e.g. first
+        // layout update, or --force push which sends no expected revision).
+        revision: revision !== undefined ? Number(revision) : -1,
       });
       if (response.revision) {
         this.revisionTracker.track(response.revision);

--- a/src/core/adapters/local/schemaStateStorage.ts
+++ b/src/core/adapters/local/schemaStateStorage.ts
@@ -1,0 +1,8 @@
+import type { SchemaStateStorage } from "@/core/domain/formSchema/ports/schemaStateStorage";
+import { createLocalFileStorage } from "./storage";
+
+export function createLocalFileSchemaStateStorage(
+  filePath: string,
+): SchemaStateStorage {
+  return createLocalFileStorage(filePath, "schema state file");
+}

--- a/src/core/application/__tests__/helpers/formSchema.ts
+++ b/src/core/application/__tests__/helpers/formSchema.ts
@@ -1,6 +1,10 @@
 import type { FormSchemaContainer } from "@/core/application/container/formSchema";
+import { ConflictError, ConflictErrorCode } from "@/core/application/error";
 import type { FormLayout } from "@/core/domain/formSchema/entity";
-import type { FormConfigurator } from "@/core/domain/formSchema/ports/formConfigurator";
+import type {
+  ExpectedRevision,
+  FormConfigurator,
+} from "@/core/domain/formSchema/ports/formConfigurator";
 import type { SchemaStateStorage } from "@/core/domain/formSchema/ports/schemaStateStorage";
 import type { SchemaStorage } from "@/core/domain/formSchema/ports/schemaStorage";
 import type {
@@ -23,7 +27,34 @@ export class InMemoryFormConfigurator
   private layout: FormLayout = [];
   private revision = "1";
   /** Records the expected revision passed to each mutation method, in order. */
-  readonly expectedRevisions: Array<string | undefined> = [];
+  readonly expectedRevisions: Array<ExpectedRevision> = [];
+  /**
+   * When set, the next mutation (add/update/delete/layout) throws this error
+   * before mutating. Used to simulate the kintone adapter translating an API
+   * optimistic-lock failure (409 / GAIA_CO02) into a ConflictError mid-apply
+   * (TOCTOU), which the in-memory double cannot otherwise reproduce.
+   */
+  private pendingMutationError: Error | undefined = undefined;
+
+  /**
+   * Arms the test double so the next mutation throws an API optimistic-lock
+   * ConflictError (ConflictErrorCode.Conflict — distinct from the push-drift
+   * SchemaDrift code), as the real adapter would on a 409.
+   */
+  failNextMutationWithOptimisticLock(): void {
+    this.pendingMutationError = new ConflictError(
+      ConflictErrorCode.Conflict,
+      "The form was modified concurrently (revision conflict — GAIA_CO02). Please retry the operation.",
+    );
+  }
+
+  private consumeMutationError(): void {
+    if (this.pendingMutationError !== undefined) {
+      const error = this.pendingMutationError;
+      this.pendingMutationError = undefined;
+      throw error;
+    }
+  }
 
   async getFields(): Promise<ReadonlyMap<FieldCode, FieldDefinition>> {
     this.trackCall("getFields");
@@ -37,9 +68,10 @@ export class InMemoryFormConfigurator
 
   async addFields(
     fields: readonly FieldDefinition[],
-    expectedRevision?: string,
+    expectedRevision?: ExpectedRevision,
   ): Promise<void> {
     this.trackCall("addFields");
+    this.consumeMutationError();
     this.expectedRevisions.push(expectedRevision);
     for (const field of fields) {
       this.fields.set(field.code, field);
@@ -48,9 +80,10 @@ export class InMemoryFormConfigurator
 
   async updateFields(
     fields: readonly FieldDefinition[],
-    expectedRevision?: string,
+    expectedRevision?: ExpectedRevision,
   ): Promise<void> {
     this.trackCall("updateFields");
+    this.consumeMutationError();
     this.expectedRevisions.push(expectedRevision);
     for (const field of fields) {
       if (field.type === "SUBTABLE") {
@@ -73,9 +106,10 @@ export class InMemoryFormConfigurator
 
   async deleteFields(
     fieldCodes: readonly FieldCode[],
-    expectedRevision?: string,
+    expectedRevision?: ExpectedRevision,
   ): Promise<void> {
     this.trackCall("deleteFields");
+    this.consumeMutationError();
     this.expectedRevisions.push(expectedRevision);
     for (const code of fieldCodes) {
       const field = this.fields.get(code);
@@ -95,9 +129,10 @@ export class InMemoryFormConfigurator
 
   async updateLayout(
     layout: FormLayout,
-    expectedRevision?: string,
+    expectedRevision?: ExpectedRevision,
   ): Promise<void> {
     this.trackCall("updateLayout");
+    this.consumeMutationError();
     this.expectedRevisions.push(expectedRevision);
     this.layout = [...layout];
   }

--- a/src/core/application/__tests__/helpers/formSchema.ts
+++ b/src/core/application/__tests__/helpers/formSchema.ts
@@ -1,6 +1,7 @@
 import type { FormSchemaContainer } from "@/core/application/container/formSchema";
 import type { FormLayout } from "@/core/domain/formSchema/entity";
 import type { FormConfigurator } from "@/core/domain/formSchema/ports/formConfigurator";
+import type { SchemaStateStorage } from "@/core/domain/formSchema/ports/schemaStateStorage";
 import type { SchemaStorage } from "@/core/domain/formSchema/ports/schemaStorage";
 import type {
   FieldCode,
@@ -20,21 +21,37 @@ export class InMemoryFormConfigurator
 {
   private fields: Map<FieldCode, FieldDefinition> = new Map();
   private layout: FormLayout = [];
+  private revision = "1";
+  /** Records the expected revision passed to each mutation method, in order. */
+  readonly expectedRevisions: Array<string | undefined> = [];
 
   async getFields(): Promise<ReadonlyMap<FieldCode, FieldDefinition>> {
     this.trackCall("getFields");
     return new Map(this.fields);
   }
 
-  async addFields(fields: readonly FieldDefinition[]): Promise<void> {
+  async getRevision(): Promise<string> {
+    this.trackCall("getRevision");
+    return this.revision;
+  }
+
+  async addFields(
+    fields: readonly FieldDefinition[],
+    expectedRevision?: string,
+  ): Promise<void> {
     this.trackCall("addFields");
+    this.expectedRevisions.push(expectedRevision);
     for (const field of fields) {
       this.fields.set(field.code, field);
     }
   }
 
-  async updateFields(fields: readonly FieldDefinition[]): Promise<void> {
+  async updateFields(
+    fields: readonly FieldDefinition[],
+    expectedRevision?: string,
+  ): Promise<void> {
     this.trackCall("updateFields");
+    this.expectedRevisions.push(expectedRevision);
     for (const field of fields) {
       if (field.type === "SUBTABLE") {
         const existing = this.fields.get(field.code);
@@ -54,8 +71,12 @@ export class InMemoryFormConfigurator
     }
   }
 
-  async deleteFields(fieldCodes: readonly FieldCode[]): Promise<void> {
+  async deleteFields(
+    fieldCodes: readonly FieldCode[],
+    expectedRevision?: string,
+  ): Promise<void> {
     this.trackCall("deleteFields");
+    this.expectedRevisions.push(expectedRevision);
     for (const code of fieldCodes) {
       const field = this.fields.get(code);
       if (field?.type === "SUBTABLE") {
@@ -72,8 +93,12 @@ export class InMemoryFormConfigurator
     return [...this.layout];
   }
 
-  async updateLayout(layout: FormLayout): Promise<void> {
+  async updateLayout(
+    layout: FormLayout,
+    expectedRevision?: string,
+  ): Promise<void> {
     this.trackCall("updateLayout");
+    this.expectedRevisions.push(expectedRevision);
     this.layout = [...layout];
   }
 
@@ -84,7 +109,15 @@ export class InMemoryFormConfigurator
   setLayout(layout: FormLayout): void {
     this.layout = [...layout];
   }
+
+  setRevision(revision: string): void {
+    this.revision = revision;
+  }
 }
+
+export class InMemorySchemaStateStorage
+  extends InMemoryFileStorage
+  implements SchemaStateStorage {}
 
 export class InMemorySchemaStorage
   extends InMemoryFileStorage
@@ -93,6 +126,7 @@ export class InMemorySchemaStorage
 export type TestFormSchemaContainer = FormSchemaContainer & {
   formConfigurator: InMemoryFormConfigurator;
   schemaStorage: InMemorySchemaStorage;
+  schemaStateStorage: InMemorySchemaStateStorage;
   appDeployer: InMemoryAppDeployer;
 };
 
@@ -101,6 +135,7 @@ export function createTestFormSchemaContainer(): TestFormSchemaContainer {
     configCodec: testConfigCodec,
     formConfigurator: new InMemoryFormConfigurator(),
     schemaStorage: new InMemorySchemaStorage(),
+    schemaStateStorage: new InMemorySchemaStateStorage(),
     appDeployer: new InMemoryAppDeployer(),
   };
 }

--- a/src/core/application/container/applyAllCli.ts
+++ b/src/core/application/container/applyAllCli.ts
@@ -1,6 +1,7 @@
 import {
   type AppFilePaths,
   buildAppFilePaths,
+  buildStateFilePath,
 } from "@/core/domain/projectConfig/appFilePaths";
 import type { AppName } from "@/core/domain/projectConfig/valueObject";
 import { createActionCliContainer } from "./actionCli";
@@ -52,7 +53,11 @@ export function createCliApplyAllContainers(
   };
   const paths = buildAppFilePaths(input.appName, input.baseDir);
 
-  const schema = createCliContainer({ ...base, schemaFilePath: paths.schema });
+  const schema = createCliContainer({
+    ...base,
+    schemaFilePath: paths.schema,
+    stateSchemaFilePath: buildStateFilePath(input.appName, input.baseDir),
+  });
   const seed = createSeedCliContainer({ ...base, seedFilePath: paths.seed });
   const customization = createCustomizationCliContainer({
     ...base,

--- a/src/core/application/container/captureAllCli.ts
+++ b/src/core/application/container/captureAllCli.ts
@@ -1,6 +1,7 @@
 import {
   type AppFilePaths,
   buildAppFilePaths,
+  buildStateFilePath,
 } from "@/core/domain/projectConfig/appFilePaths";
 import type { AppName } from "@/core/domain/projectConfig/valueObject";
 import { createActionCliContainer } from "./actionCli";
@@ -53,7 +54,11 @@ export function createCliCaptureContainers(
   return {
     paths,
     containers: {
-      schema: createCliContainer({ ...base, schemaFilePath: paths.schema }),
+      schema: createCliContainer({
+        ...base,
+        schemaFilePath: paths.schema,
+        stateSchemaFilePath: buildStateFilePath(input.appName, input.baseDir),
+      }),
       seed: createSeedCliContainer({ ...base, seedFilePath: paths.seed }),
       customization: createCustomizationCliContainer({
         ...base,

--- a/src/core/application/container/cli.ts
+++ b/src/core/application/container/cli.ts
@@ -8,6 +8,7 @@ import { KintoneRecordManager } from "@/core/adapters/kintone/recordManager";
 import { createLocalFileCustomizationStorage } from "@/core/adapters/local/customizationStorage";
 import { LocalFileContentReader } from "@/core/adapters/local/fileContentReader";
 import { LocalFileWriter } from "@/core/adapters/local/fileWriter";
+import { createLocalFileSchemaStateStorage } from "@/core/adapters/local/schemaStateStorage";
 import { createLocalFileSchemaStorage } from "@/core/adapters/local/schemaStorage";
 import { createLocalFileSeedStorage } from "@/core/adapters/local/seedStorage";
 import { configCodec } from "@/core/adapters/yaml/configCodec";
@@ -40,6 +41,7 @@ export type CliContainerConfig = {
   appId: string;
   guestSpaceId?: string;
   schemaFilePath: string;
+  stateSchemaFilePath: string;
   client?: KintoneRestAPIClient;
 };
 
@@ -61,6 +63,9 @@ export function createCliContainer(
     configCodec,
     formConfigurator: new KintoneFormConfigurator(client, config.appId),
     schemaStorage: createLocalFileSchemaStorage(config.schemaFilePath),
+    schemaStateStorage: createLocalFileSchemaStateStorage(
+      config.stateSchemaFilePath,
+    ),
     appDeployer: new KintoneAppDeployer(client, config.appId),
   };
 }

--- a/src/core/application/container/diffAllCli.ts
+++ b/src/core/application/container/diffAllCli.ts
@@ -1,6 +1,7 @@
 import {
   type AppFilePaths,
   buildAppFilePaths,
+  buildStateFilePath,
 } from "@/core/domain/projectConfig/appFilePaths";
 import type { AppName } from "@/core/domain/projectConfig/valueObject";
 import { createActionCliContainer } from "./actionCli";
@@ -52,7 +53,11 @@ export function createCliDiffAllContainers(
   return {
     paths,
     containers: {
-      schema: createCliContainer({ ...base, schemaFilePath: paths.schema }),
+      schema: createCliContainer({
+        ...base,
+        schemaFilePath: paths.schema,
+        stateSchemaFilePath: buildStateFilePath(input.appName, input.baseDir),
+      }),
       customization: createCustomizationCliContainer({
         ...base,
         customizeFilePath: paths.customize,

--- a/src/core/application/container/formSchema.ts
+++ b/src/core/application/container/formSchema.ts
@@ -1,4 +1,5 @@
 import type { FormConfigurator } from "@/core/domain/formSchema/ports/formConfigurator";
+import type { SchemaStateStorage } from "@/core/domain/formSchema/ports/schemaStateStorage";
 import type { SchemaStorage } from "@/core/domain/formSchema/ports/schemaStorage";
 import type { AppDeployer } from "@/core/domain/ports/appDeployer";
 import type { ConfigCodec } from "@/core/domain/ports/configCodec";
@@ -9,6 +10,10 @@ export type FormSchemaDiffContainer = {
   configCodec: ConfigCodec;
   formConfigurator: FormConfigurator;
   schemaStorage: SchemaStorage;
+  // Base snapshot storage for 3-way diff/pull/push. Added to the diff (base)
+  // container so it is also injected into the full container (push/pull) via
+  // inheritance. Legacy migrate/capture also receive it but never read/write it.
+  schemaStateStorage: SchemaStateStorage;
 };
 
 export type FormSchemaContainer = FormSchemaDiffContainer & {

--- a/src/core/application/error.ts
+++ b/src/core/application/error.ts
@@ -62,6 +62,14 @@ export function isNotFoundError(error: unknown): error is NotFoundError {
 
 export const ConflictErrorCode = {
   Conflict: "CONFLICT",
+  /**
+   * The remote schema drifted from the base snapshot and the push was not
+   * forced (push-specific drift, ADR-008). Distinct from {@link Conflict},
+   * which the kintone adapter uses for API optimistic-lock (409) conflicts, so
+   * the CLI can tell snapshot drift apart from TOCTOU conflicts by code rather
+   * than by message string.
+   */
+  SchemaDrift: "SCHEMA_DRIFT",
 } as const;
 export type ConflictErrorCode =
   (typeof ConflictErrorCode)[keyof typeof ConflictErrorCode];

--- a/src/core/application/formSchema/__tests__/applySchemaChanges.test.ts
+++ b/src/core/application/formSchema/__tests__/applySchemaChanges.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import { configCodec } from "@/core/adapters/yaml/configCodec";
+import { setupTestFormSchemaContainer } from "@/core/application/__tests__/helpers";
+import { ValidationError } from "@/core/application/error";
+import { SchemaParser } from "@/core/domain/formSchema/services/schemaParser";
+import {
+  FieldCode,
+  type FieldDefinition,
+  type SubtableFieldDefinition,
+} from "@/core/domain/formSchema/valueObject";
+import { applySchemaChanges } from "../applySchemaChanges";
+
+const getContainer = setupTestFormSchemaContainer();
+
+function textField(code: string, label: string): FieldDefinition {
+  return {
+    code: FieldCode.create(code),
+    type: "SINGLE_LINE_TEXT",
+    label,
+    properties: {},
+  } as FieldDefinition;
+}
+
+function parse(yaml: string) {
+  return SchemaParser.parse(configCodec.parse(yaml));
+}
+
+describe("applySchemaChanges", () => {
+  it("Schema を直接渡して追加・更新を適用できる", async () => {
+    const container = getContainer();
+    const schema = parse(`
+layout:
+  - type: ROW
+    fields:
+      - code: name
+        type: SINGLE_LINE_TEXT
+        label: 名前
+`);
+    container.formConfigurator.setFields(new Map());
+    container.formConfigurator.setLayout([]);
+
+    await applySchemaChanges(schema, { container });
+
+    const fields = await container.formConfigurator.getFields();
+    expect(fields.has(FieldCode.create("name"))).toBe(true);
+  });
+
+  it("expectedRevision を全 mutation に引き回す", async () => {
+    const container = getContainer();
+    const schema = parse(`
+layout:
+  - type: ROW
+    fields:
+      - code: name
+        type: SINGLE_LINE_TEXT
+        label: 名前
+`);
+    container.formConfigurator.setFields(new Map());
+    container.formConfigurator.setLayout([]);
+
+    await applySchemaChanges(schema, { container, expectedRevision: "11" });
+
+    expect(
+      container.formConfigurator.expectedRevisions.every((r) => r === "11"),
+    ).toBe(true);
+  });
+
+  it("型変更は ValidationError で弾かれる（AC-13）", async () => {
+    const container = getContainer();
+    const schema = parse(`
+layout:
+  - type: ROW
+    fields:
+      - code: f1
+        type: NUMBER
+        label: 数値
+`);
+    const existing = textField("f1", "数値");
+    container.formConfigurator.setFields(
+      new Map([[FieldCode.create("f1"), existing]]),
+    );
+    container.formConfigurator.setLayout([
+      { type: "ROW", fields: [{ kind: "field", field: existing }] },
+    ]);
+
+    await expect(applySchemaChanges(schema, { container })).rejects.toThrow(
+      ValidationError,
+    );
+  });
+
+  it("既存サブテーブルへのフィールド追加は ValidationError で弾かれる（AC-13）", async () => {
+    const container = getContainer();
+    const schema = parse(`
+layout:
+  - type: SUBTABLE
+    code: items
+    label: 明細
+    fields:
+      - code: col1
+        type: SINGLE_LINE_TEXT
+        label: 列1
+      - code: col2
+        type: NUMBER
+        label: 列2
+`);
+    const col1 = textField("col1", "列1");
+    const sub: SubtableFieldDefinition = {
+      code: FieldCode.create("items"),
+      type: "SUBTABLE",
+      label: "明細",
+      properties: {
+        fields: new Map([[FieldCode.create("col1"), col1]]),
+      },
+    };
+    container.formConfigurator.setFields(
+      new Map([
+        [FieldCode.create("items"), sub],
+        [FieldCode.create("col1"), col1],
+      ]),
+    );
+    container.formConfigurator.setLayout([
+      {
+        type: "SUBTABLE",
+        code: FieldCode.create("items"),
+        label: "明細",
+        fields: [{ kind: "field", field: col1 }],
+      },
+    ]);
+
+    await expect(applySchemaChanges(schema, { container })).rejects.toThrow(
+      ValidationError,
+    );
+  });
+});

--- a/src/core/application/formSchema/__tests__/detectThreeWayDiff.test.ts
+++ b/src/core/application/formSchema/__tests__/detectThreeWayDiff.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import { configCodec } from "@/core/adapters/yaml/configCodec";
+import { setupTestFormSchemaContainer } from "@/core/application/__tests__/helpers";
+import type { TestFormSchemaContainer } from "@/core/application/__tests__/helpers/formSchema";
+import type { Schema } from "@/core/domain/formSchema/entity";
+import { SchemaParser } from "@/core/domain/formSchema/services/schemaParser";
+import { SchemaStateSerializer } from "@/core/domain/formSchema/services/schemaStateSerializer";
+import {
+  FieldCode,
+  type FieldDefinition,
+} from "@/core/domain/formSchema/valueObject";
+import { captureSchema } from "../captureSchema";
+import { detectThreeWayDiff } from "../detectThreeWayDiff";
+import { executeMigration } from "../executeMigration";
+
+const getContainer = setupTestFormSchemaContainer();
+
+function textField(code: string, label: string): FieldDefinition {
+  return {
+    code: FieldCode.create(code),
+    type: "SINGLE_LINE_TEXT",
+    label,
+    properties: {},
+  } as FieldDefinition;
+}
+
+function schemaYaml(label: string): string {
+  return `
+layout:
+  - type: ROW
+    fields:
+      - code: name
+        type: SINGLE_LINE_TEXT
+        label: ${label}
+`;
+}
+
+function setRemote(
+  container: TestFormSchemaContainer,
+  label: string,
+  revision = "1",
+): void {
+  const field = textField("name", label);
+  container.formConfigurator.setFields(
+    new Map([[FieldCode.create("name"), field]]),
+  );
+  container.formConfigurator.setLayout([
+    { type: "ROW", fields: [{ kind: "field", field }] },
+  ]);
+  container.formConfigurator.setRevision(revision);
+}
+
+function setState(
+  container: TestFormSchemaContainer,
+  schema: Schema,
+  revision: string,
+): void {
+  const data = SchemaStateSerializer.serialize({ revision, schema });
+  container.schemaStateStorage.setContent(configCodec.stringify(data));
+}
+
+function parseSchema(label: string): Schema {
+  return SchemaParser.parse(configCodec.parse(schemaYaml(label)));
+}
+
+describe("detectThreeWayDiff", () => {
+  it("state がない場合は 2-way にフォールバックする", async () => {
+    const container = getContainer();
+    container.schemaStorage.setContent(schemaYaml("名前"));
+    setRemote(container, "名前");
+
+    const result = await detectThreeWayDiff({ container });
+
+    expect(result.mode).toBe("two-way");
+  });
+
+  it("state があり local のみ変更なら localChanges に分類される", async () => {
+    const container = getContainer();
+    const base = parseSchema("名前");
+    setState(container, base, "1");
+    container.schemaStorage.setContent(schemaYaml("名前_新"));
+    setRemote(container, "名前", "1");
+
+    const result = await detectThreeWayDiff({ container });
+
+    expect(result.mode).toBe("three-way");
+    if (result.mode === "three-way") {
+      expect(result.localChanges.map((e) => e.fieldCode)).toContain("name");
+      expect(result.remoteDrift).toHaveLength(0);
+      expect(result.conflicts).toHaveLength(0);
+    }
+  });
+
+  it("remote のみ変更なら remoteDrift に分類される", async () => {
+    const container = getContainer();
+    const base = parseSchema("名前");
+    setState(container, base, "1");
+    container.schemaStorage.setContent(schemaYaml("名前"));
+    setRemote(container, "名前_リモート", "2");
+
+    const result = await detectThreeWayDiff({ container });
+
+    expect(result.mode).toBe("three-way");
+    if (result.mode === "three-way") {
+      expect(result.remoteDrift.map((e) => e.fieldCode)).toContain("name");
+    }
+  });
+
+  it("両側が別々に変更すると conflict に分類される", async () => {
+    const container = getContainer();
+    const base = parseSchema("名前");
+    setState(container, base, "1");
+    container.schemaStorage.setContent(schemaYaml("名前_ローカル"));
+    setRemote(container, "名前_リモート", "2");
+
+    const result = await detectThreeWayDiff({ container });
+
+    expect(result.mode).toBe("three-way");
+    if (result.mode === "three-way") {
+      expect(result.conflicts.map((e) => e.fieldCode)).toContain("name");
+    }
+  });
+});
+
+describe("legacy commands do not touch state storage (arch-r2-S003)", () => {
+  it("executeMigration は schemaStateStorage を読み書きしない", async () => {
+    const container = getContainer();
+    container.schemaStorage.setContent(schemaYaml("名前_新"));
+    setRemote(container, "名前_旧", "1");
+    container.schemaStateStorage.resetCallLog();
+
+    await executeMigration({ container });
+
+    expect(container.schemaStateStorage.callLog).toEqual([]);
+  });
+
+  it("captureSchema は schemaStateStorage を読み書きしない", async () => {
+    const container = getContainer();
+    setRemote(container, "名前", "1");
+    container.schemaStateStorage.resetCallLog();
+
+    await captureSchema({ container });
+
+    expect(container.schemaStateStorage.callLog).toEqual([]);
+  });
+});

--- a/src/core/application/formSchema/__tests__/pullSchema.test.ts
+++ b/src/core/application/formSchema/__tests__/pullSchema.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import { configCodec } from "@/core/adapters/yaml/configCodec";
+import { setupTestFormSchemaContainer } from "@/core/application/__tests__/helpers";
+import type { TestFormSchemaContainer } from "@/core/application/__tests__/helpers/formSchema";
+import type { Schema } from "@/core/domain/formSchema/entity";
+import { SchemaParser } from "@/core/domain/formSchema/services/schemaParser";
+import { SchemaStateSerializer } from "@/core/domain/formSchema/services/schemaStateSerializer";
+import {
+  FieldCode,
+  type FieldDefinition,
+  type MergeResolution,
+} from "@/core/domain/formSchema/valueObject";
+import { applyPulledMerge, pullSchema } from "../pullSchema";
+
+const getContainer = setupTestFormSchemaContainer();
+
+function textField(code: string, label: string): FieldDefinition {
+  return {
+    code: FieldCode.create(code),
+    type: "SINGLE_LINE_TEXT",
+    label,
+    properties: {},
+  } as FieldDefinition;
+}
+
+function schemaYaml(label: string): string {
+  return `
+layout:
+  - type: ROW
+    fields:
+      - code: name
+        type: SINGLE_LINE_TEXT
+        label: ${label}
+`;
+}
+
+function setRemote(
+  container: TestFormSchemaContainer,
+  label: string,
+  revision = "1",
+): void {
+  const field = textField("name", label);
+  container.formConfigurator.setFields(
+    new Map([[FieldCode.create("name"), field]]),
+  );
+  container.formConfigurator.setLayout([
+    { type: "ROW", fields: [{ kind: "field", field }] },
+  ]);
+  container.formConfigurator.setRevision(revision);
+}
+
+function setState(
+  container: TestFormSchemaContainer,
+  schema: Schema,
+  revision: string,
+): void {
+  const data = SchemaStateSerializer.serialize({ revision, schema });
+  container.schemaStateStorage.setContent(configCodec.stringify(data));
+}
+
+function parseSchema(label: string): Schema {
+  return SchemaParser.parse(configCodec.parse(schemaYaml(label)));
+}
+
+function mutationCalls(container: TestFormSchemaContainer): string[] {
+  return container.formConfigurator.callLog.filter(
+    (c) =>
+      c === "addFields" ||
+      c === "updateFields" ||
+      c === "deleteFields" ||
+      c === "updateLayout",
+  );
+}
+
+describe("pullSchema", () => {
+  it("--force は remote で local を上書きし state を保存する（実環境に書かない）", async () => {
+    const container = getContainer();
+    container.schemaStorage.setContent(schemaYaml("名前_ローカル"));
+    setRemote(container, "名前_リモート", "9");
+    container.formConfigurator.resetCallLog();
+
+    const result = await pullSchema({ container, input: { force: true } });
+
+    expect(result.mode).toBe("force");
+    const local = await container.schemaStorage.get();
+    expect(local.exists && local.content.includes("名前_リモート")).toBe(true);
+    const state = await container.schemaStateStorage.get();
+    expect(state.exists).toBe(true);
+    // No remote mutations.
+    expect(mutationCalls(container)).toHaveLength(0);
+  });
+
+  it("初回（state なし）は remote→local 上書きし state を初期化する", async () => {
+    const container = getContainer();
+    container.schemaStorage.setContent(schemaYaml("名前_ローカル"));
+    setRemote(container, "名前_リモート", "3");
+
+    const result = await pullSchema({ container, input: {} });
+
+    expect(result.mode).toBe("firstTime");
+    const state = await container.schemaStateStorage.get();
+    expect(state.exists).toBe(true);
+  });
+
+  it("state あり・conflict なしは自動マージして書き戻す", async () => {
+    const container = getContainer();
+    const base = parseSchema("名前");
+    setState(container, base, "5");
+    // local changed only
+    container.schemaStorage.setContent(schemaYaml("名前_新"));
+    setRemote(container, "名前", "5"); // remote == base
+
+    const result = await pullSchema({ container, input: {} });
+
+    expect(result.mode).toBe("merged");
+    if (result.mode === "merged") {
+      expect(result.merge.hasConflict).toBe(false);
+    }
+  });
+
+  it("conflict がある場合は merge を返すだけで local/state を変更しない（AC-15）", async () => {
+    const container = getContainer();
+    const base = parseSchema("名前");
+    setState(container, base, "5");
+    container.schemaStorage.setContent(schemaYaml("名前_ローカル"));
+    setRemote(container, "名前_リモート", "6"); // both diverged differently
+    container.schemaStorage.resetCallLog();
+    container.schemaStateStorage.resetCallLog();
+
+    const result = await pullSchema({ container, input: {} });
+
+    expect(result.mode).toBe("merged");
+    if (result.mode === "merged") {
+      expect(result.merge.hasConflict).toBe(true);
+    }
+    // Two-stage: nothing written until applyPulledMerge runs.
+    expect(container.schemaStorage.callLog).not.toContain("update");
+    expect(container.schemaStateStorage.callLog).not.toContain("update");
+  });
+
+  it("applyPulledMerge で resolution を適用すると local と state が書かれる", async () => {
+    const container = getContainer();
+    const base = parseSchema("名前");
+    setState(container, base, "5");
+    container.schemaStorage.setContent(schemaYaml("名前_ローカル"));
+    setRemote(container, "名前_リモート", "6");
+
+    const result = await pullSchema({ container, input: {} });
+    if (result.mode !== "merged") throw new Error("expected merged");
+
+    const resolution: MergeResolution = {
+      fields: new Map([[FieldCode.create("name"), "remote"]]),
+      layout: "remote",
+    };
+    await applyPulledMerge({
+      container,
+      input: {
+        merge: result.merge,
+        resolution,
+        remoteRevision: result.remoteRevision,
+        remoteSchema: result.remoteSchema,
+      },
+    });
+
+    const local = await container.schemaStorage.get();
+    expect(local.exists && local.content.includes("名前_リモート")).toBe(true);
+    const state = await container.schemaStateStorage.get();
+    expect(state.exists).toBe(true);
+    // Still no remote mutations.
+    expect(mutationCalls(container)).toHaveLength(0);
+  });
+});

--- a/src/core/application/formSchema/__tests__/pushSchema.test.ts
+++ b/src/core/application/formSchema/__tests__/pushSchema.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vitest";
+import { configCodec } from "@/core/adapters/yaml/configCodec";
+import { setupTestFormSchemaContainer } from "@/core/application/__tests__/helpers";
+import type { TestFormSchemaContainer } from "@/core/application/__tests__/helpers/formSchema";
+import { ConflictError, ValidationError } from "@/core/application/error";
+import type { Schema } from "@/core/domain/formSchema/entity";
+import { SchemaParser } from "@/core/domain/formSchema/services/schemaParser";
+import { SchemaStateSerializer } from "@/core/domain/formSchema/services/schemaStateSerializer";
+import {
+  FieldCode,
+  type FieldDefinition,
+} from "@/core/domain/formSchema/valueObject";
+import { PUSH_DRIFT_MESSAGE, pushSchema } from "../pushSchema";
+
+const getContainer = setupTestFormSchemaContainer();
+
+function textField(code: string, label: string): FieldDefinition {
+  return {
+    code: FieldCode.create(code),
+    type: "SINGLE_LINE_TEXT",
+    label,
+    properties: {},
+  } as FieldDefinition;
+}
+
+function schemaYaml(label: string): string {
+  return `
+layout:
+  - type: ROW
+    fields:
+      - code: name
+        type: SINGLE_LINE_TEXT
+        label: ${label}
+`;
+}
+
+function setRemote(
+  container: TestFormSchemaContainer,
+  label: string,
+  revision = "1",
+): FieldDefinition {
+  const field = textField("name", label);
+  container.formConfigurator.setFields(
+    new Map([[FieldCode.create("name"), field]]),
+  );
+  container.formConfigurator.setLayout([
+    { type: "ROW", fields: [{ kind: "field", field }] },
+  ]);
+  container.formConfigurator.setRevision(revision);
+  return field;
+}
+
+function setState(
+  container: TestFormSchemaContainer,
+  schema: Schema,
+  revision: string,
+): void {
+  const data = SchemaStateSerializer.serialize({ revision, schema });
+  container.schemaStateStorage.setContent(configCodec.stringify(data));
+}
+
+function parseSchema(label: string): Schema {
+  return SchemaParser.parse(configCodec.parse(schemaYaml(label)));
+}
+
+describe("pushSchema", () => {
+  it("初回（state なし）は drift ガードなしで適用し state を初期化する", async () => {
+    const container = getContainer();
+    container.schemaStorage.setContent(schemaYaml("名前_新"));
+    setRemote(container, "名前_旧", "5");
+
+    const result = await pushSchema({ container, input: {} });
+
+    expect(result.mode).toBe("firstTime");
+    const fields = await container.formConfigurator.getFields();
+    expect(fields.get(FieldCode.create("name"))?.label).toBe("名前_新");
+    const state = await container.schemaStateStorage.get();
+    expect(state.exists).toBe(true);
+  });
+
+  it("初回も期待 revision を送らない（検証スキップ）", async () => {
+    const container = getContainer();
+    container.schemaStorage.setContent(schemaYaml("名前_新"));
+    setRemote(container, "名前_旧", "5");
+
+    await pushSchema({ container, input: {} });
+
+    // expectedRevision must be undefined for firstTime (revision-skip).
+    expect(container.formConfigurator.expectedRevisions.length).toBeGreaterThan(
+      0,
+    );
+    expect(
+      container.formConfigurator.expectedRevisions.every(
+        (r) => r === undefined,
+      ),
+    ).toBe(true);
+  });
+
+  it("drift がなければ適用し、観測した現在 revision を期待 revision として固定送出する", async () => {
+    const container = getContainer();
+    const base = parseSchema("名前");
+    setState(container, base, "7");
+    container.schemaStorage.setContent(schemaYaml("名前_新"));
+    setRemote(container, "名前", "7"); // remote == base => no drift
+
+    await pushSchema({ container, input: {} });
+
+    const fields = await container.formConfigurator.getFields();
+    expect(fields.get(FieldCode.create("name"))?.label).toBe("名前_新");
+    // expected revision fixed to the observed current revision "7" on every
+    // mutation (does not advance even if multiple APIs are called).
+    expect(container.formConfigurator.expectedRevisions.length).toBeGreaterThan(
+      0,
+    );
+    expect(
+      container.formConfigurator.expectedRevisions.every((r) => r === "7"),
+    ).toBe(true);
+  });
+
+  it("drift があり --force でない場合 ConflictError（push 専用メッセージ）", async () => {
+    const container = getContainer();
+    const base = parseSchema("名前");
+    setState(container, base, "7");
+    container.schemaStorage.setContent(schemaYaml("名前_新"));
+    // remote diverged from base (label differs) => drift
+    setRemote(container, "名前_リモート変更", "9");
+
+    await expect(pushSchema({ container, input: {} })).rejects.toThrow(
+      ConflictError,
+    );
+    await expect(pushSchema({ container, input: {} })).rejects.toThrow(
+      PUSH_DRIFT_MESSAGE,
+    );
+  });
+
+  it("旧 migrate 適用後（state 未更新）に push すると drift→ConflictError になる", async () => {
+    const container = getContainer();
+    // state base captured at "名前"
+    const base = parseSchema("名前");
+    setState(container, base, "3");
+    container.schemaStorage.setContent(schemaYaml("名前_新"));
+    // remote was changed out-of-band by a legacy migrate (state not updated)
+    setRemote(container, "名前_別経路変更", "4");
+
+    await expect(pushSchema({ container, input: {} })).rejects.toThrow(
+      ConflictError,
+    );
+  });
+
+  it("--force は drift をスキップし期待 revision を送らない", async () => {
+    const container = getContainer();
+    const base = parseSchema("名前");
+    setState(container, base, "7");
+    container.schemaStorage.setContent(schemaYaml("名前_新"));
+    setRemote(container, "名前_リモート変更", "9"); // drift present
+
+    const result = await pushSchema({ container, input: { force: true } });
+
+    expect(result.mode).toBe("push");
+    expect(
+      container.formConfigurator.expectedRevisions.every(
+        (r) => r === undefined,
+      ),
+    ).toBe(true);
+  });
+
+  it("型変更は ValidationError で弾かれる", async () => {
+    const container = getContainer();
+    const base = parseSchema("名前");
+    setState(container, base, "1");
+    container.schemaStorage.setContent(`
+layout:
+  - type: ROW
+    fields:
+      - code: name
+        type: NUMBER
+        label: 数値
+`);
+    setRemote(container, "名前", "1");
+
+    await expect(pushSchema({ container, input: {} })).rejects.toThrow(
+      ValidationError,
+    );
+  });
+
+  it("local schema がない場合 ValidationError", async () => {
+    const container = getContainer();
+    setRemote(container, "名前", "1");
+
+    await expect(pushSchema({ container, input: {} })).rejects.toThrow(
+      ValidationError,
+    );
+  });
+
+  it("適用後 getRevision で取得した preview revision を state に記録する", async () => {
+    const container = getContainer();
+    const base = parseSchema("名前");
+    setState(container, base, "7");
+    container.schemaStorage.setContent(schemaYaml("名前_新"));
+    setRemote(container, "名前", "7");
+
+    const result = await pushSchema({ container, input: {} });
+
+    expect(result.revision).toBe("7");
+  });
+});

--- a/src/core/application/formSchema/__tests__/pushSchema.test.ts
+++ b/src/core/application/formSchema/__tests__/pushSchema.test.ts
@@ -2,8 +2,13 @@ import { describe, expect, it } from "vitest";
 import { configCodec } from "@/core/adapters/yaml/configCodec";
 import { setupTestFormSchemaContainer } from "@/core/application/__tests__/helpers";
 import type { TestFormSchemaContainer } from "@/core/application/__tests__/helpers/formSchema";
-import { ConflictError, ValidationError } from "@/core/application/error";
+import {
+  ConflictError,
+  ConflictErrorCode,
+  ValidationError,
+} from "@/core/application/error";
 import type { Schema } from "@/core/domain/formSchema/entity";
+import { SKIP_REVISION_CHECK } from "@/core/domain/formSchema/ports/formConfigurator";
 import { SchemaParser } from "@/core/domain/formSchema/services/schemaParser";
 import { SchemaStateSerializer } from "@/core/domain/formSchema/services/schemaStateSerializer";
 import {
@@ -85,13 +90,14 @@ describe("pushSchema", () => {
 
     await pushSchema({ container, input: {} });
 
-    // expectedRevision must be undefined for firstTime (revision-skip).
+    // expectedRevision must be the skip sentinel for firstTime (revision-skip),
+    // not undefined (which would fall back to the tracked revision — B-001).
     expect(container.formConfigurator.expectedRevisions.length).toBeGreaterThan(
       0,
     );
     expect(
       container.formConfigurator.expectedRevisions.every(
-        (r) => r === undefined,
+        (r) => r === SKIP_REVISION_CHECK,
       ),
     ).toBe(true);
   });
@@ -159,7 +165,7 @@ describe("pushSchema", () => {
     expect(result.mode).toBe("push");
     expect(
       container.formConfigurator.expectedRevisions.every(
-        (r) => r === undefined,
+        (r) => r === SKIP_REVISION_CHECK,
       ),
     ).toBe(true);
   });
@@ -190,6 +196,39 @@ layout:
     await expect(pushSchema({ container, input: {} })).rejects.toThrow(
       ValidationError,
     );
+  });
+
+  it("drift 拒否は SchemaDrift コードで区別される（API 楽観ロックではない）", async () => {
+    const container = getContainer();
+    const base = parseSchema("名前");
+    setState(container, base, "7");
+    container.schemaStorage.setContent(schemaYaml("名前_新"));
+    setRemote(container, "名前_リモート変更", "9");
+
+    await expect(pushSchema({ container, input: {} })).rejects.toMatchObject({
+      code: ConflictErrorCode.SchemaDrift,
+    });
+  });
+
+  it("drift なし通過後の適用中 TOCTOU 409 は ConflictError(API 由来) として伝播する（W-005）", async () => {
+    const container = getContainer();
+    const base = parseSchema("名前");
+    setState(container, base, "7");
+    container.schemaStorage.setContent(schemaYaml("名前_新"));
+    setRemote(container, "名前", "7"); // no drift at check time
+    // The remote changes again between the drift check and the apply: the
+    // mutation API rejects with an optimistic-lock 409, which the adapter maps
+    // to a ConflictError. pushSchema must let it propagate untouched (not
+    // swallow it, and not re-tag it as SchemaDrift).
+    container.formConfigurator.failNextMutationWithOptimisticLock();
+
+    const error = await pushSchema({ container, input: {} }).catch((e) => e);
+
+    expect(error).toBeInstanceOf(ConflictError);
+    // It is the API optimistic-lock code, NOT the push-drift code: the CLI uses
+    // this distinction to choose the TOCTOU message (ADR-008 / ADR-014).
+    expect(error.code).toBe(ConflictErrorCode.Conflict);
+    expect(error.code).not.toBe(ConflictErrorCode.SchemaDrift);
   });
 
   it("適用後 getRevision で取得した preview revision を state に記録する", async () => {

--- a/src/core/application/formSchema/applySchemaChanges.ts
+++ b/src/core/application/formSchema/applySchemaChanges.ts
@@ -71,8 +71,8 @@ export type ApplySchemaChangesContext = Readonly<{
 /**
  * Applies a {@link Schema} to the remote form (preview).
  *
- * This is the shared application core extracted from `executeMigration`
- * (ADR-009): it computes the diff against the current form, classifies
+ * This is the shared application core (ADR-009): it computes the diff against
+ * the current form, classifies
  * add/update/delete/layout changes, rejects field type changes and additions
  * to existing subtables with a {@link ValidationError} (AC-13), and applies the
  * changes via the configurator. `migrate` (via local YAML) and `push` (via a

--- a/src/core/application/formSchema/applySchemaChanges.ts
+++ b/src/core/application/formSchema/applySchemaChanges.ts
@@ -1,5 +1,6 @@
 import { ValidationError, ValidationErrorCode } from "@/core/application/error";
 import type { Schema } from "@/core/domain/formSchema/entity";
+import type { ExpectedRevision } from "@/core/domain/formSchema/ports/formConfigurator";
 import { DiffDetector } from "@/core/domain/formSchema/services/diffDetector";
 import {
   collectSubtableInnerFieldCodes,
@@ -57,10 +58,14 @@ export type ApplySchemaChangesContext = Readonly<{
   container: FormSchemaContainer;
   /**
    * Expected app (preview) revision to enforce on mutations (TOCTOU guard,
-   * ADR-005). When omitted (e.g. migrate, or `--force` push), no expected
-   * revision is enforced.
+   * ADR-005 / ADR-010). Three states (see {@link ExpectedRevision}):
+   * - a revision string: enforce it (push non-force).
+   * - {@link SKIP_REVISION_CHECK}: skip the revision check (`--force` push /
+   *   first run).
+   * - omitted/`undefined`: fall back to the adapter's tracked revision
+   *   (migrate, behaviour unchanged).
    */
-  expectedRevision?: string;
+  expectedRevision?: ExpectedRevision;
 }>;
 
 /**

--- a/src/core/application/formSchema/applySchemaChanges.ts
+++ b/src/core/application/formSchema/applySchemaChanges.ts
@@ -1,0 +1,166 @@
+import { ValidationError, ValidationErrorCode } from "@/core/application/error";
+import type { Schema } from "@/core/domain/formSchema/entity";
+import { DiffDetector } from "@/core/domain/formSchema/services/diffDetector";
+import {
+  collectSubtableInnerFieldCodes,
+  enrichLayoutWithFields,
+} from "@/core/domain/formSchema/services/layoutEnricher";
+import { splitSubtableInnerFields } from "@/core/domain/formSchema/services/subtableFieldSplitter";
+import type {
+  FieldCode,
+  FieldDefinition,
+} from "@/core/domain/formSchema/valueObject";
+import type { FormSchemaContainer } from "../container/formSchema";
+
+function processModifiedEntry(
+  after: FieldDefinition,
+  before: FieldDefinition | undefined,
+  fieldsToUpdate: FieldDefinition[],
+  innerFieldsToDelete: FieldCode[],
+): void {
+  if (
+    after.type === "SUBTABLE" &&
+    before !== undefined &&
+    before.type === "SUBTABLE"
+  ) {
+    const { newInnerFields, existingInnerFields, deletedInnerFieldCodes } =
+      splitSubtableInnerFields(after, before);
+
+    if (newInnerFields.size > 0) {
+      throw new ValidationError(
+        ValidationErrorCode.InvalidInput,
+        `kintone REST API does not support adding fields to an existing subtable. Use the schema override command instead. Subtable: ${after.code}`,
+      );
+    }
+
+    if (existingInnerFields.size > 0) {
+      fieldsToUpdate.push({
+        ...after,
+        properties: { fields: existingInnerFields },
+      });
+    }
+
+    for (const code of deletedInnerFieldCodes) {
+      innerFieldsToDelete.push(code);
+    }
+  } else if (before !== undefined && before.type !== after.type) {
+    throw new ValidationError(
+      ValidationErrorCode.InvalidInput,
+      `Field type change detected for "${after.code}" (${before.type} → ${after.type}). Use the schema override command instead.`,
+    );
+  } else {
+    fieldsToUpdate.push(after);
+  }
+}
+
+export type ApplySchemaChangesContext = Readonly<{
+  container: FormSchemaContainer;
+  /**
+   * Expected app (preview) revision to enforce on mutations (TOCTOU guard,
+   * ADR-005). When omitted (e.g. migrate, or `--force` push), no expected
+   * revision is enforced.
+   */
+  expectedRevision?: string;
+}>;
+
+/**
+ * Applies a {@link Schema} to the remote form (preview).
+ *
+ * This is the shared application core extracted from `executeMigration`
+ * (ADR-009): it computes the diff against the current form, classifies
+ * add/update/delete/layout changes, rejects field type changes and additions
+ * to existing subtables with a {@link ValidationError} (AC-13), and applies the
+ * changes via the configurator. `migrate` (via local YAML) and `push` (via a
+ * merged/local in-memory `Schema`) share this exact implementation.
+ *
+ * When `expectedRevision` is provided it is passed to every mutation so a
+ * concurrent change yields a 409 conflict.
+ */
+export async function applySchemaChanges(
+  schema: Schema,
+  { container, expectedRevision }: ApplySchemaChangesContext,
+): Promise<void> {
+  const [currentFields, currentLayout] = await Promise.all([
+    container.formConfigurator.getFields(),
+    container.formConfigurator.getLayout(),
+  ]);
+  const diff = DiffDetector.detect(schema, currentFields);
+  const enrichedCurrentLayout = enrichLayoutWithFields(
+    currentLayout,
+    currentFields,
+  );
+  const hasLayoutChanges = DiffDetector.detectLayoutChanges(
+    schema.layout,
+    enrichedCurrentLayout,
+  );
+
+  if (diff.isEmpty && !hasLayoutChanges) {
+    return;
+  }
+
+  const subtableInnerCodes = collectSubtableInnerFieldCodes(schema.fields);
+
+  const added = diff.entries.filter((e) => e.type === "added");
+  const modified = diff.entries.filter((e) => e.type === "modified");
+  const deleted = diff.entries.filter((e) => e.type === "deleted");
+
+  const fieldsToAdd: FieldDefinition[] = [];
+  const fieldsToUpdate: FieldDefinition[] = [];
+  const innerFieldsToDelete: FieldCode[] = [];
+
+  for (const entry of added) {
+    if (entry.after === undefined) continue;
+    if (subtableInnerCodes.has(entry.fieldCode)) continue;
+    fieldsToAdd.push(entry.after);
+  }
+
+  for (const entry of modified) {
+    if (entry.after === undefined) continue;
+    if (subtableInnerCodes.has(entry.fieldCode)) continue;
+    processModifiedEntry(
+      entry.after,
+      entry.before,
+      fieldsToUpdate,
+      innerFieldsToDelete,
+    );
+  }
+
+  // Operation order: add → update → delete.
+  // Unlike forceOverrideForm (delete → add → update), subtable re-creation
+  // is not needed here because new inner fields on existing subtables are
+  // rejected with a ValidationError above.
+  if (fieldsToAdd.length > 0) {
+    await container.formConfigurator.addFields(fieldsToAdd, expectedRevision);
+  }
+
+  if (fieldsToUpdate.length > 0) {
+    await container.formConfigurator.updateFields(
+      fieldsToUpdate,
+      expectedRevision,
+    );
+  }
+
+  if (deleted.length > 0 || innerFieldsToDelete.length > 0) {
+    const currentSubtableInnerCodes =
+      collectSubtableInnerFieldCodes(currentFields);
+    const fieldCodes = [
+      ...deleted
+        .filter((e) => !currentSubtableInnerCodes.has(e.fieldCode))
+        .map((e) => e.fieldCode),
+      ...innerFieldsToDelete,
+    ];
+    if (fieldCodes.length > 0) {
+      await container.formConfigurator.deleteFields(
+        fieldCodes,
+        expectedRevision,
+      );
+    }
+  }
+
+  if (hasLayoutChanges) {
+    await container.formConfigurator.updateLayout(
+      schema.layout,
+      expectedRevision,
+    );
+  }
+}

--- a/src/core/application/formSchema/detectThreeWayDiff.ts
+++ b/src/core/application/formSchema/detectThreeWayDiff.ts
@@ -1,0 +1,92 @@
+import type { ThreeWayEntry } from "@/core/domain/diff";
+import { isLayoutEqual } from "@/core/domain/formSchema/services/diffDetector";
+import { enrichLayoutWithFields } from "@/core/domain/formSchema/services/layoutEnricher";
+import { computeThreeWayMerge } from "@/core/domain/formSchema/services/threeWayMerge";
+import type {
+  FieldCode,
+  FieldDefinition,
+} from "@/core/domain/formSchema/valueObject";
+import type { FormSchemaDiffServiceArgs } from "../container/formSchema";
+import { detectDiff } from "./detectDiff";
+import type { DetectThreeWayDiffOutput, ThreeWayDiffFieldEntry } from "./dto";
+import { loadThreeWayInputs } from "./loadThreeWayInputs";
+
+function toEntry(
+  entry: ThreeWayEntry<FieldCode, FieldDefinition>,
+  kind: ThreeWayDiffFieldEntry["kind"],
+): ThreeWayDiffFieldEntry {
+  const label =
+    entry.local?.label ?? entry.remote?.label ?? entry.base?.label ?? "";
+  return { fieldCode: entry.key, fieldLabel: label, kind };
+}
+
+/**
+ * Detects differences with 3-way awareness (AC-10, AC-11).
+ *
+ * When a state (base snapshot) exists, classifies changes into local-only,
+ * remote drift, and conflicts. When no state exists, falls back to the existing
+ * 2-way `detectDiff`.
+ */
+export async function detectThreeWayDiff({
+  container,
+}: FormSchemaDiffServiceArgs): Promise<DetectThreeWayDiffOutput> {
+  const { state, local, remote } = await loadThreeWayInputs(container);
+
+  if (state === undefined || local === undefined) {
+    // No state (first run) or local YAML gone: fall back to 2-way diff.
+    const diff = await detectDiff({ container });
+    return { mode: "two-way", diff };
+  }
+
+  const merge = computeThreeWayMerge(state.schema, local, remote);
+
+  const localChanges: ThreeWayDiffFieldEntry[] = [];
+  const remoteDrift: ThreeWayDiffFieldEntry[] = [];
+  const conflicts: ThreeWayDiffFieldEntry[] = [];
+  for (const entry of merge.fieldEntries) {
+    switch (entry.change.kind) {
+      case "localOnly":
+        localChanges.push(toEntry(entry, "localOnly"));
+        break;
+      case "remoteOnly":
+        remoteDrift.push(toEntry(entry, "remoteOnly"));
+        break;
+      case "conflict":
+        conflicts.push(toEntry(entry, "conflict"));
+        break;
+      default:
+        break;
+    }
+  }
+
+  const enrichedBaseLayout = enrichLayoutWithFields(
+    state.schema.layout,
+    state.schema.fields,
+  );
+  const layoutLocalChanged = !isLayoutEqual(
+    enrichedBaseLayout,
+    merge.localLayout,
+  );
+  const layoutRemoteChanged = !isLayoutEqual(
+    enrichedBaseLayout,
+    merge.remoteLayout,
+  );
+
+  const isEmpty =
+    localChanges.length === 0 &&
+    remoteDrift.length === 0 &&
+    conflicts.length === 0 &&
+    !layoutLocalChanged &&
+    !layoutRemoteChanged;
+
+  return {
+    mode: "three-way",
+    localChanges,
+    remoteDrift,
+    conflicts,
+    layoutLocalChanged,
+    layoutRemoteChanged,
+    layoutConflict: merge.layoutConflict,
+    isEmpty,
+  };
+}

--- a/src/core/application/formSchema/dto.ts
+++ b/src/core/application/formSchema/dto.ts
@@ -1,4 +1,8 @@
-import type { FieldCode } from "@/core/domain/formSchema/valueObject";
+import type { Schema } from "@/core/domain/formSchema/entity";
+import type {
+  FieldCode,
+  FormSchemaThreeWayMerge,
+} from "@/core/domain/formSchema/valueObject";
 
 export type DiffEntryDto = {
   readonly type: "added" | "modified" | "deleted";
@@ -41,4 +45,59 @@ export type DetectDiffOutput = {
 export type CaptureSchemaOutput = {
   readonly schemaText: string;
   readonly hasExistingSchema: boolean;
+};
+
+// --- 3-way diff / pull / push DTOs ---
+
+export type ThreeWayFieldChangeKind = "localOnly" | "remoteOnly" | "conflict";
+
+export type ThreeWayDiffFieldEntry = {
+  readonly fieldCode: FieldCode;
+  readonly fieldLabel: string;
+  readonly kind: ThreeWayFieldChangeKind;
+};
+
+export type DetectThreeWayDiffOutput =
+  | {
+      readonly mode: "three-way";
+      /** Fields changed only locally (local will be pushed). */
+      readonly localChanges: readonly ThreeWayDiffFieldEntry[];
+      /** Fields changed only remotely (drift; pull would bring them in). */
+      readonly remoteDrift: readonly ThreeWayDiffFieldEntry[];
+      /** Fields changed on both sides to different values (conflicts). */
+      readonly conflicts: readonly ThreeWayDiffFieldEntry[];
+      readonly layoutLocalChanged: boolean;
+      readonly layoutRemoteChanged: boolean;
+      readonly layoutConflict: boolean;
+      readonly isEmpty: boolean;
+    }
+  | {
+      readonly mode: "two-way";
+      readonly diff: DetectDiffOutput;
+    };
+
+/**
+ * Result of the first stage of `pull`. For the `merged` mode the merge is
+ * returned (possibly with conflicts) so the CLI can resolve conflicts before
+ * the local YAML / state are written by `applyPulledMerge` (AC-15).
+ */
+export type PullSchemaOutput =
+  | {
+      readonly mode: "force";
+      readonly schemaText: string;
+    }
+  | {
+      readonly mode: "firstTime";
+      readonly schemaText: string;
+    }
+  | {
+      readonly mode: "merged";
+      readonly merge: FormSchemaThreeWayMerge;
+      readonly remoteRevision: string;
+      readonly remoteSchema: Schema;
+    };
+
+export type PushSchemaOutput = {
+  readonly mode: "push" | "firstTime";
+  readonly revision: string;
 };

--- a/src/core/application/formSchema/executeMigration.ts
+++ b/src/core/application/formSchema/executeMigration.ts
@@ -1,59 +1,17 @@
 import { ValidationError, ValidationErrorCode } from "@/core/application/error";
-import { DiffDetector } from "@/core/domain/formSchema/services/diffDetector";
-import {
-  collectSubtableInnerFieldCodes,
-  enrichLayoutWithFields,
-} from "@/core/domain/formSchema/services/layoutEnricher";
-import { splitSubtableInnerFields } from "@/core/domain/formSchema/services/subtableFieldSplitter";
-import type {
-  FieldCode,
-  FieldDefinition,
-} from "@/core/domain/formSchema/valueObject";
 import type { FormSchemaServiceArgs } from "../container/formSchema";
+import { applySchemaChanges } from "./applySchemaChanges";
 import { assertSchemaValid } from "./assertSchemaValid";
 import { parseSchemaText } from "./parseSchema";
 
-function processModifiedEntry(
-  after: FieldDefinition,
-  before: FieldDefinition | undefined,
-  fieldsToUpdate: FieldDefinition[],
-  innerFieldsToDelete: FieldCode[],
-): void {
-  if (
-    after.type === "SUBTABLE" &&
-    before !== undefined &&
-    before.type === "SUBTABLE"
-  ) {
-    const { newInnerFields, existingInnerFields, deletedInnerFieldCodes } =
-      splitSubtableInnerFields(after, before);
-
-    if (newInnerFields.size > 0) {
-      throw new ValidationError(
-        ValidationErrorCode.InvalidInput,
-        `kintone REST API does not support adding fields to an existing subtable. Use the schema override command instead. Subtable: ${after.code}`,
-      );
-    }
-
-    if (existingInnerFields.size > 0) {
-      fieldsToUpdate.push({
-        ...after,
-        properties: { fields: existingInnerFields },
-      });
-    }
-
-    for (const code of deletedInnerFieldCodes) {
-      innerFieldsToDelete.push(code);
-    }
-  } else if (before !== undefined && before.type !== after.type) {
-    throw new ValidationError(
-      ValidationErrorCode.InvalidInput,
-      `Field type change detected for "${after.code}" (${before.type} → ${after.type}). Use the schema override command instead.`,
-    );
-  } else {
-    fieldsToUpdate.push(after);
-  }
-}
-
+/**
+ * Reads the local schema YAML and applies it to the remote form.
+ *
+ * Thin wrapper around {@link applySchemaChanges} (ADR-009): it loads/parses the
+ * local schema file and validates it, then delegates the application core to
+ * the shared function. It does not enforce an expected revision (legacy migrate
+ * behaviour) and does not read or write the state file.
+ */
 export async function executeMigration({
   container,
 }: FormSchemaServiceArgs): Promise<void> {
@@ -68,78 +26,5 @@ export async function executeMigration({
 
   assertSchemaValid(schema);
 
-  const [currentFields, currentLayout] = await Promise.all([
-    container.formConfigurator.getFields(),
-    container.formConfigurator.getLayout(),
-  ]);
-  const diff = DiffDetector.detect(schema, currentFields);
-  const enrichedCurrentLayout = enrichLayoutWithFields(
-    currentLayout,
-    currentFields,
-  );
-  const hasLayoutChanges = DiffDetector.detectLayoutChanges(
-    schema.layout,
-    enrichedCurrentLayout,
-  );
-
-  if (diff.isEmpty && !hasLayoutChanges) {
-    return;
-  }
-
-  const subtableInnerCodes = collectSubtableInnerFieldCodes(schema.fields);
-
-  const added = diff.entries.filter((e) => e.type === "added");
-  const modified = diff.entries.filter((e) => e.type === "modified");
-  const deleted = diff.entries.filter((e) => e.type === "deleted");
-
-  const fieldsToAdd: FieldDefinition[] = [];
-  const fieldsToUpdate: FieldDefinition[] = [];
-  const innerFieldsToDelete: FieldCode[] = [];
-
-  for (const entry of added) {
-    if (entry.after === undefined) continue;
-    if (subtableInnerCodes.has(entry.fieldCode)) continue;
-    fieldsToAdd.push(entry.after);
-  }
-
-  for (const entry of modified) {
-    if (entry.after === undefined) continue;
-    if (subtableInnerCodes.has(entry.fieldCode)) continue;
-    processModifiedEntry(
-      entry.after,
-      entry.before,
-      fieldsToUpdate,
-      innerFieldsToDelete,
-    );
-  }
-
-  // Operation order: add → update → delete.
-  // Unlike forceOverrideForm (delete → add → update), subtable re-creation
-  // is not needed here because new inner fields on existing subtables are
-  // rejected with a ValidationError above.
-  if (fieldsToAdd.length > 0) {
-    await container.formConfigurator.addFields(fieldsToAdd);
-  }
-
-  if (fieldsToUpdate.length > 0) {
-    await container.formConfigurator.updateFields(fieldsToUpdate);
-  }
-
-  if (deleted.length > 0 || innerFieldsToDelete.length > 0) {
-    const currentSubtableInnerCodes =
-      collectSubtableInnerFieldCodes(currentFields);
-    const fieldCodes = [
-      ...deleted
-        .filter((e) => !currentSubtableInnerCodes.has(e.fieldCode))
-        .map((e) => e.fieldCode),
-      ...innerFieldsToDelete,
-    ];
-    if (fieldCodes.length > 0) {
-      await container.formConfigurator.deleteFields(fieldCodes);
-    }
-  }
-
-  if (hasLayoutChanges) {
-    await container.formConfigurator.updateLayout(schema.layout);
-  }
+  await applySchemaChanges(schema, { container });
 }

--- a/src/core/application/formSchema/loadThreeWayInputs.ts
+++ b/src/core/application/formSchema/loadThreeWayInputs.ts
@@ -45,6 +45,16 @@ export async function loadThreeWayInputs(
     remoteLayout,
     remoteFields,
   );
+  // base/local are layout-derived (round-tripped through SchemaSerializer /
+  // SchemaParser, which serialize layout only), so their field maps contain only
+  // layout-placed fields. The remote field map (getFields) is the full set and
+  // is NOT re-derived from layout here, so it could in principle retain a
+  // layout-non-placed field that base/local lack. In kintone, however, every
+  // field is always placed in the form layout, so getFields and the layout-
+  // derived field set coincide and no asymmetry arises in practice. The 3-way
+  // normalization (normalizeForThreeWay) only drops GROUP / subtable-inner, not
+  // layout-non-placed fields, so this relies on that kintone invariant rather
+  // than re-deriving remote fields from layout (documented in ADR-013).
   const remote = Schema.create(remoteFields, enrichedRemoteLayout);
 
   return { state, local, remote, remoteRevision };

--- a/src/core/application/formSchema/loadThreeWayInputs.ts
+++ b/src/core/application/formSchema/loadThreeWayInputs.ts
@@ -1,0 +1,51 @@
+import { Schema } from "@/core/domain/formSchema/entity";
+import { enrichLayoutWithFields } from "@/core/domain/formSchema/services/layoutEnricher";
+import type { SchemaState } from "@/core/domain/formSchema/state";
+import type { FormSchemaDiffContainer } from "../container/formSchema";
+import { parseSchemaText } from "./parseSchema";
+import { loadState } from "./schemaStateIo";
+
+export type ThreeWayInputs = Readonly<{
+  /** Parsed state (base snapshot + revision), or undefined on first run. */
+  state: SchemaState | undefined;
+  /** Local schema parsed from the YAML file, or undefined when absent. */
+  local: Schema | undefined;
+  /** Remote schema reconstructed from getFields/getLayout. */
+  remote: Schema;
+  /** Current remote (preview) revision observed via getRevision. */
+  remoteRevision: string;
+}>;
+
+/**
+ * Loads the three inputs of a 3-way schema sync: the base snapshot (state), the
+ * local YAML schema, and the remote schema, plus the current remote revision.
+ *
+ * The remote schema is reconstructed via the same enrichment path as `capture`
+ * so it compares like-with-like against base/local after normalization
+ * (ADR-007). `getRevision` is read for the drift signal / expected revision but
+ * never short-circuits snapshot fetching (ADR-004).
+ */
+export async function loadThreeWayInputs(
+  container: FormSchemaDiffContainer,
+): Promise<ThreeWayInputs> {
+  const [state, localResult, remoteFields, remoteLayout, remoteRevision] =
+    await Promise.all([
+      loadState(container.schemaStateStorage, container.configCodec),
+      container.schemaStorage.get(),
+      container.formConfigurator.getFields(),
+      container.formConfigurator.getLayout(),
+      container.formConfigurator.getRevision(),
+    ]);
+
+  const local = localResult.exists
+    ? parseSchemaText(container.configCodec, localResult.content)
+    : undefined;
+
+  const enrichedRemoteLayout = enrichLayoutWithFields(
+    remoteLayout,
+    remoteFields,
+  );
+  const remote = Schema.create(remoteFields, enrichedRemoteLayout);
+
+  return { state, local, remote, remoteRevision };
+}

--- a/src/core/application/formSchema/pullSchema.ts
+++ b/src/core/application/formSchema/pullSchema.ts
@@ -1,0 +1,114 @@
+import type { Schema } from "@/core/domain/formSchema/entity";
+import { enrichLayoutWithFields } from "@/core/domain/formSchema/services/layoutEnricher";
+import { SchemaSerializer } from "@/core/domain/formSchema/services/schemaSerializer";
+import {
+  computeThreeWayMerge,
+  resolveMerge,
+} from "@/core/domain/formSchema/services/threeWayMerge";
+import type {
+  FormSchemaThreeWayMerge,
+  MergeResolution,
+} from "@/core/domain/formSchema/valueObject";
+import type { FormSchemaServiceArgs } from "../container/formSchema";
+import { stringifyConfig } from "../stringifyConfig";
+import type { PullSchemaOutput } from "./dto";
+import { loadThreeWayInputs } from "./loadThreeWayInputs";
+import { saveState } from "./schemaStateIo";
+
+export type PullSchemaInput = {
+  /** Overwrite local with remote (capture-equivalent), bypassing merge. */
+  readonly force?: boolean;
+};
+
+function serializeSchema(
+  container: FormSchemaServiceArgs["container"],
+  schema: Schema,
+): string {
+  const enrichedLayout = enrichLayoutWithFields(schema.layout, schema.fields);
+  return stringifyConfig(
+    container.configCodec,
+    SchemaSerializer.serialize(enrichedLayout, schema.fields),
+  );
+}
+
+/**
+ * First stage of `schema pull` (AC-4, AC-5, AC-6, AC-11).
+ *
+ * - `force`: returns the remote snapshot for local overwrite (capture-equiv).
+ * - first run (no state): returns remote for one-way overwrite.
+ * - otherwise: computes the 3-way merge and returns it for conflict resolution
+ *   by the CLI. The local YAML / state are NOT written here — that happens in
+ *   {@link applyPulledMerge} after resolution, so an aborted resolution leaves
+ *   local and state untouched (AC-15).
+ *
+ * This stage never writes to the remote (pull is read-only against kintone).
+ */
+export async function pullSchema({
+  container,
+  input,
+}: FormSchemaServiceArgs<PullSchemaInput>): Promise<PullSchemaOutput> {
+  const { state, local, remote, remoteRevision } =
+    await loadThreeWayInputs(container);
+
+  if (input.force) {
+    const schemaText = serializeSchema(container, remote);
+    await container.schemaStorage.update(schemaText);
+    await saveState(
+      container.schemaStateStorage,
+      container.configCodec,
+      remoteRevision,
+      remote,
+    );
+    return { mode: "force", schemaText };
+  }
+
+  if (state === undefined || local === undefined) {
+    // First run / no local: one-way overwrite from remote and initialize state.
+    const schemaText = serializeSchema(container, remote);
+    await container.schemaStorage.update(schemaText);
+    await saveState(
+      container.schemaStateStorage,
+      container.configCodec,
+      remoteRevision,
+      remote,
+    );
+    return { mode: "firstTime", schemaText };
+  }
+
+  const merge = computeThreeWayMerge(state.schema, local, remote);
+
+  return { mode: "merged", merge, remoteRevision, remoteSchema: remote };
+}
+
+export type ApplyPulledMergeInput = {
+  readonly merge: FormSchemaThreeWayMerge;
+  readonly resolution: MergeResolution;
+  readonly remoteRevision: string;
+  readonly remoteSchema: Schema;
+};
+
+/**
+ * Second stage of `schema pull`: applies a resolved 3-way merge.
+ *
+ * Writes the merged schema to the local YAML and updates the state to the
+ * remote snapshot/revision. Called only after the CLI has fully resolved all
+ * conflicts; if the user aborts resolution this is never invoked, so local and
+ * state remain unchanged (AC-15).
+ */
+export async function applyPulledMerge({
+  container,
+  input,
+}: FormSchemaServiceArgs<ApplyPulledMergeInput>): Promise<{
+  readonly schemaText: string;
+}> {
+  const merged = resolveMerge(input.merge, input.resolution);
+  const schemaText = serializeSchema(container, merged);
+  await container.schemaStorage.update(schemaText);
+  await saveState(
+    container.schemaStateStorage,
+    container.configCodec,
+    input.remoteRevision,
+    input.remoteSchema,
+  );
+  return { schemaText };
+}

--- a/src/core/application/formSchema/pullSchema.ts
+++ b/src/core/application/formSchema/pullSchema.ts
@@ -1,3 +1,4 @@
+import { wrapBusinessRuleError } from "@/core/application/error";
 import type { Schema } from "@/core/domain/formSchema/entity";
 import { enrichLayoutWithFields } from "@/core/domain/formSchema/services/layoutEnricher";
 import { SchemaSerializer } from "@/core/domain/formSchema/services/schemaSerializer";
@@ -11,6 +12,7 @@ import type {
 } from "@/core/domain/formSchema/valueObject";
 import type { FormSchemaServiceArgs } from "../container/formSchema";
 import { stringifyConfig } from "../stringifyConfig";
+import { assertSchemaValid } from "./assertSchemaValid";
 import type { PullSchemaOutput } from "./dto";
 import { loadThreeWayInputs } from "./loadThreeWayInputs";
 import { saveState } from "./schemaStateIo";
@@ -50,6 +52,11 @@ export async function pullSchema({
   const { state, local, remote, remoteRevision } =
     await loadThreeWayInputs(container);
 
+  // force / firstTime intentionally trust the remote without assertSchemaValid:
+  // these are capture-equivalent one-way overwrites (ADR-006/ADR-007, "base =
+  // capture result"), and the remote is the source of truth. The merged path
+  // (applyPulledMerge), by contrast, validates before writing because the
+  // merged schema is locally synthesized and benefits from early feedback.
   if (input.force) {
     const schemaText = serializeSchema(container, remote);
     await container.schemaStorage.update(schemaText);
@@ -101,7 +108,15 @@ export async function applyPulledMerge({
 }: FormSchemaServiceArgs<ApplyPulledMergeInput>): Promise<{
   readonly schemaText: string;
 }> {
-  const merged = resolveMerge(input.merge, input.resolution);
+  // resolveMerge throws a BusinessRuleError when the resolution does not cover
+  // every conflict (programmer invariant); translate it to a ValidationError per
+  // the CLAUDE.md error policy (domain → application).
+  const merged = wrapBusinessRuleError(() =>
+    resolveMerge(input.merge, input.resolution),
+  );
+  // Validate the locally synthesized merged schema before writing for early
+  // feedback (unlike force/firstTime which trust the remote as-is).
+  assertSchemaValid(merged);
   const schemaText = serializeSchema(container, merged);
   await container.schemaStorage.update(schemaText);
   await saveState(

--- a/src/core/application/formSchema/pushSchema.ts
+++ b/src/core/application/formSchema/pushSchema.ts
@@ -4,6 +4,7 @@ import {
   ValidationError,
   ValidationErrorCode,
 } from "@/core/application/error";
+import { SKIP_REVISION_CHECK } from "@/core/domain/formSchema/ports/formConfigurator";
 import { isLayoutEqual } from "@/core/domain/formSchema/services/diffDetector";
 import { enrichLayoutWithFields } from "@/core/domain/formSchema/services/layoutEnricher";
 import { computeThreeWayMerge } from "@/core/domain/formSchema/services/threeWayMerge";
@@ -21,7 +22,7 @@ export type PushSchemaInput = {
 
 /** Message thrown when the remote drifted from base and `--force` was not set. */
 export const PUSH_DRIFT_MESSAGE =
-  "実環境が base から変更されています。先に `schema pull` を実行してください。";
+  "The remote has changed since the base snapshot. Run `schema pull` first.";
 
 /**
  * Applies the local schema to the remote with drift detection and optimistic
@@ -30,8 +31,8 @@ export const PUSH_DRIFT_MESSAGE =
  * - Reads the current revision (expected-revision source + drift signal) and
  *   the remote snapshot (drift judged by snapshot comparison, never skipped by
  *   revision — ADR-004).
- * - drift && !force → {@link ConflictError} with a push-specific message (drift
- *   distinguished from API optimistic-lock conflicts by message — ADR-008).
+ * - drift && !force → {@link ConflictError} tagged with `SchemaDrift` (drift
+ *   distinguished from API optimistic-lock conflicts by error code — ADR-008).
  * - otherwise applies the local schema via the shared {@link applySchemaChanges}
  *   (type changes / subtable additions rejected with ValidationError — AC-13),
  *   sending the observed remote revision as the expected revision (ADR-005).
@@ -71,14 +72,30 @@ export async function pushSchema({
     const layoutDrift = !isLayoutEqual(enrichedBaseLayout, merge.remoteLayout);
 
     if (hasFieldDrift || layoutDrift) {
-      throw new ConflictError(ConflictErrorCode.Conflict, PUSH_DRIFT_MESSAGE);
+      // Tag with the SchemaDrift code so the CLI distinguishes this snapshot
+      // drift from API optimistic-lock (TOCTOU) conflicts by code, not by
+      // message string (ADR-008 / adapter W-001).
+      throw new ConflictError(
+        ConflictErrorCode.SchemaDrift,
+        PUSH_DRIFT_MESSAGE,
+      );
     }
   }
 
-  // Expected revision: observed current revision when guarding (normal push,
-  // no drift so it equals base.revision); none for --force or first run.
+  // Expected revision (three states, ADR-005 / ADR-010):
+  // - normal push (guarding): the observed current revision (no drift so it
+  //   equals base.revision), enforced on every mutation as a TOCTOU guard.
+  // - `--force`: SKIP_REVISION_CHECK — the apply must succeed even when the
+  //   remote drifted, so the revision check is skipped (AC-9). This must be a
+  //   distinct sentinel rather than `undefined`, otherwise the adapter would
+  //   fall back to the tracked revision and force could still 409 (B-001).
+  // - first run (no state): SKIP_REVISION_CHECK as well. There is no base
+  //   snapshot, so no expected revision can be established; the initial push is
+  //   intentionally unguarded against TOCTOU (AC-11). Sending no revision keeps
+  //   the first push from failing on an unrelated concurrent change. Do not add
+  //   a revision guard here when porting to other domains.
   const expectedRevision =
-    input.force || firstTime ? undefined : remoteRevision;
+    input.force || firstTime ? SKIP_REVISION_CHECK : remoteRevision;
 
   await applySchemaChanges(local, { container, expectedRevision });
 

--- a/src/core/application/formSchema/pushSchema.ts
+++ b/src/core/application/formSchema/pushSchema.ts
@@ -1,0 +1,95 @@
+import {
+  ConflictError,
+  ConflictErrorCode,
+  ValidationError,
+  ValidationErrorCode,
+} from "@/core/application/error";
+import { isLayoutEqual } from "@/core/domain/formSchema/services/diffDetector";
+import { enrichLayoutWithFields } from "@/core/domain/formSchema/services/layoutEnricher";
+import { computeThreeWayMerge } from "@/core/domain/formSchema/services/threeWayMerge";
+import type { FormSchemaServiceArgs } from "../container/formSchema";
+import { applySchemaChanges } from "./applySchemaChanges";
+import { assertSchemaValid } from "./assertSchemaValid";
+import type { PushSchemaOutput } from "./dto";
+import { loadThreeWayInputs } from "./loadThreeWayInputs";
+import { saveState } from "./schemaStateIo";
+
+export type PushSchemaInput = {
+  /** Skip drift checking and send no expected revision (revision-skip). */
+  readonly force?: boolean;
+};
+
+/** Message thrown when the remote drifted from base and `--force` was not set. */
+export const PUSH_DRIFT_MESSAGE =
+  "実環境が base から変更されています。先に `schema pull` を実行してください。";
+
+/**
+ * Applies the local schema to the remote with drift detection and optimistic
+ * concurrency control (AC-7, AC-8, AC-9, AC-11, AC-14).
+ *
+ * - Reads the current revision (expected-revision source + drift signal) and
+ *   the remote snapshot (drift judged by snapshot comparison, never skipped by
+ *   revision — ADR-004).
+ * - drift && !force → {@link ConflictError} with a push-specific message (drift
+ *   distinguished from API optimistic-lock conflicts by message — ADR-008).
+ * - otherwise applies the local schema via the shared {@link applySchemaChanges}
+ *   (type changes / subtable additions rejected with ValidationError — AC-13),
+ *   sending the observed remote revision as the expected revision (ADR-005).
+ * - `--force` skips the drift check and sends no expected revision.
+ * - first run (no state): applies with no revision guard and initializes state.
+ *
+ * Deploy is performed by the CLI (single-path `confirmAndDeploy`). State records
+ * the preview revision observed after applying.
+ */
+export async function pushSchema({
+  container,
+  input,
+}: FormSchemaServiceArgs<PushSchemaInput>): Promise<PushSchemaOutput> {
+  const { state, local, remote, remoteRevision } =
+    await loadThreeWayInputs(container);
+
+  if (local === undefined) {
+    throw new ValidationError(
+      ValidationErrorCode.InvalidInput,
+      "Schema file not found",
+    );
+  }
+
+  assertSchemaValid(local);
+
+  const firstTime = state === undefined;
+
+  if (!firstTime && !input.force) {
+    const merge = computeThreeWayMerge(state.schema, local, remote);
+    const hasFieldDrift = merge.fieldEntries.some(
+      (e) => e.change.kind === "remoteOnly" || e.change.kind === "conflict",
+    );
+    const enrichedBaseLayout = enrichLayoutWithFields(
+      state.schema.layout,
+      state.schema.fields,
+    );
+    const layoutDrift = !isLayoutEqual(enrichedBaseLayout, merge.remoteLayout);
+
+    if (hasFieldDrift || layoutDrift) {
+      throw new ConflictError(ConflictErrorCode.Conflict, PUSH_DRIFT_MESSAGE);
+    }
+  }
+
+  // Expected revision: observed current revision when guarding (normal push,
+  // no drift so it equals base.revision); none for --force or first run.
+  const expectedRevision =
+    input.force || firstTime ? undefined : remoteRevision;
+
+  await applySchemaChanges(local, { container, expectedRevision });
+
+  // Record the post-apply preview revision and local schema as the new base.
+  const newRevision = await container.formConfigurator.getRevision();
+  await saveState(
+    container.schemaStateStorage,
+    container.configCodec,
+    newRevision,
+    local,
+  );
+
+  return { mode: firstTime ? "firstTime" : "push", revision: newRevision };
+}

--- a/src/core/application/formSchema/schemaStateIo.ts
+++ b/src/core/application/formSchema/schemaStateIo.ts
@@ -1,0 +1,34 @@
+import type { Schema } from "@/core/domain/formSchema/entity";
+import type { SchemaStateStorage } from "@/core/domain/formSchema/ports/schemaStateStorage";
+import { SchemaStateParser } from "@/core/domain/formSchema/services/schemaStateParser";
+import { SchemaStateSerializer } from "@/core/domain/formSchema/services/schemaStateSerializer";
+import type { SchemaState } from "@/core/domain/formSchema/state";
+import type { ConfigCodec } from "@/core/domain/ports/configCodec";
+import { wrapBusinessRuleError } from "../error";
+import { parseConfigText } from "../parseConfigText";
+import { stringifyConfig } from "../stringifyConfig";
+
+/** Loads and parses the schema state, or returns undefined when none exists. */
+export async function loadState(
+  storage: SchemaStateStorage,
+  codec: ConfigCodec,
+): Promise<SchemaState | undefined> {
+  const result = await storage.get();
+  if (!result.exists) {
+    return undefined;
+  }
+  const parsed = parseConfigText(codec, result.content, "Schema state");
+  return wrapBusinessRuleError(() => SchemaStateParser.parse(parsed));
+}
+
+/** Serializes and persists the schema state via the codec port. */
+export async function saveState(
+  storage: SchemaStateStorage,
+  codec: ConfigCodec,
+  revision: string,
+  schema: Schema,
+): Promise<void> {
+  const data = SchemaStateSerializer.serialize({ revision, schema });
+  const text = stringifyConfig(codec, data);
+  await storage.update(text);
+}

--- a/src/core/domain/__tests__/diff.test.ts
+++ b/src/core/domain/__tests__/diff.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildDiffResult } from "../diff";
+import { buildDiffResult, classifyThreeWay } from "../diff";
 
 describe("buildDiffResult", () => {
   it("should count entries by type", () => {
@@ -55,5 +55,103 @@ describe("buildDiffResult", () => {
     const result = buildDiffResult([], ["w1", "w2"]);
     expect(result.isEmpty).toBe(true);
     expect(result.warnings).toEqual(["w1", "w2"]);
+  });
+});
+
+describe("classifyThreeWay", () => {
+  const eq = (a: string, b: string): boolean => a === b;
+  const m = (entries: [string, string][]): Map<string, string> =>
+    new Map(entries);
+
+  function kindOf(
+    result: ReturnType<typeof classifyThreeWay<string, string>>,
+    key: string,
+  ): string | undefined {
+    return result.entries.find((e) => e.key === key)?.change.kind;
+  }
+
+  it("unchanged: no side diverged from base", () => {
+    const r = classifyThreeWay(
+      m([["k", "v"]]),
+      m([["k", "v"]]),
+      m([["k", "v"]]),
+      eq,
+    );
+    expect(kindOf(r, "k")).toBe("unchanged");
+    expect(r.entries.find((e) => e.key === "k")?.merged).toBe("v");
+    expect(r.hasConflict).toBe(false);
+  });
+
+  it("localOnly: only local diverged", () => {
+    const r = classifyThreeWay(
+      m([["k", "v"]]),
+      m([["k", "L"]]),
+      m([["k", "v"]]),
+      eq,
+    );
+    expect(kindOf(r, "k")).toBe("localOnly");
+    expect(r.entries.find((e) => e.key === "k")?.merged).toBe("L");
+  });
+
+  it("remoteOnly: only remote diverged", () => {
+    const r = classifyThreeWay(
+      m([["k", "v"]]),
+      m([["k", "v"]]),
+      m([["k", "R"]]),
+      eq,
+    );
+    expect(kindOf(r, "k")).toBe("remoteOnly");
+    expect(r.entries.find((e) => e.key === "k")?.merged).toBe("R");
+  });
+
+  it("bothSame: both diverged to the same value", () => {
+    const r = classifyThreeWay(
+      m([["k", "v"]]),
+      m([["k", "X"]]),
+      m([["k", "X"]]),
+      eq,
+    );
+    expect(kindOf(r, "k")).toBe("bothSame");
+    expect(r.hasConflict).toBe(false);
+  });
+
+  it("conflict: both diverged to different values", () => {
+    const r = classifyThreeWay(
+      m([["k", "v"]]),
+      m([["k", "L"]]),
+      m([["k", "R"]]),
+      eq,
+    );
+    expect(kindOf(r, "k")).toBe("conflict");
+    expect(r.conflicts).toHaveLength(1);
+    expect(r.hasConflict).toBe(true);
+    expect(r.entries.find((e) => e.key === "k")?.merged).toBeUndefined();
+  });
+
+  it("addition on one side is localOnly/remoteOnly", () => {
+    const r = classifyThreeWay(new Map(), m([["k", "L"]]), new Map(), eq);
+    expect(kindOf(r, "k")).toBe("localOnly");
+  });
+
+  it("deletion on one side is localOnly/remoteOnly", () => {
+    const r = classifyThreeWay(m([["k", "v"]]), new Map(), m([["k", "v"]]), eq);
+    expect(kindOf(r, "k")).toBe("localOnly");
+    expect(r.entries.find((e) => e.key === "k")?.merged).toBeUndefined();
+  });
+
+  it("deletion on both sides is bothSame", () => {
+    const r = classifyThreeWay(m([["k", "v"]]), new Map(), new Map(), eq);
+    expect(kindOf(r, "k")).toBe("bothSame");
+    expect(r.hasConflict).toBe(false);
+  });
+
+  it("different additions on both sides is a conflict", () => {
+    const r = classifyThreeWay(new Map(), m([["k", "L"]]), m([["k", "R"]]), eq);
+    expect(kindOf(r, "k")).toBe("conflict");
+  });
+
+  it("same addition on both sides is bothSame", () => {
+    const r = classifyThreeWay(new Map(), m([["k", "X"]]), m([["k", "X"]]), eq);
+    expect(kindOf(r, "k")).toBe("bothSame");
   });
 });

--- a/src/core/domain/diff.ts
+++ b/src/core/domain/diff.ts
@@ -40,3 +40,113 @@ export function buildDiffResult<
     warnings,
   };
 }
+
+// --- Generic 3-way merge primitive (domain-agnostic) ---
+
+/**
+ * Classification of how a single entity changed across base/local/remote.
+ *
+ * - `unchanged`: neither local nor remote diverged from base.
+ * - `localOnly`: only local diverged from base (remote == base).
+ * - `remoteOnly`: only remote diverged from base (local == base).
+ * - `bothSame`: both diverged from base but to the same value (no conflict).
+ * - `conflict`: both diverged from base to different values.
+ *
+ * Existence/non-existence is treated as a value (sentinel), so additions and
+ * deletions are represented naturally (e.g. both-side deletion = `bothSame`).
+ */
+export type ThreeWayChange =
+  | { kind: "unchanged" }
+  | { kind: "localOnly" }
+  | { kind: "remoteOnly" }
+  | { kind: "bothSame" }
+  | { kind: "conflict" };
+
+/** Result of classifying a single key across base/local/remote. */
+export type ThreeWayEntry<K, V> = Readonly<{
+  key: K;
+  change: ThreeWayChange;
+  base?: V;
+  local?: V;
+  remote?: V;
+  /** Auto-merged value; `undefined` when the entry is a conflict. */
+  merged?: V;
+}>;
+
+export type ThreeWayMergeResult<K, V> = Readonly<{
+  entries: readonly ThreeWayEntry<K, V>[];
+  conflicts: readonly ThreeWayEntry<K, V>[];
+  hasConflict: boolean;
+}>;
+
+/**
+ * Classifies every key present in any of base/local/remote into a 3-way change.
+ *
+ * Pure and domain-agnostic: the caller supplies the equality function `eq`
+ * and the value type `V`. Presence/absence of a key is treated as a value, so
+ * `eq` is only ever called with two defined values; an `undefined` on one side
+ * (absence) compared to a defined value (presence) is always "changed".
+ */
+export function classifyThreeWay<K, V>(
+  base: ReadonlyMap<K, V>,
+  local: ReadonlyMap<K, V>,
+  remote: ReadonlyMap<K, V>,
+  eq: (a: V, b: V) => boolean,
+): ThreeWayMergeResult<K, V> {
+  const keys = new Set<K>([...base.keys(), ...local.keys(), ...remote.keys()]);
+  const entries: ThreeWayEntry<K, V>[] = [];
+  const conflicts: ThreeWayEntry<K, V>[] = [];
+
+  const sidesEqual = (a: V | undefined, b: V | undefined): boolean => {
+    if (a === undefined && b === undefined) return true;
+    if (a === undefined || b === undefined) return false;
+    return eq(a, b);
+  };
+
+  for (const key of keys) {
+    const baseValue = base.get(key);
+    const localValue = local.get(key);
+    const remoteValue = remote.get(key);
+
+    const dl = !sidesEqual(baseValue, localValue);
+    const dr = !sidesEqual(baseValue, remoteValue);
+
+    let change: ThreeWayChange;
+    let merged: V | undefined;
+    if (!dl && !dr) {
+      change = { kind: "unchanged" };
+      merged = baseValue;
+    } else if (dl && !dr) {
+      change = { kind: "localOnly" };
+      merged = localValue;
+    } else if (!dl && dr) {
+      change = { kind: "remoteOnly" };
+      merged = remoteValue;
+    } else if (sidesEqual(localValue, remoteValue)) {
+      change = { kind: "bothSame" };
+      merged = localValue;
+    } else {
+      change = { kind: "conflict" };
+      merged = undefined;
+    }
+
+    const entry: ThreeWayEntry<K, V> = {
+      key,
+      change,
+      ...(baseValue !== undefined ? { base: baseValue } : {}),
+      ...(localValue !== undefined ? { local: localValue } : {}),
+      ...(remoteValue !== undefined ? { remote: remoteValue } : {}),
+      ...(merged !== undefined ? { merged } : {}),
+    };
+    entries.push(entry);
+    if (change.kind === "conflict") {
+      conflicts.push(entry);
+    }
+  }
+
+  return {
+    entries,
+    conflicts,
+    hasConflict: conflicts.length > 0,
+  };
+}

--- a/src/core/domain/formSchema/errorCode.ts
+++ b/src/core/domain/formSchema/errorCode.ts
@@ -7,6 +7,7 @@ export const FormSchemaErrorCode = {
   FsInvalidLayoutStructure: "FS_INVALID_LAYOUT_STRUCTURE",
   FsInvalidDecorationElement: "FS_INVALID_DECORATION_ELEMENT",
   FsEmptyFields: "FS_EMPTY_FIELDS",
+  FsInvalidStateStructure: "FS_INVALID_STATE_STRUCTURE",
 } as const;
 
 export type FormSchemaErrorCode =

--- a/src/core/domain/formSchema/errorCode.ts
+++ b/src/core/domain/formSchema/errorCode.ts
@@ -8,6 +8,7 @@ export const FormSchemaErrorCode = {
   FsInvalidDecorationElement: "FS_INVALID_DECORATION_ELEMENT",
   FsEmptyFields: "FS_EMPTY_FIELDS",
   FsInvalidStateStructure: "FS_INVALID_STATE_STRUCTURE",
+  FsInvalidMergeResolution: "FS_INVALID_MERGE_RESOLUTION",
 } as const;
 
 export type FormSchemaErrorCode =

--- a/src/core/domain/formSchema/errorCode.ts
+++ b/src/core/domain/formSchema/errorCode.ts
@@ -9,6 +9,7 @@ export const FormSchemaErrorCode = {
   FsEmptyFields: "FS_EMPTY_FIELDS",
   FsInvalidStateStructure: "FS_INVALID_STATE_STRUCTURE",
   FsInvalidMergeResolution: "FS_INVALID_MERGE_RESOLUTION",
+  FsOrphanMergedField: "FS_ORPHAN_MERGED_FIELD",
 } as const;
 
 export type FormSchemaErrorCode =

--- a/src/core/domain/formSchema/ports/formConfigurator.ts
+++ b/src/core/domain/formSchema/ports/formConfigurator.ts
@@ -2,6 +2,25 @@ import type { FormLayout } from "../entity";
 import type { FieldCode, FieldDefinition } from "../valueObject";
 
 /**
+ * Sentinel passed as `expectedRevision` to explicitly skip the kintone revision
+ * check (sends `-1` / omits the expected revision). Used by `--force` push so
+ * that the apply succeeds even when the remote drifted (AC-9 / ADR-005 /
+ * ADR-010). This is distinct from `undefined`, which means "use the adapter's
+ * default tracked revision" (existing migrate behaviour).
+ */
+export const SKIP_REVISION_CHECK = Symbol("skip-revision-check");
+
+/**
+ * The expected revision to enforce on a mutation. Three states:
+ * - `undefined`: no explicit revision — fall back to the adapter's tracked
+ *   revision (migrate's existing behaviour).
+ * - a revision string: enforce exactly this revision (push, TOCTOU guard).
+ * - {@link SKIP_REVISION_CHECK}: skip the revision check entirely (`--force`
+ *   push / first run).
+ */
+export type ExpectedRevision = string | typeof SKIP_REVISION_CHECK | undefined;
+
+/**
  * Port for managing kintone form field configurations.
  *
  * Implementations must exclude system fields (e.g. RECORD_NUMBER, CREATOR,
@@ -23,24 +42,29 @@ export interface FormConfigurator {
    */
   getRevision(): Promise<string>;
   /**
-   * Mutation methods accept an optional `expectedRevision`. When provided, it is
-   * sent to the kintone API as the expected revision so that a concurrent change
-   * (TOCTOU) results in a 409 conflict (ADR-005). When omitted, the adapter does
-   * not enforce a revision check (kintone's `-1` / revision-skip behaviour),
-   * which is what `--force` push relies on.
+   * Mutation methods accept an {@link ExpectedRevision} with three distinct
+   * states (see {@link ExpectedRevision} / {@link SKIP_REVISION_CHECK}):
+   * - a revision string: enforce it so a concurrent change (TOCTOU) yields a
+   *   409 conflict (push non-force, ADR-005).
+   * - {@link SKIP_REVISION_CHECK}: skip the revision check (`--force` push /
+   *   first run, AC-9).
+   * - `undefined`: fall back to the adapter's tracked revision (migrate).
    */
   addFields(
     fields: readonly FieldDefinition[],
-    expectedRevision?: string,
+    expectedRevision?: ExpectedRevision,
   ): Promise<void>;
   updateFields(
     fields: readonly FieldDefinition[],
-    expectedRevision?: string,
+    expectedRevision?: ExpectedRevision,
   ): Promise<void>;
   deleteFields(
     fieldCodes: readonly FieldCode[],
-    expectedRevision?: string,
+    expectedRevision?: ExpectedRevision,
   ): Promise<void>;
   getLayout(): Promise<FormLayout>;
-  updateLayout(layout: FormLayout, expectedRevision?: string): Promise<void>;
+  updateLayout(
+    layout: FormLayout,
+    expectedRevision?: ExpectedRevision,
+  ): Promise<void>;
 }

--- a/src/core/domain/formSchema/ports/formConfigurator.ts
+++ b/src/core/domain/formSchema/ports/formConfigurator.ts
@@ -14,9 +14,33 @@ import type { FieldCode, FieldDefinition } from "../valueObject";
 export interface FormConfigurator {
   /** Returns all non-system fields currently configured in the form. */
   getFields(): Promise<ReadonlyMap<FieldCode, FieldDefinition>>;
-  addFields(fields: readonly FieldDefinition[]): Promise<void>;
-  updateFields(fields: readonly FieldDefinition[]): Promise<void>;
-  deleteFields(fieldCodes: readonly FieldCode[]): Promise<void>;
+  /**
+   * Returns the current app (preview) revision in a single API call.
+   *
+   * Used as the source of the expected revision for push (TOCTOU guard) and as
+   * a first-line drift signal. The final drift judgement is made by comparing
+   * snapshots, so this value never short-circuits snapshot fetching (ADR-004).
+   */
+  getRevision(): Promise<string>;
+  /**
+   * Mutation methods accept an optional `expectedRevision`. When provided, it is
+   * sent to the kintone API as the expected revision so that a concurrent change
+   * (TOCTOU) results in a 409 conflict (ADR-005). When omitted, the adapter does
+   * not enforce a revision check (kintone's `-1` / revision-skip behaviour),
+   * which is what `--force` push relies on.
+   */
+  addFields(
+    fields: readonly FieldDefinition[],
+    expectedRevision?: string,
+  ): Promise<void>;
+  updateFields(
+    fields: readonly FieldDefinition[],
+    expectedRevision?: string,
+  ): Promise<void>;
+  deleteFields(
+    fieldCodes: readonly FieldCode[],
+    expectedRevision?: string,
+  ): Promise<void>;
   getLayout(): Promise<FormLayout>;
-  updateLayout(layout: FormLayout): Promise<void>;
+  updateLayout(layout: FormLayout, expectedRevision?: string): Promise<void>;
 }

--- a/src/core/domain/formSchema/ports/schemaStateStorage.ts
+++ b/src/core/domain/formSchema/ports/schemaStateStorage.ts
@@ -1,0 +1,12 @@
+import type { StorageResult } from "@/core/domain/ports/storageResult";
+
+/**
+ * Port for persisting the schema base snapshot (state file).
+ *
+ * Mirrors {@link SchemaStorage}: `get()` returns `exists: false` on first run
+ * (no state yet), and `update()` overwrites the state file.
+ */
+export interface SchemaStateStorage {
+  get(): Promise<StorageResult>;
+  update(content: string): Promise<void>;
+}

--- a/src/core/domain/formSchema/services/__tests__/schemaState.test.ts
+++ b/src/core/domain/formSchema/services/__tests__/schemaState.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { BusinessRuleError } from "@/core/domain/error";
+import type { Schema } from "../../entity";
+import { SchemaParser } from "../schemaParser";
+import { SchemaStateParser } from "../schemaStateParser";
+import { SchemaStateSerializer } from "../schemaStateSerializer";
+
+// A realistic captured-form object (the shape SchemaParser consumes).
+const realisticForm = {
+  layout: [
+    {
+      type: "ROW",
+      fields: [
+        {
+          code: "name",
+          type: "SINGLE_LINE_TEXT",
+          label: "名前",
+          required: true,
+        },
+        { code: "qty", type: "NUMBER", label: "数量" },
+      ],
+    },
+    {
+      type: "GROUP",
+      code: "grp1",
+      label: "基本情報",
+      openGroup: true,
+      layout: [
+        {
+          type: "ROW",
+          fields: [{ code: "memo", type: "MULTI_LINE_TEXT", label: "メモ" }],
+        },
+      ],
+    },
+    {
+      type: "SUBTABLE",
+      code: "items",
+      label: "明細",
+      fields: [
+        { code: "item_name", type: "SINGLE_LINE_TEXT", label: "品名" },
+        { code: "item_qty", type: "NUMBER", label: "個数" },
+      ],
+    },
+    {
+      type: "REFERENCE_TABLE",
+      code: "ref",
+      label: "参照",
+      referenceTable: {
+        relatedApp: { app: "123" },
+        condition: { field: "name", relatedField: "rel" },
+        displayFields: ["item_name"],
+      },
+    },
+    {
+      type: "ROW",
+      fields: [
+        { type: "LABEL", label: "区切り", elementId: "e1", size: {} },
+        { type: "SPACER", elementId: "e2", size: {} },
+        { type: "HR", elementId: "e3", size: {} },
+      ],
+    },
+  ],
+};
+
+describe("SchemaState serialize/parse", () => {
+  it("revision を含めて round-trip できる", () => {
+    const schema: Schema = SchemaParser.parse(realisticForm);
+    const serialized = SchemaStateSerializer.serialize({
+      revision: "42",
+      schema,
+    });
+    expect(serialized.revision).toBe("42");
+
+    const parsed = SchemaStateParser.parse(serialized);
+    expect(parsed.revision).toBe("42");
+
+    // serialize -> parse -> serialize is a fixed point.
+    const reserialized = SchemaStateSerializer.serialize(parsed);
+    expect(reserialized).toEqual(serialized);
+  });
+
+  it("field/subtable/group/reference-table/decoration を含む snapshot を保持する", () => {
+    const schema = SchemaParser.parse(realisticForm);
+    const parsed = SchemaStateParser.parse(
+      SchemaStateSerializer.serialize({ revision: "1", schema }),
+    );
+    expect(parsed.schema.layout).toEqual(schema.layout);
+  });
+
+  it("revision がない場合は BusinessRuleError をスローする", () => {
+    const schema = SchemaParser.parse(realisticForm);
+    const data = SchemaStateSerializer.serialize({ revision: "1", schema });
+    const { revision: _omit, ...withoutRevision } = data;
+    expect(() => SchemaStateParser.parse(withoutRevision)).toThrow(
+      BusinessRuleError,
+    );
+  });
+
+  it("非オブジェクトは BusinessRuleError をスローする", () => {
+    expect(() => SchemaStateParser.parse("not an object")).toThrow(
+      BusinessRuleError,
+    );
+  });
+
+  it("空フォーム（最低1フィールド制約）は round-trip できない", () => {
+    // A layout with no fields cannot satisfy Schema.create's minimum-1-field
+    // constraint, so parsing it back throws.
+    const emptyData = { revision: "1", layout: [] };
+    expect(() => SchemaStateParser.parse(emptyData)).toThrow(BusinessRuleError);
+  });
+});

--- a/src/core/domain/formSchema/services/__tests__/threeWayMerge.test.ts
+++ b/src/core/domain/formSchema/services/__tests__/threeWayMerge.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
-import type { Schema } from "../../entity";
-import { FieldCode, type MergeResolution } from "../../valueObject";
+import { Schema } from "../../entity";
+import {
+  FieldCode,
+  type FieldDefinition,
+  type MergeResolution,
+} from "../../valueObject";
 import { SchemaParser } from "../schemaParser";
 import {
   computeThreeWayMerge,
@@ -24,6 +28,23 @@ function schemaOf(rows: Record<string, unknown>[][]): Schema {
 }
 
 const base = schemaOf([[fieldRow("name", "SINGLE_LINE_TEXT", "名前")]]);
+
+/**
+ * Rebuilds a schema so its field map mimics `getFields()` output: GROUP
+ * definitions are removed from the top-level field map (kintone's
+ * field-properties API does not return GROUP), while every other field —
+ * including the group's inner fields — stays at the top level. The layout is
+ * preserved unchanged. This reproduces the real base/local-vs-remote asymmetry
+ * that normalizeForThreeWay must absorb (ADR-007).
+ */
+function asRemoteGetFields(schema: Schema): Schema {
+  const fields = new Map<FieldCode, FieldDefinition>();
+  for (const [code, def] of schema.fields) {
+    if (def.type === "GROUP") continue;
+    fields.set(code, def);
+  }
+  return Schema.create(fields, schema.layout);
+}
 
 describe("normalizeForThreeWay", () => {
   it("GROUP と subtable inner を field チャネルから除外する", () => {
@@ -79,8 +100,12 @@ describe("computeThreeWayMerge", () => {
     expect(merge.fieldConflicts).toHaveLength(1);
   });
 
-  it("GROUP は field チャネルで remote 削除と誤検出されない", () => {
-    // base/local have a GROUP; remote (getFields-like) lacks GROUP definitions.
+  it("remote だけ GROUP 定義が欠落しても grp が remote 削除と誤検出されない（非対称再現）", () => {
+    // base/local carry the GROUP definition in their field map (SchemaParser
+    // puts `grp` at the top level). remote mimics getFields(): the GROUP
+    // definition is absent but its inner field stays top-level. Without
+    // normalization, grp would classify as remoteOnly (a remote deletion) and
+    // be reported as drift; normalizeForThreeWay must drop it from all three.
     const withGroup = SchemaParser.parse({
       layout: [
         { type: "ROW", fields: [fieldRow("name", "SINGLE_LINE_TEXT", "名前")] },
@@ -97,10 +122,52 @@ describe("computeThreeWayMerge", () => {
         },
       ],
     });
-    const merge = computeThreeWayMerge(withGroup, withGroup, withGroup);
-    // grp must not appear as a field-channel entry at all.
+    // Sanity: the asymmetry is real — base has the GROUP def, remote does not.
+    expect(withGroup.fields.has(FieldCode.create("grp"))).toBe(true);
+    const remote = asRemoteGetFields(withGroup);
+    expect(remote.fields.has(FieldCode.create("grp"))).toBe(false);
+
+    const merge = computeThreeWayMerge(withGroup, withGroup, remote);
+
+    // grp must not appear as a field-channel entry at all, and must not be
+    // reported as a remoteOnly deletion / conflict.
     expect(
       merge.fieldEntries.some((e) => e.key === FieldCode.create("grp")),
+    ).toBe(false);
+    expect(
+      merge.fieldEntries.some(
+        (e) => e.change.kind === "remoteOnly" || e.change.kind === "conflict",
+      ),
+    ).toBe(false);
+    expect(merge.hasConflict).toBe(false);
+  });
+
+  it("subtable inner の非対称（remote は inner を top-level flatten）でも subtable 単位で一致扱い", () => {
+    // base/local: SchemaParser puts the subtable definition plus its inner
+    // field `col` at the top level. remote mimics getFields(): same shape. The
+    // subtable is compared whole, so no inner field surfaces as a separate
+    // (mis-classified) entry, and there is no drift.
+    const withSub = SchemaParser.parse({
+      layout: [
+        {
+          type: "SUBTABLE",
+          code: "items",
+          label: "明細",
+          fields: [fieldRow("col", "SINGLE_LINE_TEXT", "列")],
+        },
+      ],
+    });
+    const remote = asRemoteGetFields(withSub);
+
+    const merge = computeThreeWayMerge(withSub, withSub, remote);
+
+    expect(
+      merge.fieldEntries.some((e) => e.key === FieldCode.create("col")),
+    ).toBe(false);
+    expect(
+      merge.fieldEntries.some(
+        (e) => e.change.kind === "remoteOnly" || e.change.kind === "conflict",
+      ),
     ).toBe(false);
     expect(merge.hasConflict).toBe(false);
   });
@@ -212,5 +279,142 @@ describe("resolveMerge", () => {
       layout: "noConflict",
     });
     expect(merged.fields.get(FieldCode.create("name"))?.label).toBe("名前_新");
+  });
+
+  // W-004 (ADR-012): the most complex resolveMerge path — a subtable conflict
+  // whose inner construction differs between sides — must reconstruct the
+  // chosen side's inner fields as top-level entries (and drop the rejected
+  // side's). Fixtures include a GROUP and a subtable so the reconstruction from
+  // the chosen layout is genuinely exercised, not just a single SINGLE_LINE.
+  describe("GROUP/subtable-inner 再構成", () => {
+    const subtableBase = SchemaParser.parse({
+      layout: [
+        { type: "ROW", fields: [fieldRow("name", "SINGLE_LINE_TEXT", "名前")] },
+        {
+          type: "GROUP",
+          code: "grp",
+          label: "G",
+          layout: [
+            {
+              type: "ROW",
+              fields: [fieldRow("g_inner", "SINGLE_LINE_TEXT", "G内部")],
+            },
+          ],
+        },
+        {
+          type: "SUBTABLE",
+          code: "items",
+          label: "明細",
+          fields: [fieldRow("col_a", "SINGLE_LINE_TEXT", "列A")],
+        },
+      ],
+    });
+
+    // local: subtable inner has col_b (renamed/replaced inner construction).
+    const subtableLocal = SchemaParser.parse({
+      layout: [
+        { type: "ROW", fields: [fieldRow("name", "SINGLE_LINE_TEXT", "名前")] },
+        {
+          type: "GROUP",
+          code: "grp",
+          label: "G",
+          layout: [
+            {
+              type: "ROW",
+              fields: [fieldRow("g_inner", "SINGLE_LINE_TEXT", "G内部")],
+            },
+          ],
+        },
+        {
+          type: "SUBTABLE",
+          code: "items",
+          label: "明細",
+          fields: [fieldRow("col_b", "SINGLE_LINE_TEXT", "列B")],
+        },
+      ],
+    });
+
+    // remote: subtable inner has col_c (a third, different construction).
+    const subtableRemote = SchemaParser.parse({
+      layout: [
+        { type: "ROW", fields: [fieldRow("name", "SINGLE_LINE_TEXT", "名前")] },
+        {
+          type: "GROUP",
+          code: "grp",
+          label: "G",
+          layout: [
+            {
+              type: "ROW",
+              fields: [fieldRow("g_inner", "SINGLE_LINE_TEXT", "G内部")],
+            },
+          ],
+        },
+        {
+          type: "SUBTABLE",
+          code: "items",
+          label: "明細",
+          fields: [fieldRow("col_c", "SINGLE_LINE_TEXT", "列C")],
+        },
+      ],
+    });
+
+    it("subtable conflict を local 採用すると採用側 inner が top-level に展開され他方は落ちる", () => {
+      const merge = computeThreeWayMerge(
+        subtableBase,
+        subtableLocal,
+        subtableRemote,
+      );
+      // The subtable diverged on both sides => conflict over `items`.
+      expect(
+        merge.fieldConflicts.some((c) => c.key === FieldCode.create("items")),
+      ).toBe(true);
+
+      const merged = resolveMerge(merge, {
+        fields: new Map([[FieldCode.create("items"), "local"]]),
+        layout: "local",
+      });
+
+      const subtable = merged.fields.get(FieldCode.create("items"));
+      expect(subtable?.type).toBe("SUBTABLE");
+      if (subtable?.type === "SUBTABLE") {
+        expect(subtable.properties.fields.has(FieldCode.create("col_b"))).toBe(
+          true,
+        );
+        expect(subtable.properties.fields.has(FieldCode.create("col_c"))).toBe(
+          false,
+        );
+      }
+      // The chosen inner field is reconstructed at top level...
+      expect(merged.fields.has(FieldCode.create("col_b"))).toBe(true);
+      // ...and the rejected side's inner field is not present.
+      expect(merged.fields.has(FieldCode.create("col_c"))).toBe(false);
+      expect(merged.fields.has(FieldCode.create("col_a"))).toBe(false);
+      // GROUP inner field stays top-level (reconstructed from the chosen side).
+      expect(merged.fields.has(FieldCode.create("g_inner"))).toBe(true);
+    });
+
+    it("subtable conflict を remote 採用すると採用側 inner が top-level に展開される", () => {
+      const merge = computeThreeWayMerge(
+        subtableBase,
+        subtableLocal,
+        subtableRemote,
+      );
+
+      const merged = resolveMerge(merge, {
+        fields: new Map([[FieldCode.create("items"), "remote"]]),
+        layout: "remote",
+      });
+
+      const subtable = merged.fields.get(FieldCode.create("items"));
+      expect(subtable?.type).toBe("SUBTABLE");
+      if (subtable?.type === "SUBTABLE") {
+        expect(subtable.properties.fields.has(FieldCode.create("col_c"))).toBe(
+          true,
+        );
+      }
+      expect(merged.fields.has(FieldCode.create("col_c"))).toBe(true);
+      expect(merged.fields.has(FieldCode.create("col_b"))).toBe(false);
+      expect(merged.fields.has(FieldCode.create("g_inner"))).toBe(true);
+    });
   });
 });

--- a/src/core/domain/formSchema/services/__tests__/threeWayMerge.test.ts
+++ b/src/core/domain/formSchema/services/__tests__/threeWayMerge.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "vitest";
+import type { Schema } from "../../entity";
+import { FieldCode, type MergeResolution } from "../../valueObject";
+import { SchemaParser } from "../schemaParser";
+import {
+  computeThreeWayMerge,
+  normalizeForThreeWay,
+  resolveMerge,
+} from "../threeWayMerge";
+
+function fieldRow(
+  code: string,
+  type = "SINGLE_LINE_TEXT",
+  label = code,
+  extra: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return { type, code, label, ...extra };
+}
+
+function schemaOf(rows: Record<string, unknown>[][]): Schema {
+  return SchemaParser.parse({
+    layout: rows.map((fields) => ({ type: "ROW", fields })),
+  });
+}
+
+const base = schemaOf([[fieldRow("name", "SINGLE_LINE_TEXT", "名前")]]);
+
+describe("normalizeForThreeWay", () => {
+  it("GROUP と subtable inner を field チャネルから除外する", () => {
+    const schema = SchemaParser.parse({
+      layout: [
+        {
+          type: "GROUP",
+          code: "grp",
+          label: "G",
+          layout: [
+            {
+              type: "ROW",
+              fields: [fieldRow("inner", "SINGLE_LINE_TEXT", "内部")],
+            },
+          ],
+        },
+        {
+          type: "SUBTABLE",
+          code: "items",
+          label: "明細",
+          fields: [fieldRow("col", "SINGLE_LINE_TEXT", "列")],
+        },
+      ],
+    });
+    const normalized = normalizeForThreeWay(schema.fields);
+    // grp (GROUP definition) and col (subtable inner) are excluded.
+    expect(normalized.has(FieldCode.create("grp"))).toBe(false);
+    expect(normalized.has(FieldCode.create("col"))).toBe(false);
+    // Group inner fields are ordinary top-level fields (present in remote too).
+    expect(normalized.has(FieldCode.create("inner"))).toBe(true);
+    // The subtable itself remains as a single entity.
+    expect(normalized.has(FieldCode.create("items"))).toBe(true);
+  });
+});
+
+describe("computeThreeWayMerge", () => {
+  it("片側のみのフィールド変更は自動マージされ conflict にならない", () => {
+    const local = schemaOf([[fieldRow("name", "SINGLE_LINE_TEXT", "名前_新")]]);
+    const remote = base;
+    const merge = computeThreeWayMerge(base, local, remote);
+    expect(merge.hasConflict).toBe(false);
+    const entry = merge.fieldEntries.find(
+      (e) => e.key === FieldCode.create("name"),
+    );
+    expect(entry?.change.kind).toBe("localOnly");
+  });
+
+  it("両側が同一フィールドを別の値に変更すると conflict になる", () => {
+    const local = schemaOf([[fieldRow("name", "SINGLE_LINE_TEXT", "L")]]);
+    const remote = schemaOf([[fieldRow("name", "SINGLE_LINE_TEXT", "R")]]);
+    const merge = computeThreeWayMerge(base, local, remote);
+    expect(merge.hasConflict).toBe(true);
+    expect(merge.fieldConflicts).toHaveLength(1);
+  });
+
+  it("GROUP は field チャネルで remote 削除と誤検出されない", () => {
+    // base/local have a GROUP; remote (getFields-like) lacks GROUP definitions.
+    const withGroup = SchemaParser.parse({
+      layout: [
+        { type: "ROW", fields: [fieldRow("name", "SINGLE_LINE_TEXT", "名前")] },
+        {
+          type: "GROUP",
+          code: "grp",
+          label: "G",
+          layout: [
+            {
+              type: "ROW",
+              fields: [fieldRow("inner", "SINGLE_LINE_TEXT", "内部")],
+            },
+          ],
+        },
+      ],
+    });
+    const merge = computeThreeWayMerge(withGroup, withGroup, withGroup);
+    // grp must not appear as a field-channel entry at all.
+    expect(
+      merge.fieldEntries.some((e) => e.key === FieldCode.create("grp")),
+    ).toBe(false);
+    expect(merge.hasConflict).toBe(false);
+  });
+
+  it("subtable はサブテーブル丸ごと1エンティティとして扱う", () => {
+    const withSub = SchemaParser.parse({
+      layout: [
+        {
+          type: "SUBTABLE",
+          code: "items",
+          label: "明細",
+          fields: [fieldRow("col1", "SINGLE_LINE_TEXT", "列1")],
+        },
+      ],
+    });
+    const merge = computeThreeWayMerge(withSub, withSub, withSub);
+    const subtableEntries = merge.fieldEntries.filter(
+      (e) => e.key === FieldCode.create("items"),
+    );
+    expect(subtableEntries).toHaveLength(1);
+    // inner col1 is not a separate field-channel entry.
+    expect(
+      merge.fieldEntries.some((e) => e.key === FieldCode.create("col1")),
+    ).toBe(false);
+  });
+
+  it("両側 layout 変更で同一なら layout conflict にならない", () => {
+    const local = schemaOf([
+      [fieldRow("name", "SINGLE_LINE_TEXT", "名前")],
+      [fieldRow("extra", "SINGLE_LINE_TEXT", "追加")],
+    ]);
+    const merge = computeThreeWayMerge(base, local, local);
+    expect(merge.layoutConflict).toBe(false);
+  });
+
+  it("両側 layout を別々に変更すると layout conflict になる", () => {
+    const local = schemaOf([
+      [fieldRow("name", "SINGLE_LINE_TEXT", "名前")],
+      [fieldRow("la", "SINGLE_LINE_TEXT", "ローカル追加")],
+    ]);
+    const remote = schemaOf([
+      [fieldRow("name", "SINGLE_LINE_TEXT", "名前")],
+      [fieldRow("ra", "SINGLE_LINE_TEXT", "リモート追加")],
+    ]);
+    const merge = computeThreeWayMerge(base, local, remote);
+    expect(merge.layoutConflict).toBe(true);
+    expect(merge.hasConflict).toBe(true);
+  });
+});
+
+describe("resolveMerge", () => {
+  it("field conflict を local 採用で解決する", () => {
+    const local = schemaOf([[fieldRow("name", "SINGLE_LINE_TEXT", "L")]]);
+    const remote = schemaOf([[fieldRow("name", "SINGLE_LINE_TEXT", "R")]]);
+    const merge = computeThreeWayMerge(base, local, remote);
+    const resolution: MergeResolution = {
+      fields: new Map([[FieldCode.create("name"), "local"]]),
+      layout: "local",
+    };
+    const merged = resolveMerge(merge, resolution);
+    expect(merged.fields.get(FieldCode.create("name"))?.label).toBe("L");
+  });
+
+  it("field conflict を remote 採用で解決する", () => {
+    const local = schemaOf([[fieldRow("name", "SINGLE_LINE_TEXT", "L")]]);
+    const remote = schemaOf([[fieldRow("name", "SINGLE_LINE_TEXT", "R")]]);
+    const merge = computeThreeWayMerge(base, local, remote);
+    const resolution: MergeResolution = {
+      fields: new Map([[FieldCode.create("name"), "remote"]]),
+      layout: "remote",
+    };
+    const merged = resolveMerge(merge, resolution);
+    expect(merged.fields.get(FieldCode.create("name"))?.label).toBe("R");
+  });
+
+  it("conflict 未網羅の resolution はエラーになる", () => {
+    const local = schemaOf([[fieldRow("name", "SINGLE_LINE_TEXT", "L")]]);
+    const remote = schemaOf([[fieldRow("name", "SINGLE_LINE_TEXT", "R")]]);
+    const merge = computeThreeWayMerge(base, local, remote);
+    const resolution: MergeResolution = {
+      fields: new Map(),
+      layout: "local",
+    };
+    expect(() => resolveMerge(merge, resolution)).toThrow();
+  });
+
+  it("layout conflict で side 未指定はエラーになる", () => {
+    const local = schemaOf([
+      [fieldRow("name", "SINGLE_LINE_TEXT", "名前")],
+      [fieldRow("la", "SINGLE_LINE_TEXT", "ローカル")],
+    ]);
+    const remote = schemaOf([
+      [fieldRow("name", "SINGLE_LINE_TEXT", "名前")],
+      [fieldRow("ra", "SINGLE_LINE_TEXT", "リモート")],
+    ]);
+    const merge = computeThreeWayMerge(base, local, remote);
+    const resolution: MergeResolution = {
+      fields: new Map(),
+      layout: "noConflict",
+    };
+    expect(() => resolveMerge(merge, resolution)).toThrow();
+  });
+
+  it("conflict がない自動マージを再構成できる", () => {
+    const local = schemaOf([[fieldRow("name", "SINGLE_LINE_TEXT", "名前_新")]]);
+    const merge = computeThreeWayMerge(base, local, base);
+    const merged = resolveMerge(merge, {
+      fields: new Map(),
+      layout: "noConflict",
+    });
+    expect(merged.fields.get(FieldCode.create("name"))?.label).toBe("名前_新");
+  });
+});

--- a/src/core/domain/formSchema/services/__tests__/threeWayMerge.test.ts
+++ b/src/core/domain/formSchema/services/__tests__/threeWayMerge.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { BusinessRuleError } from "../../../error";
 import { Schema } from "../../entity";
+import { FormSchemaErrorCode } from "../../errorCode";
 import {
   FieldCode,
   type FieldDefinition,
@@ -415,6 +417,79 @@ describe("resolveMerge", () => {
       expect(merged.fields.has(FieldCode.create("col_c"))).toBe(true);
       expect(merged.fields.has(FieldCode.create("col_b"))).toBe(false);
       expect(merged.fields.has(FieldCode.create("g_inner"))).toBe(true);
+    });
+  });
+
+  // W-001 (round-2, ADR-016): the field channel and the layout channel are
+  // resolved independently. A field added on one side auto-merges into the
+  // merged field map, but if the conflicting layout from the *other* side is
+  // chosen, that field is not placed anywhere. Layout-driven serialization
+  // would silently drop it. resolveMerge must reject this inconsistent
+  // resolution instead of producing a schema that loses the adopted field.
+  describe("orphan field 検出 (W-001)", () => {
+    // base has two ordered fields so local can change the layout (reorder)
+    // WITHOUT adding a field. remote adds `rfoo` (auto-merged as remoteOnly
+    // into the field channel) and places it in the remote layout. The layouts
+    // conflict, so resolveMerge must pick a layout side.
+    const orphanBase = schemaOf([
+      [fieldRow("name", "SINGLE_LINE_TEXT", "名前")],
+      [fieldRow("age", "SINGLE_LINE_TEXT", "年齢")],
+    ]);
+    // local reorders the two existing fields (layout-only change, no new field).
+    const orphanLocal = schemaOf([
+      [fieldRow("age", "SINGLE_LINE_TEXT", "年齢")],
+      [fieldRow("name", "SINGLE_LINE_TEXT", "名前")],
+    ]);
+    // remote keeps the original order and appends a new field rfoo.
+    const orphanRemote = schemaOf([
+      [fieldRow("name", "SINGLE_LINE_TEXT", "名前")],
+      [fieldRow("age", "SINGLE_LINE_TEXT", "年齢")],
+      [fieldRow("rfoo", "SINGLE_LINE_TEXT", "リモート追加")],
+    ]);
+
+    it("追加 field を含む側を採用しつつ layout は含まない側を採用すると拒否される", () => {
+      const merge = computeThreeWayMerge(orphanBase, orphanLocal, orphanRemote);
+      expect(merge.layoutConflict).toBe(true);
+      // rfoo is auto-merged into the field channel (remoteOnly addition).
+      expect(
+        merge.fieldEntries.some(
+          (e) =>
+            e.key === FieldCode.create("rfoo") &&
+            e.change.kind === "remoteOnly",
+        ),
+      ).toBe(true);
+
+      // Choosing the local layout (which lacks rfoo) leaves rfoo unplaced.
+      expect(() =>
+        resolveMerge(merge, {
+          fields: new Map(),
+          layout: "local",
+        }),
+      ).toThrow(BusinessRuleError);
+
+      try {
+        resolveMerge(merge, { fields: new Map(), layout: "local" });
+        expect.unreachable("should have thrown");
+      } catch (error) {
+        expect(error).toBeInstanceOf(BusinessRuleError);
+        expect((error as BusinessRuleError).code).toBe(
+          FormSchemaErrorCode.FsOrphanMergedField,
+        );
+        expect((error as BusinessRuleError).message).toContain("rfoo");
+      }
+    });
+
+    it("追加 field を含む側の layout を採用すれば成立し field が保持される", () => {
+      const merge = computeThreeWayMerge(orphanBase, orphanLocal, orphanRemote);
+      // Choosing the remote layout (which contains rfoo) is consistent: every
+      // merged field is placed, so the adopted field is preserved.
+      const merged = resolveMerge(merge, {
+        fields: new Map(),
+        layout: "remote",
+      });
+      expect(merged.fields.has(FieldCode.create("rfoo"))).toBe(true);
+      expect(merged.fields.has(FieldCode.create("name"))).toBe(true);
+      expect(merged.fields.has(FieldCode.create("age"))).toBe(true);
     });
   });
 });

--- a/src/core/domain/formSchema/services/__tests__/threeWayMerge.test.ts
+++ b/src/core/domain/formSchema/services/__tests__/threeWayMerge.test.ts
@@ -563,4 +563,176 @@ describe("resolveMerge", () => {
       expect(merged.fields.has(FieldCode.create("extra"))).toBe(true);
     });
   });
+
+  // B-001 (round-4, ADR-018): the resurrected check must not treat GROUP codes
+  // as resurrected fields. The remote field map comes from getFields(), which
+  // never returns GROUP definitions (ADR-007), so a GROUP placed in the remote
+  // layout has no entry in `mergedFields`. The check must exclude GROUP codes,
+  // or adopting a remote layout that contains a GROUP would always be rejected
+  // even without any deletion or conflict. The fixtures here build the remote
+  // via `asRemoteGetFields` so the getFields asymmetry is reproduced on the
+  // resolveMerge path (not just normalization).
+  describe("GROUP の getFields 非対称で resurrected 誤検出しない (B-001)", () => {
+    // All three sides carry a GROUP. local and remote each make a layout-only
+    // change (reorder the top-level rows) so the layouts conflict WITHOUT any
+    // field channel change. The remote field map omits the GROUP definition,
+    // mimicking getFields().
+    const groupBase = SchemaParser.parse({
+      layout: [
+        { type: "ROW", fields: [fieldRow("name", "SINGLE_LINE_TEXT", "名前")] },
+        { type: "ROW", fields: [fieldRow("age", "SINGLE_LINE_TEXT", "年齢")] },
+        {
+          type: "GROUP",
+          code: "grp",
+          label: "G",
+          layout: [
+            {
+              type: "ROW",
+              fields: [fieldRow("g_inner", "SINGLE_LINE_TEXT", "G内部")],
+            },
+          ],
+        },
+      ],
+    });
+    // local reorders name/age (layout-only change).
+    const groupLocal = SchemaParser.parse({
+      layout: [
+        { type: "ROW", fields: [fieldRow("age", "SINGLE_LINE_TEXT", "年齢")] },
+        { type: "ROW", fields: [fieldRow("name", "SINGLE_LINE_TEXT", "名前")] },
+        {
+          type: "GROUP",
+          code: "grp",
+          label: "G",
+          layout: [
+            {
+              type: "ROW",
+              fields: [fieldRow("g_inner", "SINGLE_LINE_TEXT", "G内部")],
+            },
+          ],
+        },
+      ],
+    });
+    // remote moves the GROUP to the top (a different layout change) and is
+    // rebuilt to drop the GROUP definition from its field map (getFields shape).
+    const groupRemoteParsed = SchemaParser.parse({
+      layout: [
+        {
+          type: "GROUP",
+          code: "grp",
+          label: "G",
+          layout: [
+            {
+              type: "ROW",
+              fields: [fieldRow("g_inner", "SINGLE_LINE_TEXT", "G内部")],
+            },
+          ],
+        },
+        { type: "ROW", fields: [fieldRow("name", "SINGLE_LINE_TEXT", "名前")] },
+        { type: "ROW", fields: [fieldRow("age", "SINGLE_LINE_TEXT", "年齢")] },
+      ],
+    });
+    const groupRemote = asRemoteGetFields(groupRemoteParsed);
+
+    it("削除なしの正当な merge は remote layout 採用でも過剰拒否されず GROUP が保持される", () => {
+      // Sanity: the asymmetry is real — remote's field map omits the GROUP.
+      expect(groupRemote.fields.has(FieldCode.create("grp"))).toBe(false);
+
+      const merge = computeThreeWayMerge(groupBase, groupLocal, groupRemote);
+      expect(merge.layoutConflict).toBe(true);
+      // No field-channel deletion/conflict: grp is excluded, others unchanged.
+      expect(
+        merge.fieldEntries.some(
+          (e) => e.change.kind === "remoteOnly" || e.change.kind === "conflict",
+        ),
+      ).toBe(false);
+
+      // Adopting the remote layout (which places the GROUP) must succeed even
+      // though the remote field map lacks the GROUP definition.
+      const merged = resolveMerge(merge, {
+        fields: new Map(),
+        layout: "remote",
+      });
+      // The GROUP is preserved in the result (reconstructed from the layout).
+      expect(
+        merged.layout.some(
+          (item) => item.type === "GROUP" && item.code === "grp",
+        ),
+      ).toBe(true);
+      // Ordinary fields survive too.
+      expect(merged.fields.has(FieldCode.create("name"))).toBe(true);
+      expect(merged.fields.has(FieldCode.create("age"))).toBe(true);
+      expect(merged.fields.has(FieldCode.create("g_inner"))).toBe(true);
+    });
+
+    it("真の resurrected（削除した通常 field を remote layout が残す）は引き続き拒否される", () => {
+      // local deletes `age` (and drops it from the local layout). remote keeps
+      // `age` placed and is built getFields-style (GROUP omitted). Adopting the
+      // remote layout would resurrect the deleted ordinary field `age`; this
+      // must still be rejected even with the GROUP exclusion in place.
+      const deleteLocal = SchemaParser.parse({
+        layout: [
+          {
+            type: "ROW",
+            fields: [fieldRow("name", "SINGLE_LINE_TEXT", "名前")],
+          },
+          {
+            type: "GROUP",
+            code: "grp",
+            label: "G",
+            layout: [
+              {
+                type: "ROW",
+                fields: [fieldRow("g_inner", "SINGLE_LINE_TEXT", "G内部")],
+              },
+            ],
+          },
+        ],
+      });
+      const deleteRemoteParsed = SchemaParser.parse({
+        layout: [
+          {
+            type: "GROUP",
+            code: "grp",
+            label: "G",
+            layout: [
+              {
+                type: "ROW",
+                fields: [fieldRow("g_inner", "SINGLE_LINE_TEXT", "G内部")],
+              },
+            ],
+          },
+          {
+            type: "ROW",
+            fields: [fieldRow("name", "SINGLE_LINE_TEXT", "名前")],
+          },
+          {
+            type: "ROW",
+            fields: [fieldRow("age", "SINGLE_LINE_TEXT", "年齢")],
+          },
+        ],
+      });
+      const deleteRemote = asRemoteGetFields(deleteRemoteParsed);
+
+      const merge = computeThreeWayMerge(groupBase, deleteLocal, deleteRemote);
+      expect(merge.layoutConflict).toBe(true);
+      const ageEntry = merge.fieldEntries.find(
+        (e) => e.key === FieldCode.create("age"),
+      );
+      expect(ageEntry?.change.kind).toBe("localOnly");
+      expect(ageEntry?.merged).toBeUndefined();
+
+      try {
+        resolveMerge(merge, { fields: new Map(), layout: "remote" });
+        expect.unreachable("should have thrown");
+      } catch (error) {
+        expect(error).toBeInstanceOf(BusinessRuleError);
+        expect((error as BusinessRuleError).code).toBe(
+          FormSchemaErrorCode.FsOrphanMergedField,
+        );
+        expect((error as BusinessRuleError).message).toContain("age");
+        // The GROUP must NOT be reported as resurrected.
+        expect((error as BusinessRuleError).message).not.toContain("grp");
+      }
+    });
+  });
 });

--- a/src/core/domain/formSchema/services/__tests__/threeWayMerge.test.ts
+++ b/src/core/domain/formSchema/services/__tests__/threeWayMerge.test.ts
@@ -492,4 +492,75 @@ describe("resolveMerge", () => {
       expect(merged.fields.has(FieldCode.create("age"))).toBe(true);
     });
   });
+
+  // W-001 (round-3, ADR-017): the mirror of the orphan case. A field DELETED on
+  // one side resolves to `undefined` in the field channel and is removed from
+  // the merged field map. If the OTHER side's conflicting layout (which still
+  // contains the field) is chosen, layout-driven serialization would re-emit
+  // the deleted field's full definition from the layout element — silently
+  // undoing the deletion. resolveMerge must reject this resurrection.
+  describe("resurrected field 検出 (W-001 鏡像)", () => {
+    // base has three fields. local deletes `age` (field channel localOnly
+    // delete, and the local layout drops the `age` row). remote keeps `age` and
+    // makes a separate, field-preserving layout change (reorders name/extra),
+    // so the layouts conflict without introducing a new auto-merged field.
+    const base = schemaOf([
+      [fieldRow("name", "SINGLE_LINE_TEXT", "名前")],
+      [fieldRow("age", "SINGLE_LINE_TEXT", "年齢")],
+      [fieldRow("extra", "SINGLE_LINE_TEXT", "備考")],
+    ]);
+    const local = schemaOf([
+      [fieldRow("name", "SINGLE_LINE_TEXT", "名前")],
+      [fieldRow("extra", "SINGLE_LINE_TEXT", "備考")],
+    ]);
+    const remote = schemaOf([
+      [fieldRow("extra", "SINGLE_LINE_TEXT", "備考")],
+      [fieldRow("name", "SINGLE_LINE_TEXT", "名前")],
+      [fieldRow("age", "SINGLE_LINE_TEXT", "年齢")],
+    ]);
+
+    it("片側で削除した field を含む側の layout を採用すると拒否される", () => {
+      const merge = computeThreeWayMerge(base, local, remote);
+      expect(merge.layoutConflict).toBe(true);
+      // age is auto-merged as a localOnly deletion (merged === undefined).
+      const ageEntry = merge.fieldEntries.find(
+        (e) => e.key === FieldCode.create("age"),
+      );
+      expect(ageEntry?.change.kind).toBe("localOnly");
+      expect(ageEntry?.merged).toBeUndefined();
+
+      // Choosing the remote layout (which still places age) would resurrect the
+      // deleted field via layout-driven serialization.
+      expect(() =>
+        resolveMerge(merge, {
+          fields: new Map(),
+          layout: "remote",
+        }),
+      ).toThrow(BusinessRuleError);
+
+      try {
+        resolveMerge(merge, { fields: new Map(), layout: "remote" });
+        expect.unreachable("should have thrown");
+      } catch (error) {
+        expect(error).toBeInstanceOf(BusinessRuleError);
+        expect((error as BusinessRuleError).code).toBe(
+          FormSchemaErrorCode.FsOrphanMergedField,
+        );
+        expect((error as BusinessRuleError).message).toContain("age");
+      }
+    });
+
+    it("削除を反映する側の layout を採用すれば成立し field が消える", () => {
+      const merge = computeThreeWayMerge(base, local, remote);
+      // Choosing the local layout (which omits age) is consistent with the
+      // deletion: the field is gone and nothing is resurrected.
+      const merged = resolveMerge(merge, {
+        fields: new Map(),
+        layout: "local",
+      });
+      expect(merged.fields.has(FieldCode.create("age"))).toBe(false);
+      expect(merged.fields.has(FieldCode.create("name"))).toBe(true);
+      expect(merged.fields.has(FieldCode.create("extra"))).toBe(true);
+    });
+  });
 });

--- a/src/core/domain/formSchema/services/diffDetector.ts
+++ b/src/core/domain/formSchema/services/diffDetector.ts
@@ -34,7 +34,7 @@ function isPropertiesEqual(a: FieldDefinition, b: FieldDefinition): boolean {
   return deepEqual(a.properties, b.properties);
 }
 
-function isFieldEqual(a: FieldDefinition, b: FieldDefinition): boolean {
+export function isFieldEqual(a: FieldDefinition, b: FieldDefinition): boolean {
   if (a.type !== b.type) return false;
   if (a.label !== b.label) return false;
   if (a.code !== b.code) return false;
@@ -126,7 +126,7 @@ function describeChanges(
   return changes.length > 0 ? changes.join("\n") : "no visible changes";
 }
 
-function isLayoutEqual(a: FormLayout, b: FormLayout): boolean {
+export function isLayoutEqual(a: FormLayout, b: FormLayout): boolean {
   return deepEqual(a, b);
 }
 

--- a/src/core/domain/formSchema/services/schemaStateParser.ts
+++ b/src/core/domain/formSchema/services/schemaStateParser.ts
@@ -1,0 +1,36 @@
+import { BusinessRuleError } from "@/core/domain/error";
+import { isRecord } from "@/core/domain/typeGuards";
+import { FormSchemaErrorCode } from "../errorCode";
+import type { SchemaState } from "../state";
+import { SchemaParser } from "./schemaParser";
+
+/**
+ * Parses pre-parsed (codec-decoded) data into a {@link SchemaState}.
+ *
+ * The top-level `revision` is extracted and the remainder (the captured
+ * `layout`) is parsed via {@link SchemaParser}. This is the inverse of
+ * {@link SchemaStateSerializer}. The domain layer does not depend on YAML;
+ * the application layer handles codec decoding before calling this.
+ */
+export const SchemaStateParser = {
+  parse: (parsed: unknown): SchemaState => {
+    if (!isRecord(parsed)) {
+      throw new BusinessRuleError(
+        FormSchemaErrorCode.FsInvalidStateStructure,
+        "Schema state must be an object",
+      );
+    }
+
+    const { revision, ...rest } = parsed;
+    if (typeof revision !== "string" || revision.length === 0) {
+      throw new BusinessRuleError(
+        FormSchemaErrorCode.FsInvalidStateStructure,
+        'Schema state must have a non-empty "revision" string',
+      );
+    }
+
+    const schema = SchemaParser.parse(rest);
+
+    return { revision, schema };
+  },
+};

--- a/src/core/domain/formSchema/services/schemaStateSerializer.ts
+++ b/src/core/domain/formSchema/services/schemaStateSerializer.ts
@@ -1,0 +1,25 @@
+import type { SchemaState } from "../state";
+import { enrichLayoutWithFields } from "./layoutEnricher";
+import { SchemaSerializer } from "./schemaSerializer";
+
+/**
+ * Serializes a {@link SchemaState} to a plain object suitable for YAML
+ * stringification (via the codec port in the application layer).
+ *
+ * The schema portion is serialized through the exact same path as `capture`
+ * (`enrichLayoutWithFields` -> `SchemaSerializer.serialize`) so that the state
+ * snapshot is round-trip compatible with the captured schema (ADR-007). The
+ * top-level `revision` is added alongside the captured `layout`.
+ */
+export const SchemaStateSerializer = {
+  serialize: (state: SchemaState): Record<string, unknown> => {
+    const enrichedLayout = enrichLayoutWithFields(
+      state.schema.layout,
+      state.schema.fields,
+    );
+    return {
+      revision: state.revision,
+      ...SchemaSerializer.serialize(enrichedLayout, state.schema.fields),
+    };
+  },
+};

--- a/src/core/domain/formSchema/services/threeWayMerge.ts
+++ b/src/core/domain/formSchema/services/threeWayMerge.ts
@@ -196,7 +196,7 @@ function assertNoOrphanFields(
   mergedFields: ReadonlyMap<FieldCode, FieldDefinition>,
   layout: FormLayout,
 ): void {
-  const placed = collectLayoutFieldCodes(layout);
+  const { placed, groupCodes } = collectLayoutFieldCodes(layout);
 
   const orphans: FieldCode[] = [];
   for (const code of mergedFields.keys()) {
@@ -211,8 +211,18 @@ function assertNoOrphanFields(
     );
   }
 
+  // The resurrected check assumes "every placed code exists in the merged field
+  // map". That holds for ordinary fields, SUBTABLE and REFERENCE_TABLE codes
+  // (getFields returns all three; subtable inner fields are flattened to the top
+  // level and REFERENCE_TABLE carries properties). It does NOT hold for GROUP:
+  // kintone's field-properties API never returns GROUP definitions (ADR-007),
+  // so when the remote field map (getFields-derived) backs `mergedFields`, GROUP
+  // codes are structurally absent even though they are placed in the layout.
+  // GROUP is a layout-only structural element and cannot be a deleted/resurrected
+  // field, so it is excluded from the resurrected check (ADR-018).
   const resurrected: FieldCode[] = [];
   for (const code of placed) {
+    if (groupCodes.has(code)) continue;
     if (!mergedFields.has(code)) resurrected.push(code);
   }
   if (resurrected.length > 0) {
@@ -231,8 +241,18 @@ function assertNoOrphanFields(
 // their own code; ROW and nested (group/subtable) field elements contribute the
 // placed field's code. Decoration (SPACER/HR/LABEL) and system-field elements
 // are intentionally excluded because they never appear in the field map.
-function collectLayoutFieldCodes(layout: FormLayout): ReadonlySet<FieldCode> {
+//
+// GROUP codes are also reported separately (`groupCodes`) because they are
+// layout-only structural elements that kintone's field-properties API never
+// returns (ADR-007). The resurrected check uses this set to exclude GROUP codes,
+// which can be placed without a matching field-map entry; the orphan check is
+// unaffected because it walks the field map, where GROUP codes never appear.
+function collectLayoutFieldCodes(layout: FormLayout): Readonly<{
+  placed: ReadonlySet<FieldCode>;
+  groupCodes: ReadonlySet<FieldCode>;
+}> {
   const placed = new Set<FieldCode>();
+  const groupCodes = new Set<FieldCode>();
   const collectElements = (elements: readonly LayoutElement[]): void => {
     for (const element of elements) {
       if (element.kind === "field") placed.add(element.field.code);
@@ -245,6 +265,7 @@ function collectLayoutFieldCodes(layout: FormLayout): ReadonlySet<FieldCode> {
         break;
       case "GROUP":
         placed.add(item.code);
+        groupCodes.add(item.code);
         for (const row of item.layout) collectElements(row.fields);
         break;
       case "SUBTABLE":
@@ -256,7 +277,7 @@ function collectLayoutFieldCodes(layout: FormLayout): ReadonlySet<FieldCode> {
         break;
     }
   }
-  return placed;
+  return { placed, groupCodes };
 }
 
 function assertResolutionCovers(

--- a/src/core/domain/formSchema/services/threeWayMerge.ts
+++ b/src/core/domain/formSchema/services/threeWayMerge.ts
@@ -1,0 +1,236 @@
+import { classifyThreeWay } from "../../diff";
+import { Schema } from "../entity";
+import type {
+  FieldCode,
+  FieldDefinition,
+  FormSchemaThreeWayMerge,
+  MergeResolution,
+} from "../valueObject";
+import { isFieldEqual, isLayoutEqual } from "./diffDetector";
+import {
+  collectSubtableInnerFieldCodes,
+  enrichLayoutWithFields,
+} from "./layoutEnricher";
+
+/**
+ * Normalizes a field map so that base/local/remote share the same population
+ * before 3-way classification (ADR-007).
+ *
+ * - Subtable inner fields are removed from the top level: a subtable is treated
+ *   as a single entity (its inner Map is compared whole by `isFieldEqual`).
+ * - GROUP definitions are removed from the field channel: GROUP structural
+ *   changes surface via the layout channel.
+ *
+ * `getFields()` (remote) already excludes system fields and flattens subtable
+ * inner fields to the top level; parsed local/base schemas include GROUP and
+ * subtable inner definitions. Running all three through this normalization
+ * aligns their populations so classification compares like-with-like.
+ */
+export function normalizeForThreeWay(
+  fields: ReadonlyMap<FieldCode, FieldDefinition>,
+): ReadonlyMap<FieldCode, FieldDefinition> {
+  const innerCodes = collectSubtableInnerFieldCodes(fields);
+  const normalized = new Map<FieldCode, FieldDefinition>();
+  for (const [code, def] of fields) {
+    if (def.type === "GROUP") continue;
+    if (innerCodes.has(code)) continue;
+    normalized.set(code, def);
+  }
+  return normalized;
+}
+
+/**
+ * Computes a 3-way merge of two form schemas against a common base.
+ *
+ * Fields are classified per-entity over the normalized field channel; layout
+ * is coarse-grained (single conflict flag, ADR-003). GROUP/subtable-inner are
+ * excluded from the field channel and reconstructed from the chosen layout in
+ * {@link resolveMerge}.
+ */
+export function computeThreeWayMerge(
+  base: Schema,
+  local: Schema,
+  remote: Schema,
+): FormSchemaThreeWayMerge {
+  const baseFieldsNorm = normalizeForThreeWay(base.fields);
+  const localFieldsNorm = normalizeForThreeWay(local.fields);
+  const remoteFieldsNorm = normalizeForThreeWay(remote.fields);
+
+  const fieldResult = classifyThreeWay<FieldCode, FieldDefinition>(
+    baseFieldsNorm,
+    localFieldsNorm,
+    remoteFieldsNorm,
+    isFieldEqual,
+  );
+
+  const enrichedBaseLayout = enrichLayoutWithFields(base.layout, base.fields);
+  const enrichedLocalLayout = enrichLayoutWithFields(
+    local.layout,
+    local.fields,
+  );
+  const enrichedRemoteLayout = enrichLayoutWithFields(
+    remote.layout,
+    remote.fields,
+  );
+
+  const layoutLocalChanged = !isLayoutEqual(
+    enrichedBaseLayout,
+    enrichedLocalLayout,
+  );
+  const layoutRemoteChanged = !isLayoutEqual(
+    enrichedBaseLayout,
+    enrichedRemoteLayout,
+  );
+
+  let layoutConflict = false;
+  let mergedLayout: Schema["layout"] | undefined;
+  if (layoutLocalChanged && layoutRemoteChanged) {
+    if (isLayoutEqual(enrichedLocalLayout, enrichedRemoteLayout)) {
+      mergedLayout = enrichedLocalLayout;
+    } else {
+      layoutConflict = true;
+    }
+  } else if (layoutLocalChanged) {
+    mergedLayout = enrichedLocalLayout;
+  } else if (layoutRemoteChanged) {
+    mergedLayout = enrichedRemoteLayout;
+  } else {
+    mergedLayout = enrichedBaseLayout;
+  }
+
+  return {
+    fieldEntries: fieldResult.entries,
+    fieldConflicts: fieldResult.conflicts,
+    layoutConflict,
+    baseLayout: enrichedBaseLayout,
+    localLayout: enrichedLocalLayout,
+    remoteLayout: enrichedRemoteLayout,
+    ...(mergedLayout !== undefined ? { mergedLayout } : {}),
+    hasConflict: fieldResult.hasConflict || layoutConflict,
+    baseFields: base.fields,
+    localFields: local.fields,
+    remoteFields: remote.fields,
+  };
+}
+
+/**
+ * Reconstructs the merged {@link Schema} after conflicts have been resolved.
+ *
+ * The chosen layout (local/remote on conflict, otherwise the auto-merged
+ * layout) determines the structure. GROUP/subtable-inner definitions that were
+ * excluded from the field channel are reconstructed from the field map that
+ * corresponds to the chosen layout, so the result is internally consistent.
+ *
+ * @throws when `resolution` does not cover every field conflict, or when the
+ *   layout resolution is inconsistent with `layoutConflict`.
+ */
+export function resolveMerge(
+  merge: FormSchemaThreeWayMerge,
+  resolution: MergeResolution,
+): Schema {
+  assertResolutionCovers(merge, resolution);
+
+  // Choose the layout source and its corresponding full field map. The full
+  // field map carries GROUP/subtable-inner definitions for the structure that
+  // matches the chosen layout.
+  const layoutSide: "local" | "remote" = merge.layoutConflict
+    ? (resolution.layout as "local" | "remote")
+    : layoutAutoSide(merge);
+
+  const chosenLayout =
+    layoutSide === "local" ? merge.localLayout : merge.remoteLayout;
+  const chosenSideFields =
+    layoutSide === "local" ? merge.localFields : merge.remoteFields;
+
+  // Start from the chosen side's full field map (includes GROUP / subtable
+  // inner), then overlay the merged top-level field channel decisions.
+  const mergedFields = new Map<FieldCode, FieldDefinition>(chosenSideFields);
+  for (const entry of merge.fieldEntries) {
+    overlayFieldEntry(
+      mergedFields,
+      entry,
+      resolveFieldEntry(entry, resolution),
+    );
+  }
+
+  return Schema.create(mergedFields, chosenLayout);
+}
+
+function assertResolutionCovers(
+  merge: FormSchemaThreeWayMerge,
+  resolution: MergeResolution,
+): void {
+  for (const conflict of merge.fieldConflicts) {
+    if (!resolution.fields.has(conflict.key)) {
+      throw new Error(
+        `Merge resolution missing field conflict: ${conflict.key}`,
+      );
+    }
+  }
+  if (
+    merge.layoutConflict &&
+    resolution.layout !== "local" &&
+    resolution.layout !== "remote"
+  ) {
+    throw new Error(
+      "Merge resolution must choose a layout side for the layout conflict",
+    );
+  }
+}
+
+function dropSubtableInner(
+  fields: Map<FieldCode, FieldDefinition>,
+  code: FieldCode,
+): void {
+  const existing = fields.get(code);
+  if (existing?.type === "SUBTABLE") {
+    for (const innerCode of existing.properties.fields.keys()) {
+      fields.delete(innerCode);
+    }
+  }
+}
+
+// Overlays a single field-channel decision onto the merged field map, keeping
+// subtable inner top-level entries consistent with the chosen definition.
+function overlayFieldEntry(
+  mergedFields: Map<FieldCode, FieldDefinition>,
+  entry: FormSchemaThreeWayMerge["fieldEntries"][number],
+  resolved: FieldDefinition | undefined,
+): void {
+  dropSubtableInner(mergedFields, entry.key);
+  if (resolved === undefined) {
+    mergedFields.delete(entry.key);
+    return;
+  }
+  mergedFields.set(entry.key, resolved);
+  if (resolved.type === "SUBTABLE") {
+    for (const [innerCode, innerDef] of resolved.properties.fields) {
+      mergedFields.set(innerCode, innerDef);
+    }
+  }
+}
+
+function layoutAutoSide(merge: FormSchemaThreeWayMerge): "local" | "remote" {
+  // When there is no layout conflict, mergedLayout equals one of the enriched
+  // layouts. Prefer the side that matches mergedLayout so the field map aligns.
+  if (merge.mergedLayout === merge.remoteLayout) return "remote";
+  return "local";
+}
+
+function resolveFieldEntry(
+  entry: FormSchemaThreeWayMerge["fieldEntries"][number],
+  resolution: MergeResolution,
+): FieldDefinition | undefined {
+  switch (entry.change.kind) {
+    case "unchanged":
+    case "localOnly":
+    case "bothSame":
+      return entry.merged;
+    case "remoteOnly":
+      return entry.merged;
+    case "conflict": {
+      const side = resolution.fields.get(entry.key);
+      return side === "remote" ? entry.remote : entry.local;
+    }
+  }
+}

--- a/src/core/domain/formSchema/services/threeWayMerge.ts
+++ b/src/core/domain/formSchema/services/threeWayMerge.ts
@@ -1,11 +1,13 @@
 import { BusinessRuleError } from "@/core/domain/error";
 import { classifyThreeWay } from "../../diff";
+import type { FormLayout } from "../entity";
 import { Schema } from "../entity";
 import { FormSchemaErrorCode } from "../errorCode";
 import type {
   FieldCode,
   FieldDefinition,
   FormSchemaThreeWayMerge,
+  LayoutElement,
   MergeResolution,
 } from "../valueObject";
 import { isFieldEqual, isLayoutEqual } from "./diffDetector";
@@ -161,7 +163,75 @@ export function resolveMerge(
     );
   }
 
+  assertNoOrphanFields(mergedFields, chosenLayout);
+
   return Schema.create(mergedFields, chosenLayout);
+}
+
+/**
+ * Rejects merge resolutions that would produce an orphan field: a top-level
+ * field present in the merged field map but absent from the chosen layout.
+ *
+ * The field channel and the layout channel are resolved independently
+ * (`resolveFieldEntry` vs `layoutSide`). A field added on one side
+ * (auto-merged into `mergedFields`) can be placed only in that side's layout;
+ * if the conflicting layout from the other side is chosen, the field is not
+ * placed anywhere. Because schema serialization is layout-driven
+ * (`SchemaSerializer.serialize` walks the layout, not the field map), such an
+ * orphan field would be silently dropped on write-back. Detecting it here turns
+ * a silent correctness loss into an explicit, actionable error: the chosen
+ * resolution combination is internally inconsistent and the user must pick the
+ * layout side that contains the adopted field.
+ */
+function assertNoOrphanFields(
+  mergedFields: ReadonlyMap<FieldCode, FieldDefinition>,
+  layout: FormLayout,
+): void {
+  const placed = collectLayoutFieldCodes(layout);
+  const orphans: FieldCode[] = [];
+  for (const code of mergedFields.keys()) {
+    if (!placed.has(code)) orphans.push(code);
+  }
+  if (orphans.length > 0) {
+    throw new BusinessRuleError(
+      FormSchemaErrorCode.FsOrphanMergedField,
+      `Merge resolution leaves field(s) not placed in the chosen layout: ${orphans.join(
+        ", ",
+      )}. The adopted field exists on a different side than the chosen layout; choose the layout side that contains the field.`,
+    );
+  }
+}
+
+// Collects every field code that the layout places, so orphan top-level fields
+// (present in the merged field map but unplaced) can be detected. GROUP /
+// SUBTABLE / REFERENCE_TABLE items contribute their own code; ROW and nested
+// (group/subtable) field elements contribute the placed field's code.
+function collectLayoutFieldCodes(layout: FormLayout): ReadonlySet<FieldCode> {
+  const placed = new Set<FieldCode>();
+  const collectElements = (elements: readonly LayoutElement[]): void => {
+    for (const element of elements) {
+      if (element.kind === "field") placed.add(element.field.code);
+    }
+  };
+  for (const item of layout) {
+    switch (item.type) {
+      case "ROW":
+        collectElements(item.fields);
+        break;
+      case "GROUP":
+        placed.add(item.code);
+        for (const row of item.layout) collectElements(row.fields);
+        break;
+      case "SUBTABLE":
+        placed.add(item.code);
+        collectElements(item.fields);
+        break;
+      case "REFERENCE_TABLE":
+        placed.add(item.code);
+        break;
+    }
+  }
+  return placed;
 }
 
 function assertResolutionCovers(

--- a/src/core/domain/formSchema/services/threeWayMerge.ts
+++ b/src/core/domain/formSchema/services/threeWayMerge.ts
@@ -169,25 +169,35 @@ export function resolveMerge(
 }
 
 /**
- * Rejects merge resolutions that would produce an orphan field: a top-level
- * field present in the merged field map but absent from the chosen layout.
+ * Rejects merge resolutions whose field channel and layout channel disagree on
+ * which fields exist. The two channels are resolved independently
+ * (`resolveFieldEntry` vs `layoutSide`), so the merged field map and the chosen
+ * layout can diverge in two mirror-image ways, both of which corrupt the
+ * layout-driven write-back (`SchemaSerializer.serialize` walks the layout, not
+ * the field map):
  *
- * The field channel and the layout channel are resolved independently
- * (`resolveFieldEntry` vs `layoutSide`). A field added on one side
- * (auto-merged into `mergedFields`) can be placed only in that side's layout;
- * if the conflicting layout from the other side is chosen, the field is not
- * placed anywhere. Because schema serialization is layout-driven
- * (`SchemaSerializer.serialize` walks the layout, not the field map), such an
- * orphan field would be silently dropped on write-back. Detecting it here turns
- * a silent correctness loss into an explicit, actionable error: the chosen
- * resolution combination is internally inconsistent and the user must pick the
- * layout side that contains the adopted field.
+ * 1. **Orphan field** — a field in `mergedFields` but absent from the chosen
+ *    layout. A field added on one side (auto-merged into `mergedFields`) is
+ *    placed only in that side's layout; choosing the conflicting layout from
+ *    the other side leaves the field unplaced, so it is silently dropped on
+ *    write-back (ADR-016).
+ * 2. **Resurrected field** — a field placed in the chosen layout but absent
+ *    from `mergedFields`. A field deleted on one side (field channel resolves
+ *    to `undefined`, removed from `mergedFields`) still appears in the other
+ *    side's layout; choosing that layout makes serialization re-emit the
+ *    deleted field's full definition from the layout element, silently undoing
+ *    the deletion (ADR-017).
+ *
+ * Detecting both turns a silent correctness loss into an explicit, actionable
+ * error: the chosen resolution combination is internally inconsistent and the
+ * user must pick the layout side that matches the field-channel decisions.
  */
 function assertNoOrphanFields(
   mergedFields: ReadonlyMap<FieldCode, FieldDefinition>,
   layout: FormLayout,
 ): void {
   const placed = collectLayoutFieldCodes(layout);
+
   const orphans: FieldCode[] = [];
   for (const code of mergedFields.keys()) {
     if (!placed.has(code)) orphans.push(code);
@@ -200,12 +210,27 @@ function assertNoOrphanFields(
       )}. The adopted field exists on a different side than the chosen layout; choose the layout side that contains the field.`,
     );
   }
+
+  const resurrected: FieldCode[] = [];
+  for (const code of placed) {
+    if (!mergedFields.has(code)) resurrected.push(code);
+  }
+  if (resurrected.length > 0) {
+    throw new BusinessRuleError(
+      FormSchemaErrorCode.FsOrphanMergedField,
+      `Merge resolution keeps field(s) placed in the chosen layout that were removed from the field set: ${resurrected.join(
+        ", ",
+      )}. The field was deleted on one side but the chosen layout still contains it; choose the layout side that omits the deleted field.`,
+    );
+  }
 }
 
-// Collects every field code that the layout places, so orphan top-level fields
-// (present in the merged field map but unplaced) can be detected. GROUP /
-// SUBTABLE / REFERENCE_TABLE items contribute their own code; ROW and nested
-// (group/subtable) field elements contribute the placed field's code.
+// Collects every field code that the layout places, so the merged field map
+// and the chosen layout can be cross-checked in both directions (orphan and
+// resurrected fields). GROUP / SUBTABLE / REFERENCE_TABLE items contribute
+// their own code; ROW and nested (group/subtable) field elements contribute the
+// placed field's code. Decoration (SPACER/HR/LABEL) and system-field elements
+// are intentionally excluded because they never appear in the field map.
 function collectLayoutFieldCodes(layout: FormLayout): ReadonlySet<FieldCode> {
   const placed = new Set<FieldCode>();
   const collectElements = (elements: readonly LayoutElement[]): void => {

--- a/src/core/domain/formSchema/services/threeWayMerge.ts
+++ b/src/core/domain/formSchema/services/threeWayMerge.ts
@@ -1,5 +1,7 @@
+import { BusinessRuleError } from "@/core/domain/error";
 import { classifyThreeWay } from "../../diff";
 import { Schema } from "../entity";
+import { FormSchemaErrorCode } from "../errorCode";
 import type {
   FieldCode,
   FieldDefinition,
@@ -84,18 +86,23 @@ export function computeThreeWayMerge(
 
   let layoutConflict = false;
   let mergedLayout: Schema["layout"] | undefined;
+  let layoutAutoSide: "local" | "remote" | "base" | undefined;
   if (layoutLocalChanged && layoutRemoteChanged) {
     if (isLayoutEqual(enrichedLocalLayout, enrichedRemoteLayout)) {
       mergedLayout = enrichedLocalLayout;
+      layoutAutoSide = "local";
     } else {
       layoutConflict = true;
     }
   } else if (layoutLocalChanged) {
     mergedLayout = enrichedLocalLayout;
+    layoutAutoSide = "local";
   } else if (layoutRemoteChanged) {
     mergedLayout = enrichedRemoteLayout;
+    layoutAutoSide = "remote";
   } else {
     mergedLayout = enrichedBaseLayout;
+    layoutAutoSide = "base";
   }
 
   return {
@@ -106,6 +113,7 @@ export function computeThreeWayMerge(
     localLayout: enrichedLocalLayout,
     remoteLayout: enrichedRemoteLayout,
     ...(mergedLayout !== undefined ? { mergedLayout } : {}),
+    ...(layoutAutoSide !== undefined ? { layoutAutoSide } : {}),
     hasConflict: fieldResult.hasConflict || layoutConflict,
     baseFields: base.fields,
     localFields: local.fields,
@@ -160,9 +168,14 @@ function assertResolutionCovers(
   merge: FormSchemaThreeWayMerge,
   resolution: MergeResolution,
 ): void {
+  // These are programmer invariants (the CLI must produce a resolution that
+  // covers every conflict). They are domain-rule violations, so throw a
+  // BusinessRuleError that the application layer translates to a ValidationError
+  // via wrapBusinessRuleError (CLAUDE.md error policy).
   for (const conflict of merge.fieldConflicts) {
     if (!resolution.fields.has(conflict.key)) {
-      throw new Error(
+      throw new BusinessRuleError(
+        FormSchemaErrorCode.FsInvalidMergeResolution,
         `Merge resolution missing field conflict: ${conflict.key}`,
       );
     }
@@ -172,7 +185,8 @@ function assertResolutionCovers(
     resolution.layout !== "local" &&
     resolution.layout !== "remote"
   ) {
-    throw new Error(
+    throw new BusinessRuleError(
+      FormSchemaErrorCode.FsInvalidMergeResolution,
       "Merge resolution must choose a layout side for the layout conflict",
     );
   }
@@ -211,10 +225,11 @@ function overlayFieldEntry(
 }
 
 function layoutAutoSide(merge: FormSchemaThreeWayMerge): "local" | "remote" {
-  // When there is no layout conflict, mergedLayout equals one of the enriched
-  // layouts. Prefer the side that matches mergedLayout so the field map aligns.
-  if (merge.mergedLayout === merge.remoteLayout) return "remote";
-  return "local";
+  // Read the explicit side flag set by computeThreeWayMerge rather than relying
+  // on reference equality of mergedLayout (W-001). When neither side changed
+  // ("base"), all three layouts are equal, so "local" reconstructs an
+  // equivalent field map.
+  return merge.layoutAutoSide === "remote" ? "remote" : "local";
 }
 
 function resolveFieldEntry(

--- a/src/core/domain/formSchema/state.ts
+++ b/src/core/domain/formSchema/state.ts
@@ -1,0 +1,17 @@
+import type { Schema } from "./entity";
+
+/**
+ * Base snapshot used as the common ancestor for 3-way merge.
+ *
+ * A `SchemaState` is the form schema (fields + layout) at the time the local
+ * YAML was last synchronized with the remote app, together with the app
+ * (preview) revision observed at that moment. It is persisted to a state file
+ * (see `buildStateFilePath`) by `schema pull` / `schema push` and used by
+ * `schema diff` / `schema push` to detect drift.
+ */
+export type SchemaState = Readonly<{
+  /** The app (preview) revision observed when the snapshot was captured. */
+  revision: string;
+  /** The base snapshot of the form schema. */
+  schema: Schema;
+}>;

--- a/src/core/domain/formSchema/valueObject.ts
+++ b/src/core/domain/formSchema/valueObject.ts
@@ -394,6 +394,14 @@ export type FormSchemaThreeWayMerge = Readonly<{
    * when neither changed). `undefined` when `layoutConflict` is true.
    */
   mergedLayout?: FormLayout;
+  /**
+   * Which side the auto-merged layout was taken from when there is no conflict:
+   * the changed side, or `"base"` when neither side changed (base == local ==
+   * remote). Set explicitly so `resolveMerge` does not rely on reference
+   * equality of `mergedLayout`. `"base"` is undefined-of-side and treated as
+   * `"local"` for field-map reconstruction (all three sides agree).
+   */
+  layoutAutoSide?: "local" | "remote" | "base";
   /** True when any side diverged (field or layout). */
   hasConflict: boolean;
   /** Field maps used to reconstruct GROUP/subtable-inner from layout. */

--- a/src/core/domain/formSchema/valueObject.ts
+++ b/src/core/domain/formSchema/valueObject.ts
@@ -1,6 +1,7 @@
 import { BusinessRuleError } from "@/core/domain/error";
 import { hasControlChars, sanitizeForDisplay } from "@/lib/charValidation";
-import type { DiffResult } from "../diff";
+import type { DiffResult, ThreeWayEntry } from "../diff";
+import type { FormLayout } from "./entity";
 import { FormSchemaErrorCode } from "./errorCode";
 
 // Lookup
@@ -367,3 +368,48 @@ export type SystemFieldLayout = Readonly<{
 }>;
 
 export type LayoutElement = LayoutField | DecorationElement | SystemFieldLayout;
+
+// --- 3-way merge value objects ---
+
+/**
+ * Result of a formSchema 3-way merge.
+ *
+ * Fields are merged per-entity (subtable counts as a single entity; subtable
+ * inner fields and GROUP definitions are excluded from the field channel and
+ * handled via the layout channel). Layout is coarse-grained: a single
+ * `layoutConflict` flag rather than per-element merge (ADR-003).
+ */
+export type FormSchemaThreeWayMerge = Readonly<{
+  /** Per-field 3-way classification (normalized field channel). */
+  fieldEntries: readonly ThreeWayEntry<FieldCode, FieldDefinition>[];
+  /** Subset of `fieldEntries` that are conflicts (both sides changed). */
+  fieldConflicts: readonly ThreeWayEntry<FieldCode, FieldDefinition>[];
+  /** True when both local and remote changed the layout from base. */
+  layoutConflict: boolean;
+  baseLayout: FormLayout;
+  localLayout: FormLayout;
+  remoteLayout: FormLayout;
+  /**
+   * Auto-resolved layout when there is no conflict (the changed side, or base
+   * when neither changed). `undefined` when `layoutConflict` is true.
+   */
+  mergedLayout?: FormLayout;
+  /** True when any side diverged (field or layout). */
+  hasConflict: boolean;
+  /** Field maps used to reconstruct GROUP/subtable-inner from layout. */
+  baseFields: ReadonlyMap<FieldCode, FieldDefinition>;
+  localFields: ReadonlyMap<FieldCode, FieldDefinition>;
+  remoteFields: ReadonlyMap<FieldCode, FieldDefinition>;
+}>;
+
+/**
+ * Conflict resolution choices for {@link FormSchemaThreeWayMerge}.
+ *
+ * `fields` must cover every entry in `fieldConflicts`. `layout` must be
+ * `"local"` or `"remote"` when `layoutConflict` is true, otherwise
+ * `"noConflict"`. The type forces the caller to address both channels.
+ */
+export type MergeResolution = Readonly<{
+  fields: ReadonlyMap<FieldCode, "local" | "remote">;
+  layout: "local" | "remote" | "noConflict";
+}>;

--- a/src/core/domain/projectConfig/__tests__/appFilePaths.test.ts
+++ b/src/core/domain/projectConfig/__tests__/appFilePaths.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { type AppFilePaths, buildAppFilePaths } from "../appFilePaths";
+import {
+  type AppFilePaths,
+  buildAppFilePaths,
+  buildLegacyStateFilePath,
+  buildStateFilePath,
+} from "../appFilePaths";
 import { AppName } from "../valueObject";
 
 describe("buildAppFilePaths", () => {
@@ -63,5 +68,34 @@ describe("buildAppFilePaths", () => {
     ];
 
     expect(Object.keys(paths).sort()).toEqual([...expectedKeys].sort());
+  });
+});
+
+// W-002 (ADR-002 / arch-r2-S002): state uses an app-scoped directory layout
+// (`state/<appName>/schema.yaml`, appName INSIDE) whose hierarchy is the inverse
+// of buildAppFilePaths (`<appName>/...`, appName OUTSIDE). These tests pin the
+// direction so a regression to `state/schema.yaml` (collapse) or
+// `<appName>/state/schema.yaml` (direction flip) is caught.
+describe("buildStateFilePath", () => {
+  const appName = AppName.create("customer");
+
+  it("appName 内側の state/<appName>/schema.yaml を返す", () => {
+    expect(buildStateFilePath(appName)).toBe("state/customer/schema.yaml");
+  });
+
+  it("baseDir が指定されると state ディレクトリの外側に付与される", () => {
+    expect(buildStateFilePath(appName, "output")).toBe(
+      "output/state/customer/schema.yaml",
+    );
+  });
+});
+
+describe("buildLegacyStateFilePath", () => {
+  it("legacy 単一アプリは state/schema.yaml を返す", () => {
+    expect(buildLegacyStateFilePath()).toBe("state/schema.yaml");
+  });
+
+  it("baseDir が指定されると state ディレクトリの外側に付与される", () => {
+    expect(buildLegacyStateFilePath("output")).toBe("output/state/schema.yaml");
   });
 });

--- a/src/core/domain/projectConfig/appFilePaths.ts
+++ b/src/core/domain/projectConfig/appFilePaths.ts
@@ -41,3 +41,26 @@ export function buildAppFilePaths(
     plugin: prefix(`${appName}/plugin.yaml`),
   };
 }
+
+/**
+ * Resolves the path to the schema state (base snapshot) file.
+ *
+ * State uses an app-scoped directory layout (`state/<appName>/schema.yaml`)
+ * whose hierarchy is the inverse of {@link buildAppFilePaths} (`<appName>/...`).
+ * They are intentionally kept as separate functions: the state convention is
+ * chosen so that future per-app revision unification (e.g.
+ * `state/<appName>/revision.yaml`) can live alongside without churn.
+ */
+export function buildStateFilePath(appName: AppName, baseDir?: string): string {
+  const path = `state/${appName}/schema.yaml`;
+  return baseDir ? join(baseDir, path) : path;
+}
+
+/**
+ * Resolves the path to the legacy single-app schema state file
+ * (`state/schema.yaml`).
+ */
+export function buildLegacyStateFilePath(baseDir?: string): string {
+  const path = "state/schema.yaml";
+  return baseDir ? join(baseDir, path) : path;
+}


### PR DESCRIPTION
## Summary
- schema ドメインに **base スナップショット（state）+ revision による双方向同期**を導入（Issue #175 の実装順序 step1 = schema 限定）
- 汎用 3-way プリミティブ `classifyThreeWay<K,V>` を `diff.ts` に追加（formSchema 非依存・横展開の土台）
- formSchema の 3-way merge サービス（入力 Map 正規化・field 単位 merge・layout は粗粒度・`resolveMerge`）
- state 値オブジェクト + serializer/parser（全 field を round-trip、codec ポート経由で yaml 非依存）
- `FormConfigurator.getRevision()` 追加 + 期待 revision を明示的に引き回す TOCTOU 排他制御
- 適用核心ロジックを `applySchemaChanges` に抽出し migrate/push で共有（型変更・既存サブテーブルへの追加は ValidationError）
- 新コマンド `schema pull` / `schema push`（`--force` / `--ours` / `--theirs`、インタラクティブ conflict 解決、push は single 経路 deploy）
- `schema diff` を 3-way 表示に拡張（state 無しは従来 2-way にフォールバック）
- 初回（state なし）は一方通行フォールバック

## Issue
Part of #175 — 本 PR は実装順序 step1（schema 限定）を実装する。#175 はアンブレラとして残し、残りは follow-up で対応:
- #188 — step2: 全設定ドメインへ横展開 + factory 化 + `--all` 一括
- #189 — step3: 旧コマンド deprecation + `seed apply` → `seed push` 改名

## Implementation Plan
`.issue/175/plan.md`（中〜大規模 / 13 実装ステップ / レビュー 2 周で収束）に基づく。設計判断は `.issue/175/adr.md`（ADR-001〜012）。

## スコープ
Issue 全体（~11 ドメイン横断 + 旧コマンド廃止）のうち **step1（schema 限定）のみ**。以下は別 Issue に分割（Phase 4 で起票）:
- 他設定ドメインへの横展開 + `pull/pushCommandFactory` 汎用化
- 旧コマンド（migrate/apply/capture）の deprecation warning + `seed apply` → `seed push` 改名
- `pull --all` / `push --all` 一括操作（今回は明示的に未対応エラー）

## Test plan

### デプロイ・動作確認方法
実 kintone 検証アプリに対し接続情報を設定し（`README.md` 参照）、開発モードで実行:
```bash
pnpm dev schema pull          # 実環境 → ローカル（3-way merge）
pnpm dev schema push          # ローカル → 実環境（drift ガード + deploy）
pnpm dev:diff                 # 3-way 表示
```
詳細手順は `.issue/175/testing.md`。

### 自動テスト
- `pnpm typecheck` ✅ / `pnpm lint` ✅（既存 warning のみ）/ `pnpm test` ✅ **2438 passed**
- 新規テスト: `classifyThreeWay` 真理値表、`threeWayMerge`、state round-trip、`applySchemaChanges`、`pullSchema`（force/firstTime/merged/中断時無副作用/実環境非書込）、`pushSchema`（drift ConflictError/期待 revision/--force/型変更 ValidationError/旧コマンド後 drift）、`detectThreeWayDiff`、CLI pull/push
- 既存 migrate/capture/diff の回帰維持

## Browser Verification
- **スキップ理由:** Web UI を持たない CLI ツール（html/サーバーファイル不在を確認）。testing.md の確認項目は全て live kintone 環境 + 認証情報 + インタラクティブ CLI 操作で、agent-browser（Web UI 用）の対象外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
