### PR TITLE
feat(cli): 旧コマンドの deprecation warning + seed apply→seed push 改名 (#189)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ export KINTONE_PASSWORD=your_password
 export KINTONE_APP_ID=123
 
 # Capture current form schema
-kintone-migrator schema capture -f schema.yaml
+kintone-migrator schema pull -f schema.yaml
 
 # Edit schema.yaml, then check diff
 kintone-migrator schema diff
 
 # Apply changes
-kintone-migrator schema migrate
+kintone-migrator schema push
 ```
 
 Requires Node.js 22 or later.
@@ -212,7 +212,7 @@ Commands are organized into domain groups:
 | `plugin` | `apply` | _Deprecated — use `plugin push`._ Apply plugin settings |
 | `plugin` | `capture` | _Deprecated — use `plugin pull`._ Save current plugin settings to file |
 
-> **Deprecation notice:** the `apply`/`capture`/`migrate` commands above (and the top-level `apply`/`capture` aggregate commands) are deprecated in favor of the `push`/`pull` successors and will be removed in a future major version. `push` writes to kintone (with a drift guard; use `--force` for the legacy overwrite behavior) and `pull` reads from kintone (with 3-way merge; `--force` for legacy overwrite). `seed` is out of scope for 3-way merge, so it has `seed push` but no `seed pull` — keep using `seed capture` to read records.
+> **Deprecation notice:** the `apply`/`capture`/`migrate` commands above are deprecated in favor of their per-domain `push`/`pull` successors and will be removed in a future major version. The top-level `apply`/`capture` aggregate commands are likewise superseded by the top-level `push`/`pull` aggregate commands (which run every domain at once), not by any single `<domain> push`/`<domain> pull`. `push` writes to kintone (with a drift guard; use `--force` for the legacy overwrite behavior) and `pull` reads from kintone (with 3-way merge; `--force` for legacy overwrite). `seed` is out of scope for 3-way merge, so it has `seed push` but no `seed pull` — keep using `seed capture` to read records.
 
 All commands support `--app <name>` and `--all` for [multi-app mode](#multi-app-project-config). Commands that modify data (`schema push`, `schema override`, `seed push --clean`, `customize push`) support `--yes` / `-y` to skip confirmation prompts.
 
@@ -327,7 +327,7 @@ kintone-migrator seed apply                    # Deprecated alias for `seed push
 |---|---|
 | `--seed-file`, `-s` | Seed file path (default: `seed.yaml`) |
 | `--key-field`, `-k` | Key field code for upsert |
-| `--clean` | Delete all records before applying. |
+| `--clean` | Delete all existing records before upserting seed data (clean push). |
 | `--yes`, `-y` | Skip confirmation prompts (for `--clean` mode). |
 
 #### `seed capture`
@@ -366,6 +366,8 @@ kintone-migrator customize apply --all --yes
 
 #### `field-acl apply`
 
+> **Deprecated.** Use `field-acl push` instead (and `field-acl pull` in place of `field-acl capture`). The legacy commands keep working but will be removed in a future major version.
+
 Applies field access permissions from a YAML config file. Uses full replacement -- the file defines the complete desired state.
 
 ```bash
@@ -390,6 +392,8 @@ kintone-migrator field-acl capture --field-acl-file my-field-acl.yaml
 
 #### `view apply`
 
+> **Deprecated.** Use `view push` instead (and `view pull` in place of `view capture`). The legacy commands keep working but will be removed in a future major version.
+
 Applies view settings from a YAML config file.
 
 ```bash
@@ -412,6 +416,8 @@ kintone-migrator view capture
 ### `app-acl` -- App Access Permissions
 
 #### `app-acl apply`
+
+> **Deprecated.** Use `app-acl push` instead (and `app-acl pull` in place of `app-acl capture`). The legacy commands keep working but will be removed in a future major version.
 
 Applies app-level access permissions from a YAML config file.
 
@@ -436,6 +442,8 @@ kintone-migrator app-acl capture
 
 #### `record-acl apply`
 
+> **Deprecated.** Use `record-acl push` instead (and `record-acl pull` in place of `record-acl capture`). The legacy commands keep working but will be removed in a future major version.
+
 Applies record-level access permissions from a YAML config file.
 
 ```bash
@@ -458,6 +466,8 @@ kintone-migrator record-acl capture
 ### `process` -- Process Management (Workflow)
 
 #### `process apply`
+
+> **Deprecated.** Use `process push` instead (and `process pull` in place of `process capture`). The legacy commands keep working but will be removed in a future major version.
 
 Applies process management settings (statuses, actions, assignees) from a YAML config file.
 
@@ -482,6 +492,8 @@ kintone-migrator process capture
 
 #### `settings apply`
 
+> **Deprecated.** Use `settings push` instead (and `settings pull` in place of `settings capture`). The legacy commands keep working but will be removed in a future major version.
+
 Applies general app settings (name, description, icon, theme, etc.) from a YAML config file.
 
 ```bash
@@ -504,6 +516,8 @@ kintone-migrator settings capture
 ### `notification` -- Notification Settings
 
 #### `notification apply`
+
+> **Deprecated.** Use `notification push` instead (and `notification pull` in place of `notification capture`). The legacy commands keep working but will be removed in a future major version.
 
 Applies notification settings (general, per-record, reminder) from a YAML config file.
 
@@ -528,6 +542,8 @@ kintone-migrator notification capture
 
 #### `report apply`
 
+> **Deprecated.** Use `report push` instead (and `report pull` in place of `report capture`). The legacy commands keep working but will be removed in a future major version.
+
 Applies graph and report settings from a YAML config file.
 
 ```bash
@@ -550,6 +566,8 @@ kintone-migrator report capture
 ### `action` -- Action Settings
 
 #### `action apply`
+
+> **Deprecated.** Use `action push` instead (and `action pull` in place of `action capture`). The legacy commands keep working but will be removed in a future major version.
 
 Applies action settings (record copy actions) from a YAML config file.
 
@@ -574,6 +592,8 @@ kintone-migrator action capture
 
 #### `admin-notes apply`
 
+> **Deprecated.** Use `admin-notes push` instead (and `admin-notes pull` in place of `admin-notes capture`). The legacy commands keep working but will be removed in a future major version.
+
 Applies admin notes from a YAML config file.
 
 ```bash
@@ -596,6 +616,8 @@ kintone-migrator admin-notes capture
 ### `plugin` -- Plugin Settings
 
 #### `plugin apply`
+
+> **Deprecated.** Use `plugin push` instead (and `plugin pull` in place of `plugin capture`). The legacy commands keep working but will be removed in a future major version.
 
 Applies plugin settings (enable/disable installed plugins) from a YAML config file.
 

--- a/README.md
+++ b/README.md
@@ -179,38 +179,42 @@ Commands are organized into domain groups:
 | Group | Subcommand | Description |
 |---|---|---|
 | `schema` | `diff` | Show differences between schema file and kintone form |
-| `schema` | `migrate` | Apply schema changes (incremental) |
+| `schema` | `migrate` | _Deprecated — use `schema push`._ Apply schema changes (incremental) |
 | `schema` | `override` | Overwrite entire form from schema |
-| `schema` | `capture` | Save current form schema to file |
+| `schema` | `capture` | _Deprecated — use `schema pull`._ Save current form schema to file |
 | `schema` | `validate` | Validate schema file locally |
 | `schema` | `dump` | Dump raw field/layout JSON (for debugging) |
-| `seed` | `apply` | Apply seed data records |
+| `seed` | `push` | Apply seed data records (plain upsert; no 3-way merge) |
+| `seed` | `apply` | _Deprecated alias for `seed push`._ |
 | `seed` | `capture` | Capture records from kintone app |
-| `customize` | `apply` | Apply JS/CSS customizations |
-| `field-acl` | `apply` | Apply field access permissions |
-| `field-acl` | `capture` | Save current field permissions to file |
-| `view` | `apply` | Apply view (list) settings |
-| `view` | `capture` | Save current view settings to file |
-| `app-acl` | `apply` | Apply app-level access permissions |
-| `app-acl` | `capture` | Save current app permissions to file |
-| `record-acl` | `apply` | Apply record-level access permissions |
-| `record-acl` | `capture` | Save current record permissions to file |
-| `process` | `apply` | Apply process management (workflow) settings |
-| `process` | `capture` | Save current process management settings to file |
-| `settings` | `apply` | Apply general app settings |
-| `settings` | `capture` | Save current general settings to file |
-| `notification` | `apply` | Apply notification settings |
-| `notification` | `capture` | Save current notification settings to file |
-| `report` | `apply` | Apply graph/report settings |
-| `report` | `capture` | Save current report settings to file |
-| `action` | `apply` | Apply action settings |
-| `action` | `capture` | Save current action settings to file |
-| `admin-notes` | `apply` | Apply admin notes |
-| `admin-notes` | `capture` | Save current admin notes to file |
-| `plugin` | `apply` | Apply plugin settings |
-| `plugin` | `capture` | Save current plugin settings to file |
+| `customize` | `apply` | _Deprecated — use `customize push`._ Apply JS/CSS customizations |
+| `customize` | `capture` | _Deprecated — use `customize pull`._ Save current customizations to file |
+| `field-acl` | `apply` | _Deprecated — use `field-acl push`._ Apply field access permissions |
+| `field-acl` | `capture` | _Deprecated — use `field-acl pull`._ Save current field permissions to file |
+| `view` | `apply` | _Deprecated — use `view push`._ Apply view (list) settings |
+| `view` | `capture` | _Deprecated — use `view pull`._ Save current view settings to file |
+| `app-acl` | `apply` | _Deprecated — use `app-acl push`._ Apply app-level access permissions |
+| `app-acl` | `capture` | _Deprecated — use `app-acl pull`._ Save current app permissions to file |
+| `record-acl` | `apply` | _Deprecated — use `record-acl push`._ Apply record-level access permissions |
+| `record-acl` | `capture` | _Deprecated — use `record-acl pull`._ Save current record permissions to file |
+| `process` | `apply` | _Deprecated — use `process push`._ Apply process management (workflow) settings |
+| `process` | `capture` | _Deprecated — use `process pull`._ Save current process management settings to file |
+| `settings` | `apply` | _Deprecated — use `settings push`._ Apply general app settings |
+| `settings` | `capture` | _Deprecated — use `settings pull`._ Save current general settings to file |
+| `notification` | `apply` | _Deprecated — use `notification push`._ Apply notification settings |
+| `notification` | `capture` | _Deprecated — use `notification pull`._ Save current notification settings to file |
+| `report` | `apply` | _Deprecated — use `report push`._ Apply graph/report settings |
+| `report` | `capture` | _Deprecated — use `report pull`._ Save current report settings to file |
+| `action` | `apply` | _Deprecated — use `action push`._ Apply action settings |
+| `action` | `capture` | _Deprecated — use `action pull`._ Save current action settings to file |
+| `admin-notes` | `apply` | _Deprecated — use `admin-notes push`._ Apply admin notes |
+| `admin-notes` | `capture` | _Deprecated — use `admin-notes pull`._ Save current admin notes to file |
+| `plugin` | `apply` | _Deprecated — use `plugin push`._ Apply plugin settings |
+| `plugin` | `capture` | _Deprecated — use `plugin pull`._ Save current plugin settings to file |
 
-All commands support `--app <name>` and `--all` for [multi-app mode](#multi-app-project-config). Commands that modify data (`schema migrate`, `schema override`, `seed apply --clean`, `customize apply`) support `--yes` / `-y` to skip confirmation prompts.
+> **Deprecation notice:** the `apply`/`capture`/`migrate` commands above (and the top-level `apply`/`capture` aggregate commands) are deprecated in favor of the `push`/`pull` successors and will be removed in a future major version. `push` writes to kintone (with a drift guard; use `--force` for the legacy overwrite behavior) and `pull` reads from kintone (with 3-way merge; `--force` for legacy overwrite). `seed` is out of scope for 3-way merge, so it has `seed push` but no `seed pull` — keep using `seed capture` to read records.
+
+All commands support `--app <name>` and `--all` for [multi-app mode](#multi-app-project-config). Commands that modify data (`schema push`, `schema override`, `seed push --clean`, `customize push`) support `--yes` / `-y` to skip confirmation prompts.
 
 ### `init` -- Project Initialization
 
@@ -254,6 +258,8 @@ kintone-migrator schema diff --app customer
 
 #### `schema migrate`
 
+> **Deprecated.** Use `schema push` (drift-guarded) or `schema push --force` (legacy overwrite) instead. `schema migrate` keeps working but will be removed in a future major version.
+
 Applies only the detected differences (add, update, delete) to the kintone form.
 
 ```bash
@@ -278,6 +284,8 @@ kintone-migrator schema override --all --yes
 | `--yes`, `-y` | Skip confirmation prompts. |
 
 #### `schema capture`
+
+> **Deprecated.** Use `schema pull` (3-way merge) or `schema pull --force` (legacy overwrite) instead. `schema capture` keeps working but will be removed in a future major version.
 
 Saves the current kintone form schema to a YAML file.
 
@@ -305,13 +313,14 @@ kintone-migrator schema dump
 
 ### `seed` -- Seed Data Management
 
-#### `seed apply`
+#### `seed push`
 
-Upserts seed data records into a kintone app.
+Upserts seed data records into a kintone app. seed is out of scope for 3-way merge, so this is a plain upsert with no drift guard. `seed apply` remains as a deprecated alias for `seed push`. There is no `seed pull`; use `seed capture` to read records.
 
 ```bash
-kintone-migrator seed apply                    # Apply seed data
-kintone-migrator seed apply --clean --yes      # Delete all records first
+kintone-migrator seed push                     # Upsert seed data
+kintone-migrator seed push --clean --yes       # Delete all records first
+kintone-migrator seed apply                    # Deprecated alias for `seed push`
 ```
 
 | Option | Description |
@@ -337,6 +346,8 @@ kintone-migrator seed capture --key-field customer_code
 ### `customize` -- JS/CSS Customization
 
 #### `customize apply`
+
+> **Deprecated.** Use `customize push` instead (and `customize pull` in place of `customize capture`). The legacy commands keep working but will be removed in a future major version.
 
 Applies JS/CSS customizations from a YAML config file. Local files are uploaded and merged with existing settings.
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Commands are organized into domain groups:
 | `schema` | `capture` | _Deprecated — use `schema pull`._ Save current form schema to file |
 | `schema` | `validate` | Validate schema file locally |
 | `schema` | `dump` | Dump raw field/layout JSON (for debugging) |
-| `seed` | `push` | Apply seed data records (plain upsert; no 3-way merge) |
+| `seed` | `push` | Upsert seed data records (plain upsert; no 3-way merge) |
 | `seed` | `apply` | _Deprecated alias for `seed push`._ |
 | `seed` | `capture` | Capture records from kintone app |
 | `customize` | `apply` | _Deprecated — use `customize push`._ Apply JS/CSS customizations |
@@ -326,7 +326,6 @@ kintone-migrator seed apply                    # Deprecated alias for `seed push
 | Option | Description |
 |---|---|
 | `--seed-file`, `-s` | Seed file path (default: `seed.yaml`) |
-| `--key-field`, `-k` | Key field code for upsert |
 | `--clean` | Delete all existing records before upserting seed data (clean push). |
 | `--yes`, `-y` | Skip confirmation prompts (for `--clean` mode). |
 

--- a/src/cli/commands/__tests__/apply.test.ts
+++ b/src/cli/commands/__tests__/apply.test.ts
@@ -156,6 +156,23 @@ describe("apply command", () => {
     expect(process.exitCode).toBe(1);
   });
 
+  it("実行時に push への移行を案内する deprecation warning を出すこと（AC-1）", async () => {
+    await applyCommand.run({ values: {} } as never);
+
+    expect(p.log.warn).toHaveBeenCalledWith(expect.stringContaining("push"));
+  });
+
+  it("singleLegacy のエラー文言が旧コマンドではなく push 系の移行先を案内すること（AC-13）", async () => {
+    await applyCommand.run({ values: {} } as never);
+
+    expect(p.log.error).toHaveBeenCalledWith(
+      expect.stringContaining("schema push"),
+    );
+    expect(p.log.error).not.toHaveBeenCalledWith(
+      expect.stringContaining("schema migrate"),
+    );
+  });
+
   it("singleApp では diffAllForApp と applyAllForApp が呼ばれること", async () => {
     vi.mocked(routeMultiApp).mockImplementationOnce(
       async (

--- a/src/cli/commands/__tests__/applyCommandFactory.test.ts
+++ b/src/cli/commands/__tests__/applyCommandFactory.test.ts
@@ -131,7 +131,6 @@ describe("createApplyCommand", () => {
       expect(p.log.warn).toHaveBeenCalledWith(
         expect.stringContaining("test push"),
       );
-      // Existing behavior still runs after the warning.
       expect(config.applyFn).toHaveBeenCalled();
     });
   });

--- a/src/cli/commands/__tests__/applyCommandFactory.test.ts
+++ b/src/cli/commands/__tests__/applyCommandFactory.test.ts
@@ -103,6 +103,7 @@ function makeConfig(
   return {
     description: "Test apply",
     args: {} as Record<string, never>,
+    deprecation: { commandName: "test apply", replacement: "test push" },
     spinnerMessage: "Applying...",
     spinnerStopMessage: "Applied.",
     successMessage: "Applied successfully.",
@@ -120,6 +121,21 @@ function makeConfig(
 }
 
 describe("createApplyCommand", () => {
+  describe("deprecation warning", () => {
+    it("should print a deprecation warning pointing to the replacement", async () => {
+      const config = makeConfig();
+      const command = createApplyCommand(config);
+
+      await command.run({ values: {} } as never);
+
+      expect(p.log.warn).toHaveBeenCalledWith(
+        expect.stringContaining("test push"),
+      );
+      // Existing behavior still runs after the warning.
+      expect(config.applyFn).toHaveBeenCalled();
+    });
+  });
+
   describe("without diffPreview (backward compatibility)", () => {
     it("should apply directly without diff detection", async () => {
       const config = makeConfig();

--- a/src/cli/commands/__tests__/capture.test.ts
+++ b/src/cli/commands/__tests__/capture.test.ts
@@ -111,6 +111,23 @@ describe("capture command", () => {
     expect(process.exitCode).toBe(1);
   });
 
+  it("実行時に pull への移行を案内する deprecation warning を出すこと（AC-2）", async () => {
+    await captureCommand.run({ values: {} } as never);
+
+    expect(p.log.warn).toHaveBeenCalledWith(expect.stringContaining("pull"));
+  });
+
+  it("singleLegacy のエラー文言が旧コマンドではなく pull 系の移行先を案内すること（AC-13）", async () => {
+    await captureCommand.run({ values: {} } as never);
+
+    expect(p.log.error).toHaveBeenCalledWith(
+      expect.stringContaining("schema pull"),
+    );
+    expect(p.log.error).not.toHaveBeenCalledWith(
+      expect.stringContaining("schema capture"),
+    );
+  });
+
   it("singleApp では captureAllForApp と printCaptureAllResults が呼ばれること", async () => {
     vi.mocked(routeMultiApp).mockImplementationOnce(
       async (

--- a/src/cli/commands/__tests__/captureCommandFactory.test.ts
+++ b/src/cli/commands/__tests__/captureCommandFactory.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@clack/prompts", () => ({
+  spinner: vi.fn(() => ({
+    start: vi.fn(),
+    stop: vi.fn(),
+  })),
+  log: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+    step: vi.fn(),
+  },
+  note: vi.fn(),
+  isCancel: vi.fn(() => false),
+  cancel: vi.fn(),
+}));
+
+vi.mock("../../handleError", () => ({
+  handleCliError: vi.fn(),
+}));
+
+vi.mock("../../projectConfig", () => ({
+  routeMultiApp: vi.fn(
+    async (
+      _values: unknown,
+      handlers: { singleLegacy: () => Promise<void> },
+    ) => {
+      await handlers.singleLegacy();
+    },
+  ),
+  runMultiAppWithFailCheck: vi.fn(),
+  runMultiAppWithHeaders: vi.fn(),
+}));
+
+vi.mock("../../output", () => ({
+  printAppHeader: vi.fn(),
+}));
+
+import * as p from "@clack/prompts";
+import { createCaptureCommand } from "../captureCommandFactory";
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function makeConfig() {
+  return {
+    description: "Test capture",
+    args: {} as Record<string, never>,
+    deprecation: { commandName: "test capture", replacement: "test pull" },
+    spinnerMessage: "Capturing...",
+    spinnerStopMessage: "Captured.",
+    domainLabel: "Test",
+    multiAppSuccessMessage: "All captures completed.",
+    createContainer: vi.fn(() => ({})),
+    captureFn: vi
+      .fn()
+      .mockResolvedValue({ configText: "x", hasExistingConfig: false }),
+    saveFn: vi.fn().mockResolvedValue(undefined),
+    getConfigFilePath: vi.fn(() => "out.yaml"),
+    resolveContainerConfig: vi.fn(() => "test-config"),
+    resolveAppContainerConfig: vi.fn(() => "app-config"),
+  };
+}
+
+describe("createCaptureCommand", () => {
+  it("should print a deprecation warning pointing to the replacement", async () => {
+    const config = makeConfig();
+    const command = createCaptureCommand(config);
+
+    await command.run({ values: {} } as never);
+
+    expect(p.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("test pull"),
+    );
+    // Existing behavior still runs after the warning.
+    expect(config.captureFn).toHaveBeenCalled();
+    expect(config.saveFn).toHaveBeenCalled();
+  });
+});

--- a/src/cli/commands/__tests__/captureCommandFactory.test.ts
+++ b/src/cli/commands/__tests__/captureCommandFactory.test.ts
@@ -75,7 +75,6 @@ describe("createCaptureCommand", () => {
     expect(p.log.warn).toHaveBeenCalledWith(
       expect.stringContaining("test pull"),
     );
-    // Existing behavior still runs after the warning.
     expect(config.captureFn).toHaveBeenCalled();
     expect(config.saveFn).toHaveBeenCalled();
   });

--- a/src/cli/commands/__tests__/deprecation.test.ts
+++ b/src/cli/commands/__tests__/deprecation.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@clack/prompts", () => ({
+  log: {
+    warn: vi.fn(),
+  },
+}));
+
+import * as p from "@clack/prompts";
+import { printDeprecationWarning } from "../../deprecation";
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("printDeprecationWarning", () => {
+  it("calls p.log.warn with the old command and replacement", () => {
+    printDeprecationWarning({
+      oldCommand: "schema migrate",
+      replacement: "schema push",
+    });
+
+    expect(p.log.warn).toHaveBeenCalledTimes(1);
+    const message = vi.mocked(p.log.warn).mock.calls[0][0];
+    expect(message).toContain("schema migrate");
+    expect(message).toContain("schema push");
+    expect(message).toContain("[deprecated]");
+  });
+
+  it("includes the note when provided", () => {
+    printDeprecationWarning({
+      oldCommand: "seed apply",
+      replacement: "seed push",
+      note: "plain upsert without drift guard.",
+    });
+
+    const message = vi.mocked(p.log.warn).mock.calls[0][0];
+    expect(message).toContain("plain upsert without drift guard.");
+  });
+});

--- a/src/cli/commands/action/__tests__/capture.test.ts
+++ b/src/cli/commands/action/__tests__/capture.test.ts
@@ -114,7 +114,9 @@ describe("action capture コマンド", () => {
 
     await command.run({ values: {} } as never);
 
-    expect(p.log.warn).not.toHaveBeenCalled();
+    expect(p.log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("overwritten"),
+    );
   });
 
   it("エラー発生時にhandleCliErrorで処理される", async () => {

--- a/src/cli/commands/action/apply.ts
+++ b/src/cli/commands/action/apply.ts
@@ -12,6 +12,10 @@ import { createApplyCommand } from "../applyCommandFactory";
 export default createApplyCommand({
   description: "Apply action settings from YAML to kintone app",
   args: actionArgs,
+  deprecation: {
+    commandName: "action apply",
+    replacement: "action push",
+  },
   spinnerMessage: "Applying action settings...",
   spinnerStopMessage: "Action settings applied.",
   successMessage: "Action settings applied successfully.",

--- a/src/cli/commands/action/capture.ts
+++ b/src/cli/commands/action/capture.ts
@@ -11,6 +11,10 @@ import { createCaptureCommand } from "../captureCommandFactory";
 export default createCaptureCommand({
   description: "Capture current action settings from kintone app to file",
   args: actionArgs,
+  deprecation: {
+    commandName: "action capture",
+    replacement: "action pull",
+  },
   spinnerMessage: "Capturing action settings...",
   spinnerStopMessage: "Action settings captured.",
   domainLabel: "Action settings",

--- a/src/cli/commands/admin-notes/__tests__/capture.test.ts
+++ b/src/cli/commands/admin-notes/__tests__/capture.test.ts
@@ -116,7 +116,9 @@ describe("admin-notes capture コマンド", () => {
 
     await command.run({ values: {} } as never);
 
-    expect(p.log.warn).not.toHaveBeenCalled();
+    expect(p.log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("overwritten"),
+    );
   });
 
   it("エラー発生時にhandleCliErrorで処理される", async () => {

--- a/src/cli/commands/admin-notes/apply.ts
+++ b/src/cli/commands/admin-notes/apply.ts
@@ -12,6 +12,10 @@ import { createApplyCommand } from "../applyCommandFactory";
 export default createApplyCommand({
   description: "Apply admin notes from YAML to kintone app",
   args: adminNotesArgs,
+  deprecation: {
+    commandName: "admin-notes apply",
+    replacement: "admin-notes push",
+  },
   spinnerMessage: "Applying admin notes...",
   spinnerStopMessage: "Admin notes applied.",
   successMessage: "Admin notes applied successfully.",

--- a/src/cli/commands/admin-notes/capture.ts
+++ b/src/cli/commands/admin-notes/capture.ts
@@ -11,6 +11,10 @@ import { createCaptureCommand } from "../captureCommandFactory";
 export default createCaptureCommand({
   description: "Capture current admin notes from kintone app to file",
   args: adminNotesArgs,
+  deprecation: {
+    commandName: "admin-notes capture",
+    replacement: "admin-notes pull",
+  },
   spinnerMessage: "Capturing admin notes...",
   spinnerStopMessage: "Admin notes captured.",
   domainLabel: "Admin notes",

--- a/src/cli/commands/app-acl/__tests__/capture.test.ts
+++ b/src/cli/commands/app-acl/__tests__/capture.test.ts
@@ -114,7 +114,9 @@ describe("app-acl capture コマンド", () => {
 
     await command.run({ values: {} } as never);
 
-    expect(p.log.warn).not.toHaveBeenCalled();
+    expect(p.log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("overwritten"),
+    );
   });
 
   it("エラー発生時にhandleCliErrorで処理される", async () => {

--- a/src/cli/commands/app-acl/apply.ts
+++ b/src/cli/commands/app-acl/apply.ts
@@ -12,6 +12,10 @@ import { createApplyCommand } from "../applyCommandFactory";
 export default createApplyCommand({
   description: "Apply app access permissions from YAML to kintone app",
   args: appAclArgs,
+  deprecation: {
+    commandName: "app-acl apply",
+    replacement: "app-acl push",
+  },
   spinnerMessage: "Applying app access permissions...",
   spinnerStopMessage: "App access permissions applied.",
   successMessage: "App access permissions applied successfully.",

--- a/src/cli/commands/app-acl/capture.ts
+++ b/src/cli/commands/app-acl/capture.ts
@@ -12,6 +12,10 @@ export default createCaptureCommand({
   description:
     "Capture current app access permissions from kintone app to file",
   args: appAclArgs,
+  deprecation: {
+    commandName: "app-acl capture",
+    replacement: "app-acl pull",
+  },
   spinnerMessage: "Capturing app access permissions...",
   spinnerStopMessage: "App access permissions captured.",
   domainLabel: "App ACL",

--- a/src/cli/commands/apply.ts
+++ b/src/cli/commands/apply.ts
@@ -11,6 +11,7 @@ import type { AppEntry } from "@/core/domain/projectConfig/entity";
 import type { AppName } from "@/core/domain/projectConfig/valueObject";
 import { printApplyAllResults } from "../applyAllOutput";
 import { confirmArgs, kintoneArgs, multiAppArgs } from "../config";
+import { printDeprecationWarning } from "../deprecation";
 import { printDiffAllResults } from "../diffAllOutput";
 import { handleCliError } from "../handleError";
 import { printAppHeader } from "../output";
@@ -218,6 +219,12 @@ export default define({
   args: applyArgs,
   run: async (ctx) => {
     try {
+      printDeprecationWarning({
+        oldCommand: "apply",
+        replacement: "push",
+        note: "Use `push --force` for the legacy overwrite behavior. Legacy commands do not update local state; run pull/push to keep state in sync.",
+      });
+
       const values = ctx.values as ApplyCliValues;
       const skipConfirm = values.yes === true;
       const dryRun = values["dry-run"] === true;
@@ -225,7 +232,7 @@ export default define({
       await routeMultiApp(values, {
         singleLegacy: async () => {
           p.log.error(
-            "The 'apply' command requires a project config file.\nRun 'kintone-migrator init' to create one, or use individual apply commands (e.g. 'schema migrate').",
+            "The 'apply' command requires a project config file.\nRun 'kintone-migrator init' to create one, or use individual push commands (e.g. 'schema push').",
           );
           process.exitCode = 1;
         },

--- a/src/cli/commands/applyCommandFactory.ts
+++ b/src/cli/commands/applyCommandFactory.ts
@@ -7,6 +7,7 @@ import type {
   ProjectConfig,
 } from "@/core/domain/projectConfig/entity";
 import { confirmArgs, type WithConfirm } from "../config";
+import { printDeprecationWarning } from "../deprecation";
 import { handleCliError } from "../handleError";
 import { confirmAndDeploy, type Deployable, printAppHeader } from "../output";
 import type { MultiAppCliValues } from "../projectConfig";
@@ -20,6 +21,7 @@ type ApplyCommandConfig<
 > = {
   readonly description: string;
   readonly args: Args;
+  readonly deprecation: { commandName: string; replacement: string };
   readonly spinnerMessage: string;
   readonly spinnerStopMessage: string;
   readonly successMessage: string;
@@ -104,6 +106,11 @@ export function createApplyCommand<
     args: { ...config.args, ...confirmArgs },
     run: async (ctx) => {
       try {
+        printDeprecationWarning({
+          oldCommand: config.deprecation.commandName,
+          replacement: config.deprecation.replacement,
+        });
+
         // gunshi's ctx.values is typed as Record<string, unknown>; cast is needed
         // because the generic TCliValues carries domain-specific CLI value types.
         const values = ctx.values as TCliValues;

--- a/src/cli/commands/capture.ts
+++ b/src/cli/commands/capture.ts
@@ -5,6 +5,7 @@ import { createCliCaptureContainers } from "@/core/application/container/capture
 import { captureAllForApp } from "@/core/application/init/captureAllForApp";
 import { printCaptureAllResults } from "../captureAllOutput";
 import { kintoneArgs, multiAppArgs } from "../config";
+import { printDeprecationWarning } from "../deprecation";
 import { handleCliError } from "../handleError";
 import { printAppHeader } from "../output";
 import {
@@ -63,12 +64,18 @@ export default define({
   args: captureArgs,
   run: async (ctx) => {
     try {
+      printDeprecationWarning({
+        oldCommand: "capture",
+        replacement: "pull",
+        note: "`pull` does a 3-way merge; use `pull --force` for the legacy overwrite behavior. Legacy commands do not update local state; run pull/push to keep state in sync.",
+      });
+
       const values = ctx.values as CaptureCliValues;
 
       await routeMultiApp(values, {
         singleLegacy: async () => {
           p.log.error(
-            "The 'capture' command requires a project config file.\nRun 'kintone-migrator init' to create one, or use individual capture commands (e.g. 'schema capture').",
+            "The 'capture' command requires a project config file.\nRun 'kintone-migrator init' to create one, or use individual pull commands (e.g. 'schema pull').",
           );
           process.exitCode = 1;
         },

--- a/src/cli/commands/captureCommandFactory.ts
+++ b/src/cli/commands/captureCommandFactory.ts
@@ -6,6 +6,7 @@ import type {
   AppEntry,
   ProjectConfig,
 } from "@/core/domain/projectConfig/entity";
+import { printDeprecationWarning } from "../deprecation";
 import { handleCliError } from "../handleError";
 import { printAppHeader } from "../output";
 import type { MultiAppCliValues } from "../projectConfig";
@@ -18,6 +19,7 @@ type CaptureCommandConfig<
 > = {
   readonly description: string;
   readonly args: Args;
+  readonly deprecation: { commandName: string; replacement: string };
   readonly spinnerMessage: string;
   readonly spinnerStopMessage: string;
   readonly domainLabel: string;
@@ -80,6 +82,11 @@ export function createCaptureCommand<
     args: config.args,
     run: async (ctx) => {
       try {
+        printDeprecationWarning({
+          oldCommand: config.deprecation.commandName,
+          replacement: config.deprecation.replacement,
+        });
+
         const values = ctx.values as TCliValues;
 
         await routeMultiApp(values, {

--- a/src/cli/commands/customize/__tests__/apply.test.ts
+++ b/src/cli/commands/customize/__tests__/apply.test.ts
@@ -91,6 +91,17 @@ beforeEach(() => {
 });
 
 describe("customize apply command", () => {
+  it("should print a deprecation warning while still applying", async () => {
+    vi.mocked(applyCustomization).mockResolvedValue(undefined);
+
+    await command.run({ values: { yes: true } } as never);
+
+    expect(p.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("customize push"),
+    );
+    expect(applyCustomization).toHaveBeenCalled();
+  });
+
   it("should apply customization on success", async () => {
     vi.mocked(applyCustomization).mockResolvedValue(undefined);
 

--- a/src/cli/commands/customize/__tests__/capture.test.ts
+++ b/src/cli/commands/customize/__tests__/capture.test.ts
@@ -1,5 +1,66 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { deriveFilePrefix } from "../capture";
+
+vi.mock("@clack/prompts", () => ({
+  spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn() })),
+  log: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    step: vi.fn(),
+  },
+  note: vi.fn(),
+  outro: vi.fn(),
+  confirm: vi.fn(),
+  isCancel: vi.fn(() => false),
+  cancel: vi.fn(),
+}));
+
+vi.mock("../../../customizeConfig", () => ({
+  customizeArgs: {},
+  resolveCustomizeConfig: vi.fn(() => ({
+    customizeFilePath: "customize.yaml",
+  })),
+  resolveCustomizeAppConfig: vi.fn(),
+}));
+
+vi.mock("@/core/application/container/cli", () => ({
+  createCustomizationCliContainer: vi.fn(() => ({})),
+}));
+
+vi.mock("@/core/application/customization/captureCustomization", () => ({
+  captureCustomization: vi.fn().mockResolvedValue({
+    configText: "x",
+    hasExistingConfig: false,
+    fileResourceCount: 0,
+  }),
+}));
+
+vi.mock("@/core/application/customization/saveCustomization", () => ({
+  saveCustomization: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../../handleError", () => ({
+  handleCliError: vi.fn(),
+}));
+
+vi.mock("../../../output", () => ({
+  printAppHeader: vi.fn(),
+}));
+
+vi.mock("../../../projectConfig", () => ({
+  routeMultiApp: vi.fn(
+    async (
+      _values: unknown,
+      handlers: { singleLegacy: () => Promise<void> },
+    ) => {
+      await handlers.singleLegacy();
+    },
+  ),
+  resolveAppCliConfig: vi.fn(),
+  runMultiAppWithFailCheck: vi.fn(),
+}));
 
 describe("deriveFilePrefix", () => {
   it("customize.yaml は空文字を返す", () => {
@@ -36,5 +97,26 @@ describe("deriveFilePrefix", () => {
 
   it("ディレクトリ内の .yml ファイルも正しくファイル名を返す", () => {
     expect(deriveFilePrefix("some-dir/my-config.yml")).toBe("my-config");
+  });
+});
+
+describe("customize capture command (deprecation)", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("deprecation warning を表示しつつ capture を実行する", async () => {
+    const p = await import("@clack/prompts");
+    const { captureCustomization } = await import(
+      "@/core/application/customization/captureCustomization"
+    );
+    const command = (await import("../capture")).default;
+
+    await command.run({ values: {} } as never);
+
+    expect(p.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("customize pull"),
+    );
+    expect(captureCustomization).toHaveBeenCalled();
   });
 });

--- a/src/cli/commands/customize/apply.ts
+++ b/src/cli/commands/customize/apply.ts
@@ -16,6 +16,7 @@ import {
   resolveCustomizeAppConfig,
   resolveCustomizeConfig,
 } from "../../customizeConfig";
+import { printDeprecationWarning } from "../../deprecation";
 import { handleCliError } from "../../handleError";
 import {
   confirmAndDeploy,
@@ -90,6 +91,12 @@ export default define({
   args: { ...customizeArgs, ...confirmArgs },
   run: async (ctx) => {
     try {
+      printDeprecationWarning({
+        oldCommand: "customize apply",
+        replacement: "customize push",
+        note: "Legacy commands do not update local state; run customize pull/push to keep state in sync.",
+      });
+
       const values = ctx.values as WithConfirm<CustomizeCliValues>;
       const skipConfirm = values.yes === true;
 

--- a/src/cli/commands/customize/capture.ts
+++ b/src/cli/commands/customize/capture.ts
@@ -14,6 +14,7 @@ import {
   resolveCustomizeAppConfig,
   resolveCustomizeConfig,
 } from "../../customizeConfig";
+import { printDeprecationWarning } from "../../deprecation";
 import { handleCliError } from "../../handleError";
 import { printAppHeader } from "../../output";
 import { routeMultiApp, runMultiAppWithFailCheck } from "../../projectConfig";
@@ -80,6 +81,12 @@ export default define({
   args: customizeArgs,
   run: async (ctx) => {
     try {
+      printDeprecationWarning({
+        oldCommand: "customize capture",
+        replacement: "customize pull",
+        note: "Legacy commands do not update local state; run customize pull/push to keep state in sync.",
+      });
+
       const values = ctx.values as CustomizeCliValues;
 
       await routeMultiApp(values, {

--- a/src/cli/commands/field-acl/__tests__/capture.test.ts
+++ b/src/cli/commands/field-acl/__tests__/capture.test.ts
@@ -114,7 +114,9 @@ describe("field-acl capture コマンド", () => {
 
     await command.run({ values: {} } as never);
 
-    expect(p.log.warn).not.toHaveBeenCalled();
+    expect(p.log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("overwritten"),
+    );
   });
 
   it("エラー発生時にhandleCliErrorで処理される", async () => {

--- a/src/cli/commands/field-acl/apply.ts
+++ b/src/cli/commands/field-acl/apply.ts
@@ -12,6 +12,10 @@ import { createApplyCommand } from "../applyCommandFactory";
 export default createApplyCommand({
   description: "Apply field access permissions from YAML to kintone app",
   args: fieldAclArgs,
+  deprecation: {
+    commandName: "field-acl apply",
+    replacement: "field-acl push",
+  },
   spinnerMessage: "Applying field access permissions...",
   spinnerStopMessage: "Field access permissions applied.",
   successMessage: "Field access permissions applied successfully.",

--- a/src/cli/commands/field-acl/capture.ts
+++ b/src/cli/commands/field-acl/capture.ts
@@ -12,6 +12,10 @@ export default createCaptureCommand({
   description:
     "Capture current field access permissions from kintone app to file",
   args: fieldAclArgs,
+  deprecation: {
+    commandName: "field-acl capture",
+    replacement: "field-acl pull",
+  },
   spinnerMessage: "Capturing field access permissions...",
   spinnerStopMessage: "Field access permissions captured.",
   domainLabel: "Field ACL",

--- a/src/cli/commands/notification/__tests__/capture.test.ts
+++ b/src/cli/commands/notification/__tests__/capture.test.ts
@@ -114,7 +114,9 @@ describe("notification capture コマンド", () => {
 
     await command.run({ values: {} } as never);
 
-    expect(p.log.warn).not.toHaveBeenCalled();
+    expect(p.log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("overwritten"),
+    );
   });
 
   it("エラー発生時にhandleCliErrorで処理される", async () => {

--- a/src/cli/commands/notification/apply.ts
+++ b/src/cli/commands/notification/apply.ts
@@ -12,6 +12,10 @@ import { createApplyCommand } from "../applyCommandFactory";
 export default createApplyCommand({
   description: "Apply notification settings from YAML to kintone app",
   args: notificationArgs,
+  deprecation: {
+    commandName: "notification apply",
+    replacement: "notification push",
+  },
   spinnerMessage: "Applying notification settings...",
   spinnerStopMessage: "Notification settings applied.",
   successMessage: "Notification settings applied successfully.",

--- a/src/cli/commands/notification/capture.ts
+++ b/src/cli/commands/notification/capture.ts
@@ -11,6 +11,10 @@ import { createCaptureCommand } from "../captureCommandFactory";
 export default createCaptureCommand({
   description: "Capture current notification settings from kintone app to file",
   args: notificationArgs,
+  deprecation: {
+    commandName: "notification capture",
+    replacement: "notification pull",
+  },
   spinnerMessage: "Capturing notification settings...",
   spinnerStopMessage: "Notification settings captured.",
   domainLabel: "Notification settings",

--- a/src/cli/commands/plugin/__tests__/capture.test.ts
+++ b/src/cli/commands/plugin/__tests__/capture.test.ts
@@ -114,7 +114,9 @@ describe("plugin capture コマンド", () => {
 
     await command.run({ values: {} } as never);
 
-    expect(p.log.warn).not.toHaveBeenCalled();
+    expect(p.log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("overwritten"),
+    );
   });
 
   it("エラー発生時にhandleCliErrorで処理される", async () => {

--- a/src/cli/commands/plugin/apply.ts
+++ b/src/cli/commands/plugin/apply.ts
@@ -12,6 +12,10 @@ import { createApplyCommand } from "../applyCommandFactory";
 export default createApplyCommand({
   description: "Apply plugins from YAML to kintone app",
   args: pluginArgs,
+  deprecation: {
+    commandName: "plugin apply",
+    replacement: "plugin push",
+  },
   spinnerMessage: "Applying plugins...",
   spinnerStopMessage: "Plugins applied.",
   successMessage: "Plugins applied successfully.",

--- a/src/cli/commands/plugin/capture.ts
+++ b/src/cli/commands/plugin/capture.ts
@@ -11,6 +11,10 @@ import { createCaptureCommand } from "../captureCommandFactory";
 export default createCaptureCommand({
   description: "Capture current plugins from kintone app to file",
   args: pluginArgs,
+  deprecation: {
+    commandName: "plugin capture",
+    replacement: "plugin pull",
+  },
   spinnerMessage: "Capturing plugins...",
   spinnerStopMessage: "Plugins captured.",
   domainLabel: "Plugins",

--- a/src/cli/commands/process/__tests__/capture.test.ts
+++ b/src/cli/commands/process/__tests__/capture.test.ts
@@ -114,7 +114,9 @@ describe("process capture コマンド", () => {
 
     await command.run({ values: {} } as never);
 
-    expect(p.log.warn).not.toHaveBeenCalled();
+    expect(p.log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("overwritten"),
+    );
   });
 
   it("エラー発生時にhandleCliErrorで処理される", async () => {

--- a/src/cli/commands/process/apply.ts
+++ b/src/cli/commands/process/apply.ts
@@ -19,6 +19,10 @@ export default createApplyCommand<
 >({
   description: "Apply process management settings from YAML to kintone app",
   args: processArgs,
+  deprecation: {
+    commandName: "process apply",
+    replacement: "process push",
+  },
   spinnerMessage: "Applying process management settings...",
   spinnerStopMessage: "Process management settings applied.",
   successMessage: "Process management settings applied successfully.",

--- a/src/cli/commands/process/capture.ts
+++ b/src/cli/commands/process/capture.ts
@@ -12,6 +12,10 @@ export default createCaptureCommand({
   description:
     "Capture current process management settings from kintone app to file",
   args: processArgs,
+  deprecation: {
+    commandName: "process capture",
+    replacement: "process pull",
+  },
   spinnerMessage: "Capturing process management settings...",
   spinnerStopMessage: "Process management settings captured.",
   domainLabel: "Process management settings",

--- a/src/cli/commands/record-acl/__tests__/capture.test.ts
+++ b/src/cli/commands/record-acl/__tests__/capture.test.ts
@@ -114,7 +114,9 @@ describe("record-acl capture コマンド", () => {
 
     await command.run({ values: {} } as never);
 
-    expect(p.log.warn).not.toHaveBeenCalled();
+    expect(p.log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("overwritten"),
+    );
   });
 
   it("エラー発生時にhandleCliErrorで処理される", async () => {

--- a/src/cli/commands/record-acl/apply.ts
+++ b/src/cli/commands/record-acl/apply.ts
@@ -12,6 +12,10 @@ import { createApplyCommand } from "../applyCommandFactory";
 export default createApplyCommand({
   description: "Apply record access permissions from YAML to kintone app",
   args: recordAclArgs,
+  deprecation: {
+    commandName: "record-acl apply",
+    replacement: "record-acl push",
+  },
   spinnerMessage: "Applying record access permissions...",
   spinnerStopMessage: "Record access permissions applied.",
   successMessage: "Record access permissions applied successfully.",

--- a/src/cli/commands/record-acl/capture.ts
+++ b/src/cli/commands/record-acl/capture.ts
@@ -12,6 +12,10 @@ export default createCaptureCommand({
   description:
     "Capture current record access permissions from kintone app to file",
   args: recordAclArgs,
+  deprecation: {
+    commandName: "record-acl capture",
+    replacement: "record-acl pull",
+  },
   spinnerMessage: "Capturing record access permissions...",
   spinnerStopMessage: "Record access permissions captured.",
   domainLabel: "Record ACL",

--- a/src/cli/commands/report/__tests__/capture.test.ts
+++ b/src/cli/commands/report/__tests__/capture.test.ts
@@ -114,7 +114,9 @@ describe("report capture コマンド", () => {
 
     await command.run({ values: {} } as never);
 
-    expect(p.log.warn).not.toHaveBeenCalled();
+    expect(p.log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("overwritten"),
+    );
   });
 
   it("エラー発生時にhandleCliErrorで処理される", async () => {

--- a/src/cli/commands/report/apply.ts
+++ b/src/cli/commands/report/apply.ts
@@ -12,6 +12,10 @@ import { createApplyCommand } from "../applyCommandFactory";
 export default createApplyCommand({
   description: "Apply report settings from YAML to kintone app",
   args: reportArgs,
+  deprecation: {
+    commandName: "report apply",
+    replacement: "report push",
+  },
   spinnerMessage: "Applying report settings...",
   spinnerStopMessage: "Report settings applied.",
   successMessage: "Report settings applied successfully.",

--- a/src/cli/commands/report/capture.ts
+++ b/src/cli/commands/report/capture.ts
@@ -11,6 +11,10 @@ import { createCaptureCommand } from "../captureCommandFactory";
 export default createCaptureCommand({
   description: "Capture current report settings from kintone app to file",
   args: reportArgs,
+  deprecation: {
+    commandName: "report capture",
+    replacement: "report pull",
+  },
   spinnerMessage: "Capturing report settings...",
   spinnerStopMessage: "Report settings captured.",
   domainLabel: "Reports",

--- a/src/cli/commands/schema/__tests__/capture.test.ts
+++ b/src/cli/commands/schema/__tests__/capture.test.ts
@@ -117,7 +117,9 @@ describe("capture コマンド", () => {
 
     await command.run({ values: {} } as never);
 
-    expect(p.log.warn).not.toHaveBeenCalled();
+    expect(p.log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("overwritten"),
+    );
   });
 
   it("エラー発生時にhandleCliErrorで処理される", async () => {

--- a/src/cli/commands/schema/__tests__/capture.test.ts
+++ b/src/cli/commands/schema/__tests__/capture.test.ts
@@ -60,6 +60,22 @@ afterEach(() => {
 });
 
 describe("capture コマンド", () => {
+  it("deprecation warning を表示しつつ従来動作を実行する", async () => {
+    vi.mocked(captureSchema).mockResolvedValue({
+      schemaText: "layout:\n",
+      hasExistingSchema: false,
+    });
+    vi.mocked(saveSchema).mockResolvedValue(undefined);
+
+    await command.run({ values: {} } as never);
+
+    expect(p.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("schema pull"),
+    );
+    expect(captureSchema).toHaveBeenCalled();
+    expect(saveSchema).toHaveBeenCalled();
+  });
+
   it("現在のフォーム設定をキャプチャしてファイルに保存する", async () => {
     vi.mocked(captureSchema).mockResolvedValue({
       schemaText: "layout:\n  - type: ROW\n",

--- a/src/cli/commands/schema/__tests__/migrate.test.ts
+++ b/src/cli/commands/schema/__tests__/migrate.test.ts
@@ -115,6 +115,21 @@ function hasDiffResult(): DetectDiffOutput {
 }
 
 describe("migrate コマンド", () => {
+  it("deprecation warning を表示しつつ従来動作を実行する", async () => {
+    vi.mocked(detectDiff).mockResolvedValue(hasDiffResult());
+    vi.mocked(p.confirm).mockResolvedValue(true);
+    vi.mocked(executeMigration).mockResolvedValue(undefined);
+    vi.mocked(confirmAndDeploy).mockResolvedValue(undefined);
+
+    await command.run({ values: {} } as never);
+
+    expect(p.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("schema push"),
+    );
+    expect(detectDiff).toHaveBeenCalled();
+    expect(executeMigration).toHaveBeenCalled();
+  });
+
   it("差分がない場合、変更不要メッセージを表示して終了する", async () => {
     vi.mocked(detectDiff).mockResolvedValue(noDiffResult());
 

--- a/src/cli/commands/schema/capture.ts
+++ b/src/cli/commands/schema/capture.ts
@@ -6,6 +6,7 @@ import type { FormSchemaContainer } from "@/core/application/container/formSchem
 import { captureSchema } from "@/core/application/formSchema/captureSchema";
 import { saveSchema } from "@/core/application/formSchema/saveSchema";
 import { kintoneArgs, multiAppArgs, resolveConfig } from "../../config";
+import { printDeprecationWarning } from "../../deprecation";
 import { handleCliError } from "../../handleError";
 import { printAppHeader } from "../../output";
 import {
@@ -41,6 +42,12 @@ export default define({
   args: { ...kintoneArgs, ...multiAppArgs },
   run: async (ctx) => {
     try {
+      printDeprecationWarning({
+        oldCommand: "schema capture",
+        replacement: "schema pull",
+        note: "`schema pull` does a 3-way merge; use `schema pull --force` for the legacy overwrite behavior. Legacy commands do not update local state; run schema pull/push to keep state in sync.",
+      });
+
       await routeMultiApp(ctx.values, {
         singleLegacy: async () => {
           const config = resolveConfig(ctx.values);

--- a/src/cli/commands/schema/migrate.ts
+++ b/src/cli/commands/schema/migrate.ts
@@ -13,6 +13,7 @@ import {
   multiAppArgs,
   resolveConfig,
 } from "../../config";
+import { printDeprecationWarning } from "../../deprecation";
 import { handleCliError } from "../../handleError";
 import {
   confirmAndDeploy,
@@ -68,6 +69,12 @@ export default define({
   args: { ...kintoneArgs, ...multiAppArgs, ...confirmArgs },
   run: async (ctx) => {
     try {
+      printDeprecationWarning({
+        oldCommand: "schema migrate",
+        replacement: "schema push",
+        note: "Use `schema push --force` for the legacy overwrite behavior. Legacy commands do not update local state; run schema pull/push to keep state in sync.",
+      });
+
       const skipConfirm = ctx.values.yes === true;
 
       await routeMultiApp(ctx.values, {

--- a/src/cli/commands/seed/__tests__/push.test.ts
+++ b/src/cli/commands/seed/__tests__/push.test.ts
@@ -58,31 +58,14 @@ vi.mock("@/cli/output", () => ({
 import * as p from "@clack/prompts";
 import { handleCliError } from "@/cli/handleError";
 import { upsertSeed } from "@/core/application/seedData/upsertSeed";
-import command from "../apply";
+import command from "../push";
 
 afterEach(() => {
   vi.clearAllMocks();
 });
 
-describe("seed apply コマンド (deprecation alias)", () => {
-  it("deprecation warning を表示しつつ upsert を実行する", async () => {
-    vi.mocked(upsertSeed).mockResolvedValue({
-      added: 1,
-      updated: 0,
-      unchanged: 0,
-      deleted: 0,
-      total: 1,
-    });
-
-    await command.run({ values: {} } as never);
-
-    expect(p.log.warn).toHaveBeenCalledWith(
-      expect.stringContaining("seed push"),
-    );
-    expect(upsertSeed).toHaveBeenCalled();
-  });
-
-  it("デフォルトでupsertモードを実行する", async () => {
+describe("seed push コマンド", () => {
+  it("warning なしで upsert を実行する", async () => {
     vi.mocked(upsertSeed).mockResolvedValue({
       added: 2,
       updated: 0,
@@ -97,6 +80,9 @@ describe("seed apply コマンド (deprecation alias)", () => {
       expect.objectContaining({
         input: { clean: false },
       }),
+    );
+    expect(p.log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("deprecated"),
     );
   });
 
@@ -113,9 +99,6 @@ describe("seed apply コマンド (deprecation alias)", () => {
 
     expect(p.log.info).toHaveBeenCalledWith(expect.stringContaining("added"));
     expect(p.log.info).toHaveBeenCalledWith(expect.stringContaining("updated"));
-    expect(p.log.info).toHaveBeenCalledWith(
-      expect.stringContaining("unchanged"),
-    );
   });
 
   it("エラー発生時にhandleCliErrorで処理される", async () => {
@@ -125,19 +108,5 @@ describe("seed apply コマンド (deprecation alias)", () => {
     await command.run({ values: {} } as never);
 
     expect(handleCliError).toHaveBeenCalledWith(error);
-  });
-
-  it("削除されたレコードがある場合のサマリー表示", async () => {
-    vi.mocked(upsertSeed).mockResolvedValue({
-      added: 0,
-      updated: 0,
-      unchanged: 0,
-      deleted: 5,
-      total: 0,
-    });
-
-    await command.run({ values: { clean: true, yes: true } } as never);
-
-    expect(p.log.info).toHaveBeenCalledWith(expect.stringContaining("deleted"));
   });
 });

--- a/src/cli/commands/seed/apply.ts
+++ b/src/cli/commands/seed/apply.ts
@@ -4,7 +4,7 @@ import { runSeedPush, seedPushArgs } from "./push";
 
 /**
  * Deprecation alias for `seed push`. Kept so existing `seed apply` scripts keep
- * working; emits a warning and delegates to the same upsert run (ADR-002).
+ * working; emits a warning and delegates to the same upsert run.
  */
 export default define({
   name: "apply",

--- a/src/cli/commands/seed/apply.ts
+++ b/src/cli/commands/seed/apply.ts
@@ -1,141 +1,22 @@
-import * as p from "@clack/prompts";
 import { define } from "gunshi";
-import pc from "picocolors";
-import {
-  createSeedCliContainer,
-  type SeedCliContainerConfig,
-} from "@/core/application/container/cli";
-import { upsertSeed } from "@/core/application/seedData/upsertSeed";
-import { confirmArgs, kintoneArgs, multiAppArgs } from "../../config";
-import { handleCliError } from "../../handleError";
-import { printAppHeader } from "../../output";
-import { routeMultiApp, runMultiAppWithFailCheck } from "../../projectConfig";
-import {
-  resolveSeedAppConfig,
-  resolveSeedConfig,
-  type SeedCliValues,
-} from "./config";
+import { printDeprecationWarning } from "../../deprecation";
+import { runSeedPush, seedPushArgs } from "./push";
 
-const seedApplyArgs = {
-  ...kintoneArgs,
-  ...multiAppArgs,
-  ...confirmArgs,
-  clean: {
-    type: "boolean" as const,
-    description:
-      "Delete all existing records before applying seed data (clean apply)",
-  },
-  "seed-file": {
-    type: "string" as const,
-    short: "s",
-    description: "Seed file path (default: seed.yaml)",
-  },
-};
-
-function printUpsertResult(result: {
-  added: number;
-  updated: number;
-  unchanged: number;
-  deleted: number;
-  total: number;
-}): void {
-  const parts = [
-    result.deleted > 0 ? pc.red(`-${result.deleted} deleted`) : null,
-    result.added > 0 ? pc.green(`+${result.added} added`) : null,
-    result.updated > 0 ? pc.yellow(`~${result.updated} updated`) : null,
-    result.unchanged > 0 ? `${result.unchanged} unchanged` : null,
-  ]
-    .filter(Boolean)
-    .join(pc.dim("  |  "));
-
-  p.log.info(`Records: ${parts} (${result.total} total)`);
-}
-
-async function confirmClean(
-  skipConfirm: boolean,
-  showWarning = true,
-): Promise<boolean> {
-  if (showWarning) {
-    p.log.warn(
-      `${pc.bold(pc.red("WARNING:"))} This will delete ALL existing records before applying seed data.`,
-    );
-  }
-
-  if (!skipConfirm) {
-    const shouldContinue = await p.confirm({
-      message: "Are you sure you want to clean and re-apply seed data?",
-    });
-
-    if (p.isCancel(shouldContinue) || !shouldContinue) {
-      p.cancel("Clean seed cancelled.");
-      return false;
-    }
-  }
-
-  return true;
-}
-
-async function runUpsert(
-  config: SeedCliContainerConfig,
-  clean: boolean,
-  skipConfirm: boolean,
-  showWarning = true,
-): Promise<void> {
-  if (clean) {
-    const confirmed = await confirmClean(skipConfirm, showWarning);
-    if (!confirmed) return;
-  }
-
-  const container = createSeedCliContainer(config);
-
-  const s = p.spinner();
-  s.start(
-    clean ? "Cleaning and applying seed data..." : "Applying seed data...",
-  );
-  const result = await upsertSeed({ container, input: { clean } });
-  s.stop(clean ? "Clean seed applied." : "Seed data applied.");
-
-  printUpsertResult(result);
-}
-
+/**
+ * Deprecation alias for `seed push`. Kept so existing `seed apply` scripts keep
+ * working; emits a warning and delegates to the same upsert run (ADR-002).
+ */
 export default define({
   name: "apply",
-  description: "Apply seed data (records) to kintone app",
-  args: seedApplyArgs,
+  description:
+    "Apply seed data (records) to kintone app (deprecated alias for 'seed push')",
+  args: seedPushArgs,
   run: async (ctx) => {
-    try {
-      const values = ctx.values as SeedCliValues;
-      const clean = values.clean === true;
-      const skipConfirm = values.yes === true;
-
-      await routeMultiApp(values, {
-        singleLegacy: async () => {
-          const config = resolveSeedConfig(values);
-          await runUpsert(config, clean, skipConfirm);
-        },
-        singleApp: async (app, projectConfig) => {
-          const config = resolveSeedAppConfig(app, projectConfig, values);
-          await runUpsert(config, clean, skipConfirm);
-        },
-        multiApp: async (plan, projectConfig) => {
-          if (clean) {
-            const confirmed = await confirmClean(skipConfirm);
-            if (!confirmed) return;
-          }
-
-          await runMultiAppWithFailCheck(
-            plan,
-            async (app) => {
-              const config = resolveSeedAppConfig(app, projectConfig, values);
-              printAppHeader(app.name, app.appId);
-              await runUpsert(config, clean, true, false);
-            },
-            "All seed applications completed successfully.",
-          );
-        },
-      });
-    } catch (error) {
-      handleCliError(error);
-    }
+    printDeprecationWarning({
+      oldCommand: "seed apply",
+      replacement: "seed push",
+      note: "seed has no 3-way merge; behavior is plain upsert without drift guard.",
+    });
+    await runSeedPush(ctx);
   },
 });

--- a/src/cli/commands/seed/index.ts
+++ b/src/cli/commands/seed/index.ts
@@ -1,11 +1,16 @@
 import { define } from "gunshi";
 import applyCommand from "./apply";
 import captureCommand from "./capture";
+import pushCommand from "./push";
 
+// `pull` is intentionally not added: seed is out of scope for 3-way merge, so it
+// has no `seed pull` counterpart to `seed push`. `seed capture` stays as-is
+// (ADR-003). `apply` remains as a deprecation alias for `push` (ADR-002).
 export default define({
   name: "seed",
   description: "Manage kintone seed data (records)",
   subCommands: {
+    push: pushCommand,
     apply: applyCommand,
     capture: captureCommand,
   },

--- a/src/cli/commands/seed/index.ts
+++ b/src/cli/commands/seed/index.ts
@@ -4,8 +4,8 @@ import captureCommand from "./capture";
 import pushCommand from "./push";
 
 // `pull` is intentionally not added: seed is out of scope for 3-way merge, so it
-// has no `seed pull` counterpart to `seed push`. `seed capture` stays as-is
-// (ADR-003). `apply` remains as a deprecation alias for `push` (ADR-002).
+// has no `seed pull` counterpart to `seed push`. `seed capture` stays as-is.
+// `apply` remains as a deprecation alias for `push`.
 export default define({
   name: "seed",
   description: "Manage kintone seed data (records)",

--- a/src/cli/commands/seed/push.ts
+++ b/src/cli/commands/seed/push.ts
@@ -1,0 +1,149 @@
+import * as p from "@clack/prompts";
+import { type CommandContext, define } from "gunshi";
+import pc from "picocolors";
+import {
+  createSeedCliContainer,
+  type SeedCliContainerConfig,
+} from "@/core/application/container/cli";
+import { upsertSeed } from "@/core/application/seedData/upsertSeed";
+import { confirmArgs, kintoneArgs, multiAppArgs } from "../../config";
+import { handleCliError } from "../../handleError";
+import { printAppHeader } from "../../output";
+import { routeMultiApp, runMultiAppWithFailCheck } from "../../projectConfig";
+import {
+  resolveSeedAppConfig,
+  resolveSeedConfig,
+  type SeedCliValues,
+} from "./config";
+
+export const seedPushArgs = {
+  ...kintoneArgs,
+  ...multiAppArgs,
+  ...confirmArgs,
+  clean: {
+    type: "boolean" as const,
+    description:
+      "Delete all existing records before applying seed data (clean apply)",
+  },
+  "seed-file": {
+    type: "string" as const,
+    short: "s",
+    description: "Seed file path (default: seed.yaml)",
+  },
+};
+
+function printUpsertResult(result: {
+  added: number;
+  updated: number;
+  unchanged: number;
+  deleted: number;
+  total: number;
+}): void {
+  const parts = [
+    result.deleted > 0 ? pc.red(`-${result.deleted} deleted`) : null,
+    result.added > 0 ? pc.green(`+${result.added} added`) : null,
+    result.updated > 0 ? pc.yellow(`~${result.updated} updated`) : null,
+    result.unchanged > 0 ? `${result.unchanged} unchanged` : null,
+  ]
+    .filter(Boolean)
+    .join(pc.dim("  |  "));
+
+  p.log.info(`Records: ${parts} (${result.total} total)`);
+}
+
+async function confirmClean(
+  skipConfirm: boolean,
+  showWarning = true,
+): Promise<boolean> {
+  if (showWarning) {
+    p.log.warn(
+      `${pc.bold(pc.red("WARNING:"))} This will delete ALL existing records before applying seed data.`,
+    );
+  }
+
+  if (!skipConfirm) {
+    const shouldContinue = await p.confirm({
+      message: "Are you sure you want to clean and re-apply seed data?",
+    });
+
+    if (p.isCancel(shouldContinue) || !shouldContinue) {
+      p.cancel("Clean seed cancelled.");
+      return false;
+    }
+  }
+
+  return true;
+}
+
+async function runUpsert(
+  config: SeedCliContainerConfig,
+  clean: boolean,
+  skipConfirm: boolean,
+  showWarning = true,
+): Promise<void> {
+  if (clean) {
+    const confirmed = await confirmClean(skipConfirm, showWarning);
+    if (!confirmed) return;
+  }
+
+  const container = createSeedCliContainer(config);
+
+  const s = p.spinner();
+  s.start(
+    clean ? "Cleaning and applying seed data..." : "Applying seed data...",
+  );
+  const result = await upsertSeed({ container, input: { clean } });
+  s.stop(clean ? "Clean seed applied." : "Seed data applied.");
+
+  printUpsertResult(result);
+}
+
+/**
+ * Shared `run` body for `seed push` and its `seed apply` deprecation alias. seed
+ * is out of scope for 3-way merge (see ADR-003); this performs a plain upsert
+ * without the drift guard the other domains' push commands apply.
+ */
+export async function runSeedPush(ctx: CommandContext): Promise<void> {
+  try {
+    const values = ctx.values as SeedCliValues;
+    const clean = values.clean === true;
+    const skipConfirm = values.yes === true;
+
+    await routeMultiApp(values, {
+      singleLegacy: async () => {
+        const config = resolveSeedConfig(values);
+        await runUpsert(config, clean, skipConfirm);
+      },
+      singleApp: async (app, projectConfig) => {
+        const config = resolveSeedAppConfig(app, projectConfig, values);
+        await runUpsert(config, clean, skipConfirm);
+      },
+      multiApp: async (plan, projectConfig) => {
+        if (clean) {
+          const confirmed = await confirmClean(skipConfirm);
+          if (!confirmed) return;
+        }
+
+        await runMultiAppWithFailCheck(
+          plan,
+          async (app) => {
+            const config = resolveSeedAppConfig(app, projectConfig, values);
+            printAppHeader(app.name, app.appId);
+            await runUpsert(config, clean, true, false);
+          },
+          "All seed applications completed successfully.",
+        );
+      },
+    });
+  } catch (error) {
+    handleCliError(error);
+  }
+}
+
+export default define({
+  name: "push",
+  description:
+    "Push seed data (records) to kintone app. seed is out of scope for 3-way merge: this is a plain upsert with no drift guard.",
+  args: seedPushArgs,
+  run: runSeedPush,
+});

--- a/src/cli/commands/seed/push.ts
+++ b/src/cli/commands/seed/push.ts
@@ -23,7 +23,7 @@ export const seedPushArgs = {
   clean: {
     type: "boolean" as const,
     description:
-      "Delete all existing records before applying seed data (clean apply)",
+      "Delete all existing records before upserting seed data (clean push)",
   },
   "seed-file": {
     type: "string" as const,
@@ -57,13 +57,13 @@ async function confirmClean(
 ): Promise<boolean> {
   if (showWarning) {
     p.log.warn(
-      `${pc.bold(pc.red("WARNING:"))} This will delete ALL existing records before applying seed data.`,
+      `${pc.bold(pc.red("WARNING:"))} This will delete ALL existing records before upserting seed data.`,
     );
   }
 
   if (!skipConfirm) {
     const shouldContinue = await p.confirm({
-      message: "Are you sure you want to clean and re-apply seed data?",
+      message: "Are you sure you want to clean and re-push seed data?",
     });
 
     if (p.isCancel(shouldContinue) || !shouldContinue) {
@@ -90,10 +90,10 @@ async function runUpsert(
 
   const s = p.spinner();
   s.start(
-    clean ? "Cleaning and applying seed data..." : "Applying seed data...",
+    clean ? "Cleaning and upserting seed data..." : "Upserting seed data...",
   );
   const result = await upsertSeed({ container, input: { clean } });
-  s.stop(clean ? "Clean seed applied." : "Seed data applied.");
+  s.stop(clean ? "Clean seed upserted." : "Seed data upserted.");
 
   printUpsertResult(result);
 }
@@ -131,7 +131,7 @@ export async function runSeedPush(ctx: CommandContext): Promise<void> {
             printAppHeader(app.name, app.appId);
             await runUpsert(config, clean, true, false);
           },
-          "All seed applications completed successfully.",
+          "All seed pushes completed successfully.",
         );
       },
     });

--- a/src/cli/commands/seed/push.ts
+++ b/src/cli/commands/seed/push.ts
@@ -100,8 +100,8 @@ async function runUpsert(
 
 /**
  * Shared `run` body for `seed push` and its `seed apply` deprecation alias. seed
- * is out of scope for 3-way merge (see ADR-003); this performs a plain upsert
- * without the drift guard the other domains' push commands apply.
+ * is out of scope for 3-way merge; this performs a plain upsert without the drift
+ * guard the other domains' push commands apply.
  */
 export async function runSeedPush(ctx: CommandContext): Promise<void> {
   try {

--- a/src/cli/commands/settings/__tests__/capture.test.ts
+++ b/src/cli/commands/settings/__tests__/capture.test.ts
@@ -114,7 +114,9 @@ describe("settings capture command", () => {
 
     await command.run({ values: {} } as never);
 
-    expect(p.log.warn).not.toHaveBeenCalled();
+    expect(p.log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("overwritten"),
+    );
   });
 
   it("should handle errors with handleCliError", async () => {

--- a/src/cli/commands/settings/apply.ts
+++ b/src/cli/commands/settings/apply.ts
@@ -12,6 +12,10 @@ import { createApplyCommand } from "../applyCommandFactory";
 export default createApplyCommand({
   description: "Apply general settings from YAML to kintone app",
   args: settingsArgs,
+  deprecation: {
+    commandName: "settings apply",
+    replacement: "settings push",
+  },
   spinnerMessage: "Applying general settings...",
   spinnerStopMessage: "General settings applied.",
   successMessage: "General settings applied successfully.",

--- a/src/cli/commands/settings/capture.ts
+++ b/src/cli/commands/settings/capture.ts
@@ -11,6 +11,10 @@ import { createCaptureCommand } from "../captureCommandFactory";
 export default createCaptureCommand({
   description: "Capture current general settings from kintone app to file",
   args: settingsArgs,
+  deprecation: {
+    commandName: "settings capture",
+    replacement: "settings pull",
+  },
   spinnerMessage: "Capturing general settings...",
   spinnerStopMessage: "General settings captured.",
   domainLabel: "General settings",

--- a/src/cli/commands/view/__tests__/capture.test.ts
+++ b/src/cli/commands/view/__tests__/capture.test.ts
@@ -114,7 +114,9 @@ describe("view capture command", () => {
 
     await command.run({ values: {} } as never);
 
-    expect(p.log.warn).not.toHaveBeenCalled();
+    expect(p.log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("overwritten"),
+    );
   });
 
   it("should handle errors with handleCliError", async () => {

--- a/src/cli/commands/view/apply.ts
+++ b/src/cli/commands/view/apply.ts
@@ -19,6 +19,10 @@ export default createApplyCommand<
 >({
   description: "Apply view settings from YAML to kintone app",
   args: viewArgs,
+  deprecation: {
+    commandName: "view apply",
+    replacement: "view push",
+  },
   spinnerMessage: "Applying views...",
   spinnerStopMessage: "Views applied.",
   successMessage: "Views applied successfully.",

--- a/src/cli/commands/view/capture.ts
+++ b/src/cli/commands/view/capture.ts
@@ -11,6 +11,10 @@ import { createCaptureCommand } from "../captureCommandFactory";
 export default createCaptureCommand({
   description: "Capture current view settings from kintone app to file",
   args: viewArgs,
+  deprecation: {
+    commandName: "view capture",
+    replacement: "view pull",
+  },
   spinnerMessage: "Capturing views...",
   spinnerStopMessage: "Views captured.",
   domainLabel: "Views",

--- a/src/cli/deprecation.ts
+++ b/src/cli/deprecation.ts
@@ -3,10 +3,9 @@ import pc from "picocolors";
 
 /**
  * Prints a one-line deprecation warning steering users from a legacy command to
- * its pull/push successor. Emitted via `p.log.warn` (clack's default stdout
- * stream) like every other human-facing log in this CLI. It is a single human
- * note line: it does not change the exit code and does not pollute the
- * machine-readable data (saved config files, diff/JSON output).
+ * its pull/push successor. Emitted via `p.log.warn` so it stays a human-facing
+ * note: it does not change the exit code and does not pollute machine-readable
+ * output (saved config files, diff/JSON).
  */
 export function printDeprecationWarning(args: {
   oldCommand: string;

--- a/src/cli/deprecation.ts
+++ b/src/cli/deprecation.ts
@@ -1,0 +1,20 @@
+import * as p from "@clack/prompts";
+import pc from "picocolors";
+
+/**
+ * Prints a one-line deprecation warning steering users from a legacy command to
+ * its pull/push successor. Emitted via `p.log.warn` (clack's default stdout
+ * stream) like every other human-facing log in this CLI. It is a single human
+ * note line: it does not change the exit code and does not pollute the
+ * machine-readable data (saved config files, diff/JSON output).
+ */
+export function printDeprecationWarning(args: {
+  oldCommand: string;
+  replacement: string;
+  note?: string;
+}): void {
+  const { oldCommand, replacement, note } = args;
+  const prefix = pc.yellow("[deprecated]");
+  const head = `${prefix} \`${oldCommand}\` is deprecated and will be removed in a future major version. Use \`${replacement}\` instead.`;
+  p.log.warn(note ? `${head}\n${pc.dim(note)}` : head);
+}


### PR DESCRIPTION
## Summary
- 共通ヘルパー `src/cli/deprecation.ts`（`printDeprecationWarning`）を新設
- apply/capture factory に必須 `deprecation` フィールドを追加し、factory 経由 11 ドメインの `apply`/`capture` へ一括で deprecation warning を付与
- 手書き 6 コマンド（top-level `apply`/`capture`、`schema migrate`/`schema capture`、`customize apply`/`customize capture`）に warning を直挿し
- top-level `apply`/`capture` の `singleLegacy` 案内文言を旧コマンドではなく `push`/`pull` 系へ更新
- `seed push` を新設（seed は 3-way merge 非対象・従来どおりの upsert・drift ガードなしを description に明記）し、旧 `seed apply` は `seed push` へ委譲する deprecation alias として残す（`seed capture` は据え置き）
- README に deprecated 表記・移行先・`seed push` を反映
- 動作は一切変えていない（warning 追加と `seed push` 新設のみ）

## Issue
Closes #189

## Implementation Plan
Based on `.issue/189/plan.md`（中〜大規模、計画レビュー2周で収束）

## Test plan

### デプロイ・動作確認方法
CLI ツールのため Web サーバー・デプロイは無し。`pnpm dev <subcommand>` で確認:
- `pnpm dev schema migrate` → `[deprecated]` warning（`schema push` 案内）後に従来処理
- `pnpm dev seed apply` → warning（`seed push` 案内）後に upsert（alias）
- `pnpm dev seed push` → warning なしで upsert
- `pnpm dev seed --help` → `push`/`apply`(deprecated alias)/`capture`、`pull` 無し

### 確認項目
- 旧コマンド（top-level apply/capture、schema migrate/capture、12 設定ドメインの apply/capture、seed apply alias）で warning 表示＋従来動作維持
- `pull`/`push`/`diff`/`schema override`/`dump`/`validate`/`seed capture` には warning が出ないこと
- warning は人間向け 1 行で exit code・機械可読出力を破壊しない

### 自動テスト
- `pnpm typecheck` PASS / `pnpm lint` PASS（既存 `any` 警告2件のみ）/ `pnpm format` 変更なし / `pnpm test` 2794 passed

## Browser Verification
- スキップ理由: Web UI なし（dev/start 系の Web サーバー不在、UI ファイル不在、testing.md は全項目が CLI コマンド実行）。CLI スモーク確認はローカルで実施済み（warning 表示・seed push/alias・help を目視確認）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)