### PR TITLE
fix(notification): daysLater/hoursLater が負値を誤って拒否するバグを修正

### DIFF
--- a/spec/domains/notification.md
+++ b/spec/domains/notification.md
@@ -77,8 +77,6 @@ type ReminderNotification = Readonly<{
 - `time` は通知時刻（オプション）
 - `hoursLater` と `time` は同時に指定できない。両方指定された場合は `BusinessRuleError(NT_CONFLICTING_TIMING_FIELDS)` をスローする
 
-> ⚠️ **実装フォローアップ**: 現状の実装 `src/core/domain/notification/services/configParser.ts` は `daysLater`/`hoursLater` を**非負整数のみ許可**し、負値を `NT_INVALID_DAYS_LATER`/`NT_INVALID_HOURS_LATER` で拒否している。これは kintone REST API（[update-reminder-notification-settings](https://cybozu.dev/ja/kintone/docs/rest-api/apps/settings/update-reminder-notification-settings/)）が許容する正当な設定（−10,000〜10,000、負値=基準日時より前）を弾く**実装バグ**であり、本仕様（負値許容・範囲チェック）に合わせて修正が必要。
-
 ### ReminderNotificationConfig
 
 リマインダー通知の全体設定。

--- a/spec/fileFormats/notification.md
+++ b/spec/fileFormats/notification.md
@@ -122,8 +122,6 @@ reminder:
     - `hoursLater`: 追加時間（**−10,000〜10,000 の整数**、負値は基準日時より前、オプション）。`time` と同時に指定できない
     - `time`: 通知時刻（`"HH:MM"`、オプション）。`hoursLater` と同時に指定できない
 
-> ⚠️ **実装フォローアップ**: 現状の実装は `daysLater`/`hoursLater` を非負整数のみ許可し負値を拒否しているが、これは kintone REST API（[update-reminder-notification-settings](https://cybozu.dev/ja/kintone/docs/rest-api/apps/settings/update-reminder-notification-settings/)）の仕様（−10,000〜10,000・負値許容）に反する**実装バグ**。本仕様に合わせた修正が必要。
-
 ## バリデーション
 
 パース時に以下を検証する。詳細は [Notification ドメイン仕様](../domains/notification.md) を参照。

--- a/src/core/domain/notification/services/__tests__/configParser.test.ts
+++ b/src/core/domain/notification/services/__tests__/configParser.test.ts
@@ -1023,6 +1023,25 @@ describe("NotificationConfigParser.parse", () => {
     expect(config.reminder?.notifications[0].daysLater).toBe(-10000);
   });
 
+  it("should accept daysLater at the upper bound", () => {
+    const config = NotificationConfigParser.parse({
+      reminder: {
+        timezone: "Asia/Tokyo",
+        notifications: [
+          {
+            code: "due_date",
+            daysLater: 10000,
+            hoursLater: 9,
+            filterCond: "",
+            title: "Due",
+            targets: [{ entity: { type: "USER", code: "admin" } }],
+          },
+        ],
+      },
+    });
+    expect(config.reminder?.notifications[0].daysLater).toBe(10000);
+  });
+
   it("should throw NtInvalidDaysLater for daysLater above the upper bound", () => {
     expect(() =>
       NotificationConfigParser.parse({
@@ -1088,6 +1107,25 @@ describe("NotificationConfigParser.parse", () => {
       },
     });
     expect(config.reminder?.notifications[0].hoursLater).toBe(-3);
+  });
+
+  it("should accept hoursLater at the upper bound", () => {
+    const config = NotificationConfigParser.parse({
+      reminder: {
+        timezone: "Asia/Tokyo",
+        notifications: [
+          {
+            code: "due_date",
+            daysLater: 1,
+            hoursLater: 10000,
+            filterCond: "",
+            title: "Due",
+            targets: [{ entity: { type: "USER", code: "admin" } }],
+          },
+        ],
+      },
+    });
+    expect(config.reminder?.notifications[0].hoursLater).toBe(10000);
   });
 
   it("should throw NtInvalidHoursLater for hoursLater above the upper bound", () => {

--- a/src/core/domain/notification/services/__tests__/configParser.test.ts
+++ b/src/core/domain/notification/services/__tests__/configParser.test.ts
@@ -902,24 +902,23 @@ describe("NotificationConfigParser.parse", () => {
     );
   });
 
-  it("reminderのdaysLaterが負数でエラー", () => {
-    expect(() =>
-      NotificationConfigParser.parse({
-        reminder: {
-          timezone: "Asia/Tokyo",
-          notifications: [
-            {
-              code: "due_date",
-              daysLater: -1,
-              hoursLater: 9,
-              filterCond: "",
-              title: "Due",
-              targets: [{ entity: { type: "USER", code: "admin" } }],
-            },
-          ],
-        },
-      }),
-    ).toThrow(BusinessRuleError);
+  it("reminderのdaysLaterが負数（基準日時より前）を許容する", () => {
+    const config = NotificationConfigParser.parse({
+      reminder: {
+        timezone: "Asia/Tokyo",
+        notifications: [
+          {
+            code: "due_date",
+            daysLater: -3,
+            hoursLater: 9,
+            filterCond: "",
+            title: "Due in 3 days",
+            targets: [{ entity: { type: "USER", code: "admin" } }],
+          },
+        ],
+      },
+    });
+    expect(config.reminder?.notifications[0].daysLater).toBe(-3);
   });
 
   it("reminderのhoursLaterが小数でエラー", () => {
@@ -1005,7 +1004,26 @@ describe("NotificationConfigParser.parse", () => {
     );
   });
 
-  it("should throw NtInvalidDaysLater for negative daysLater", () => {
+  it("should accept negative daysLater within range", () => {
+    const config = NotificationConfigParser.parse({
+      reminder: {
+        timezone: "Asia/Tokyo",
+        notifications: [
+          {
+            code: "due_date",
+            daysLater: -10000,
+            hoursLater: 9,
+            filterCond: "",
+            title: "Due",
+            targets: [{ entity: { type: "USER", code: "admin" } }],
+          },
+        ],
+      },
+    });
+    expect(config.reminder?.notifications[0].daysLater).toBe(-10000);
+  });
+
+  it("should throw NtInvalidDaysLater for daysLater above the upper bound", () => {
     expect(() =>
       NotificationConfigParser.parse({
         reminder: {
@@ -1013,7 +1031,7 @@ describe("NotificationConfigParser.parse", () => {
           notifications: [
             {
               code: "due_date",
-              daysLater: -1,
+              daysLater: 10001,
               hoursLater: 9,
               filterCond: "",
               title: "Due",
@@ -1025,6 +1043,97 @@ describe("NotificationConfigParser.parse", () => {
     ).toThrow(
       expect.objectContaining({
         code: NotificationErrorCode.NtInvalidDaysLater,
+      }),
+    );
+  });
+
+  it("should throw NtInvalidDaysLater for daysLater below the lower bound", () => {
+    expect(() =>
+      NotificationConfigParser.parse({
+        reminder: {
+          timezone: "Asia/Tokyo",
+          notifications: [
+            {
+              code: "due_date",
+              daysLater: -10001,
+              hoursLater: 9,
+              filterCond: "",
+              title: "Due",
+              targets: [{ entity: { type: "USER", code: "admin" } }],
+            },
+          ],
+        },
+      }),
+    ).toThrow(
+      expect.objectContaining({
+        code: NotificationErrorCode.NtInvalidDaysLater,
+      }),
+    );
+  });
+
+  it("should accept negative hoursLater within range", () => {
+    const config = NotificationConfigParser.parse({
+      reminder: {
+        timezone: "Asia/Tokyo",
+        notifications: [
+          {
+            code: "due_date",
+            daysLater: 1,
+            hoursLater: -3,
+            filterCond: "",
+            title: "Due",
+            targets: [{ entity: { type: "USER", code: "admin" } }],
+          },
+        ],
+      },
+    });
+    expect(config.reminder?.notifications[0].hoursLater).toBe(-3);
+  });
+
+  it("should throw NtInvalidHoursLater for hoursLater above the upper bound", () => {
+    expect(() =>
+      NotificationConfigParser.parse({
+        reminder: {
+          timezone: "Asia/Tokyo",
+          notifications: [
+            {
+              code: "due_date",
+              daysLater: 1,
+              hoursLater: 10001,
+              filterCond: "",
+              title: "Due",
+              targets: [{ entity: { type: "USER", code: "admin" } }],
+            },
+          ],
+        },
+      }),
+    ).toThrow(
+      expect.objectContaining({
+        code: NotificationErrorCode.NtInvalidHoursLater,
+      }),
+    );
+  });
+
+  it("should throw NtInvalidHoursLater for hoursLater below the lower bound", () => {
+    expect(() =>
+      NotificationConfigParser.parse({
+        reminder: {
+          timezone: "Asia/Tokyo",
+          notifications: [
+            {
+              code: "due_date",
+              daysLater: 1,
+              hoursLater: -10001,
+              filterCond: "",
+              title: "Due",
+              targets: [{ entity: { type: "USER", code: "admin" } }],
+            },
+          ],
+        },
+      }),
+    ).toThrow(
+      expect.objectContaining({
+        code: NotificationErrorCode.NtInvalidHoursLater,
       }),
     );
   });

--- a/src/core/domain/notification/services/configParser.ts
+++ b/src/core/domain/notification/services/configParser.ts
@@ -14,6 +14,10 @@ import { NotificationErrorCode } from "../errorCode";
 import type { NotificationEntity } from "../valueObject";
 import { isNotificationEntityType } from "../valueObject";
 
+// kintone REST API が許容する daysLater/hoursLater の範囲（負値は基準日時より前を表す）
+const REMINDER_OFFSET_MIN = -10000;
+const REMINDER_OFFSET_MAX = 10000;
+
 function parseEntity(raw: unknown, context: string): NotificationEntity {
   if (!isRecord(raw)) {
     throw new BusinessRuleError(
@@ -204,10 +208,14 @@ function parseReminderNotification(
     );
   }
 
-  if (!Number.isInteger(raw.daysLater) || raw.daysLater < 0) {
+  if (
+    !Number.isInteger(raw.daysLater) ||
+    raw.daysLater < REMINDER_OFFSET_MIN ||
+    raw.daysLater > REMINDER_OFFSET_MAX
+  ) {
     throw new BusinessRuleError(
       NotificationErrorCode.NtInvalidDaysLater,
-      `Reminder notification at index ${index} has invalid "daysLater": ${raw.daysLater}. Must be a non-negative integer`,
+      `Reminder notification at index ${index} has invalid "daysLater": ${raw.daysLater}. Must be an integer between ${REMINDER_OFFSET_MIN} and ${REMINDER_OFFSET_MAX}`,
     );
   }
 
@@ -221,16 +229,17 @@ function parseReminderNotification(
     );
   }
 
-  // Validate that hoursLater is a non-negative integer when present
+  // Validate that hoursLater is an integer within range when present
   if (
     hasHoursLater &&
     (typeof raw.hoursLater !== "number" ||
       !Number.isInteger(raw.hoursLater) ||
-      raw.hoursLater < 0)
+      raw.hoursLater < REMINDER_OFFSET_MIN ||
+      raw.hoursLater > REMINDER_OFFSET_MAX)
   ) {
     throw new BusinessRuleError(
       NotificationErrorCode.NtInvalidHoursLater,
-      `Reminder notification at index ${index} has invalid "hoursLater": ${String(raw.hoursLater)}. Must be a non-negative integer`,
+      `Reminder notification at index ${index} has invalid "hoursLater": ${String(raw.hoursLater)}. Must be an integer between ${REMINDER_OFFSET_MIN} and ${REMINDER_OFFSET_MAX}`,
     );
   }
 

--- a/src/core/domain/notification/services/configParser.ts
+++ b/src/core/domain/notification/services/configParser.ts
@@ -229,7 +229,6 @@ function parseReminderNotification(
     );
   }
 
-  // Validate that hoursLater is an integer within range when present
   if (
     hasHoursLater &&
     (typeof raw.hoursLater !== "number" ||


### PR DESCRIPTION
## 概要

Closes #173

リマインダー通知の `daysLater` / `hoursLater` のバリデーションが**非負整数のみ**を許可し、負値を誤って拒否していた実装バグを修正する。

kintone REST API（[update-reminder-notification-settings](https://cybozu.dev/ja/kintone/docs/rest-api/apps/settings/update-reminder-notification-settings/)）は `daysLater` / `hoursLater` に **−10,000〜10,000 の整数**を許容し、**負値は「基準日時より前」を表す正当な値**（例: 締切の3日前リマインダー = `-3`）。従来の `< 0` 拒否は API が許容する正当な設定を弾いていた。

## 変更内容

- `configParser.ts`: `REMINDER_OFFSET_MIN`(-10000) / `REMINDER_OFFSET_MAX`(10000) 定数を導入し、`daysLater` / `hoursLater` のバリデーションを `< 0` 拒否から範囲チェック（整数 & −10,000〜10,000）に変更。エラーメッセージも更新。
- `configParser.test.ts`: 負値拒否前提のテスト2件を「負値許容」に書き換え。`daysLater` / `hoursLater` それぞれの範囲外（±10,001）拒否テストを追加。
- `spec/domains/notification.md` / `spec/fileFormats/notification.md`: 実装が仕様に追いついたため ⚠️ 実装フォローアップ注記を削除。

## 受け入れ基準

- `daysLater: -3` / `hoursLater: -3` が正当な値としてパースされる（負値許容）
- 範囲外（±10,001）は `NT_INVALID_DAYS_LATER` / `NT_INVALID_HOURS_LATER` をスロー
- 非整数（小数）は従来どおり拒否
- 既存の正常系（0・正の整数）は引き続きパース可能

## 確認

- `pnpm typecheck` ✅
- `pnpm test` ✅（291 files / 2804 tests passed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)