### PR TITLE
fix(plugin): apply が enabled:false を無視して追加・有効化する問題を修正

### DIFF
--- a/spec/usecases/plugin.md
+++ b/spec/usecases/plugin.md
@@ -16,16 +16,32 @@
 2. ファイルが存在しない（`exists` が `false`）場合、`ValidationError` をスローする
 3. `PluginConfigParser.parse()` でプラグイン設定をパースする
 4. `PluginConfigurator.getPlugins()` で現在のプラグイン一覧とrevisionを取得する
-5. 設定ファイルのプラグインを `enabled` に応じて振り分ける
+5. 設定ファイルのプラグインを `enabled` とリモートの現状（`get-app-plugins` が返す `id`/`enabled`）に応じて振り分ける
    - `enabled: true` かつリモートに未追加のプラグイン → 追加対象（`add-app-plugins`）
    - `enabled: true` かつリモートに追加済みのプラグイン → 何もしない（冪等）
-   - `enabled: false` のプラグイン → **スキップし警告を出力する**（無効化は API 非対応のため、kintone の管理画面で手動対応が必要である旨を案内する。エラーにはしない）
+   - `enabled: false` かつリモートに未追加のプラグイン → **スキップし警告対象にする**（追加すると有効化されてしまうため追加しない。無効化は API 非対応で kintone の管理画面で手動対応が必要である旨を案内する）
+   - `enabled: false` かつリモートに追加済み かつ リモートが `enabled: true`（無効化したいが API 非対応）のプラグイン → **スキップし警告対象にする**（無効化は反映できず手動対応が必要）
+   - `enabled: false` かつリモートに追加済み かつ リモートが `enabled: false`（既に意図どおり）のプラグイン → 何もしない（過剰警告を避けるため警告対象にしない）
+   - いずれの警告もエラーにはせず apply は継続する
 6. 追加対象が1件以上ある場合、`PluginConfigurator.addPlugins()` でまとめて追加する（取得した `revision` を引き渡す）
 7. 設定ファイルに存在しないリモートのプラグインは保持し、削除しない（マージ方式）
 
 ### 出力DTO
 
-なし（`void`）
+```typescript
+type SkippedPlugin = {
+  readonly pluginId: string;
+  // disabled: enabled:false だが kintone プラグイン API では表現できない
+  // （無効状態で追加する手段も既存プラグインを無効化する手段も無い）。
+  // kintone 管理画面での手動対応が必要。
+  readonly reason: "disabled";
+};
+
+type ApplyPluginOutput = {
+  readonly addedPluginIds: readonly string[];
+  readonly skipped: readonly SkippedPlugin[];
+};
+```
 
 ### テストケース
 
@@ -35,7 +51,9 @@
 - `enabled: true` で既にリモートに追加済みのプラグインは追加対象に含まれない（冪等）
 - 追加対象が0件の場合、`addPlugins()` は呼ばれない
 - 設定ファイルに存在しないリモートのプラグインは保持され、削除されない
-- `enabled: false` のプラグインはスキップされ、無効化は手動対応が必要である旨の警告が出力される（apply 全体はエラーにならず継続する）
+- `enabled: false` かつリモート未追加のプラグインは追加されず、`skipped`（`reason: "disabled"`）として警告対象になる（apply 全体はエラーにならず継続する）
+- `enabled: false` かつリモート追加済み かつ リモートが `enabled: true`（無効化意図・API 非対応）のプラグインは `skipped` として警告対象になる
+- `enabled: false` かつリモート追加済み かつ リモートが `enabled: false`（既に意図どおり）のプラグインは過剰警告を避けるため `skipped` に含まれない
 - capture で取り込んだ `enabled: false` のプラグインを apply しても、その無効化状態は再現されない（ラウンドトリップの非対称。API 制約として許容する）
 
 #### 異常系
@@ -191,7 +209,7 @@ type SavePluginInput = {
 - `PluginConfigurator` → kintone REST APIアダプター（`get-app-plugins` / `add-app-plugins`）
 - 設定ファイルパス → `--plugin-file` / `PLUGIN_FILE_PATH` から取得（デフォルト: `plugins.yaml`、マルチアプリ: `plugin/<appName>.yaml`）
 - 適用前に `detectPluginDiff` で差分プレビューを表示し、差分がなければ何もしない。差分がある場合は確認プロンプト（`--yes` でスキップ可）の後に適用する
-- apply はマージ（追加のみ）。`enabled: false` のプラグインはスキップされ、無効化が手動対応である旨の警告が表示される
+- apply はマージ（追加のみ）。`enabled: false` のプラグインは、リモート未追加（追加すると有効化されるため見送り）またはリモート追加済み×リモート `enabled: true`（無効化意図・API 非対応）の場合に警告対象としてスキップされ、kintone 管理画面での手動対応が必要である旨が表示される。リモートが既に `enabled: false`（意図どおり）の場合は過剰警告を避けるため警告しない
 - 適用後、`confirmAndDeploy` で運用環境への反映（デプロイ）を確認する
 
 ### plugin captureコマンド

--- a/src/cli/commands/plugin/__tests__/apply.test.ts
+++ b/src/cli/commands/plugin/__tests__/apply.test.ts
@@ -155,6 +155,24 @@ describe("plugin apply コマンド", () => {
     );
   });
 
+  it("skipped が複数件のとき各 pluginId が警告文に列挙される", async () => {
+    vi.mocked(applyPlugin).mockResolvedValue({
+      addedPluginIds: [],
+      skipped: [
+        { pluginId: "abcdefghijklmnopqrstuvwxyz012345", reason: "disabled" },
+        { pluginId: "zyxwvutsrqponmlkjihgfedcba543210", reason: "disabled" },
+      ],
+    });
+
+    await command.run({ values: { yes: true } } as never);
+
+    expect(p.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "abcdefghijklmnopqrstuvwxyz012345, zyxwvutsrqponmlkjihgfedcba543210",
+      ),
+    );
+  });
+
   it("skipped が空のとき手動対応の警告は表示されない", async () => {
     vi.mocked(applyPlugin).mockResolvedValue({
       addedPluginIds: ["djmhffjlbkikgmepoociabnpfcfjhdge"],
@@ -165,6 +183,9 @@ describe("plugin apply コマンド", () => {
 
     expect(p.log.warn).not.toHaveBeenCalledWith(
       expect.stringContaining("kintone admin UI"),
+    );
+    expect(p.log.info).toHaveBeenCalledWith(
+      expect.stringContaining("djmhffjlbkikgmepoociabnpfcfjhdge"),
     );
   });
 

--- a/src/cli/commands/plugin/__tests__/apply.test.ts
+++ b/src/cli/commands/plugin/__tests__/apply.test.ts
@@ -81,7 +81,10 @@ afterEach(() => {
 
 describe("plugin apply コマンド", () => {
   it("プラグインの適用に成功し、成功メッセージが表示される", async () => {
-    vi.mocked(applyPlugin).mockResolvedValue(undefined);
+    vi.mocked(applyPlugin).mockResolvedValue({
+      addedPluginIds: [],
+      skipped: [],
+    });
     vi.mocked(p.confirm).mockResolvedValue(true);
 
     await command.run({ values: {} } as never);
@@ -93,7 +96,10 @@ describe("plugin apply コマンド", () => {
   });
 
   it("適用後にデプロイの確認が行われる", async () => {
-    vi.mocked(applyPlugin).mockResolvedValue(undefined);
+    vi.mocked(applyPlugin).mockResolvedValue({
+      addedPluginIds: [],
+      skipped: [],
+    });
     vi.mocked(p.confirm).mockResolvedValue(true);
 
     await command.run({ values: {} } as never);
@@ -103,7 +109,10 @@ describe("plugin apply コマンド", () => {
   });
 
   it("デプロイをキャンセルした場合、警告メッセージが表示される", async () => {
-    vi.mocked(applyPlugin).mockResolvedValue(undefined);
+    vi.mocked(applyPlugin).mockResolvedValue({
+      addedPluginIds: [],
+      skipped: [],
+    });
     vi.mocked(p.confirm)
       .mockResolvedValueOnce(true)
       .mockResolvedValueOnce(false);
@@ -117,12 +126,46 @@ describe("plugin apply コマンド", () => {
   });
 
   it("--yes フラグで確認をスキップしてデプロイされる", async () => {
-    vi.mocked(applyPlugin).mockResolvedValue(undefined);
+    vi.mocked(applyPlugin).mockResolvedValue({
+      addedPluginIds: [],
+      skipped: [],
+    });
 
     await command.run({ values: { yes: true } } as never);
 
     expect(p.confirm).not.toHaveBeenCalled();
     expect(mockDeploy).toHaveBeenCalled();
+  });
+
+  it("skipped が非空のとき手動対応を促す警告が表示される", async () => {
+    vi.mocked(applyPlugin).mockResolvedValue({
+      addedPluginIds: [],
+      skipped: [
+        { pluginId: "abcdefghijklmnopqrstuvwxyz012345", reason: "disabled" },
+      ],
+    });
+
+    await command.run({ values: { yes: true } } as never);
+
+    expect(p.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("kintone admin UI"),
+    );
+    expect(p.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("abcdefghijklmnopqrstuvwxyz012345"),
+    );
+  });
+
+  it("skipped が空のとき手動対応の警告は表示されない", async () => {
+    vi.mocked(applyPlugin).mockResolvedValue({
+      addedPluginIds: ["djmhffjlbkikgmepoociabnpfcfjhdge"],
+      skipped: [],
+    });
+
+    await command.run({ values: { yes: true } } as never);
+
+    expect(p.log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("kintone admin UI"),
+    );
   });
 
   it("エラー発生時にhandleCliErrorで処理される", async () => {

--- a/src/cli/commands/plugin/apply.ts
+++ b/src/cli/commands/plugin/apply.ts
@@ -26,13 +26,12 @@ export default createApplyCommand({
     if (result.addedPluginIds.length > 0) {
       p.log.info(`Added plugins: ${result.addedPluginIds.join(", ")}`);
     }
-    // enabled: false is inexpressible via the plugin API: there is no way to
-    // add a plugin in a disabled state and no way to disable an existing one.
-    // Surface these so they can be handled manually in the kintone admin UI.
+    // enabled: false is inexpressible via the add-only plugin API; handle in
+    // the kintone admin UI.
     const disabled = result.skipped.map((s) => s.pluginId);
     if (disabled.length > 0) {
       p.log.warn(
-        `enabled: false is not supported by the kintone plugin API (cannot add in a disabled state, cannot disable an existing plugin); not changed — handle these in the kintone admin UI: ${disabled.join(", ")}`,
+        `enabled: false is not supported by the kintone plugin API (add-only; cannot disable); handle in the kintone admin UI: ${disabled.join(", ")}`,
       );
     }
   },

--- a/src/cli/commands/plugin/apply.ts
+++ b/src/cli/commands/plugin/apply.ts
@@ -1,3 +1,4 @@
+import * as p from "@clack/prompts";
 import { createPluginCliContainer } from "@/core/application/container/pluginCli";
 import { applyPlugin } from "@/core/application/plugin/applyPlugin";
 import { detectPluginDiff } from "@/core/application/plugin/detectPluginDiff";
@@ -21,6 +22,20 @@ export default createApplyCommand({
   successMessage: "Plugins applied successfully.",
   createContainer: createPluginCliContainer,
   applyFn: applyPlugin,
+  onResult: (result) => {
+    if (result.addedPluginIds.length > 0) {
+      p.log.info(`Added plugins: ${result.addedPluginIds.join(", ")}`);
+    }
+    // enabled: false is inexpressible via the plugin API: there is no way to
+    // add a plugin in a disabled state and no way to disable an existing one.
+    // Surface these so they can be handled manually in the kintone admin UI.
+    const disabled = result.skipped.map((s) => s.pluginId);
+    if (disabled.length > 0) {
+      p.log.warn(
+        `enabled: false is not supported by the kintone plugin API (cannot add in a disabled state, cannot disable an existing plugin); not changed — handle these in the kintone admin UI: ${disabled.join(", ")}`,
+      );
+    }
+  },
   diffPreview: {
     detectDiff: detectPluginDiff,
     printResult: printPluginDiffResult,

--- a/src/core/application/applyAll/__tests__/applyAllForApp.test.ts
+++ b/src/core/application/applyAll/__tests__/applyAllForApp.test.ts
@@ -137,7 +137,7 @@ function setupAllMocksToSucceed(): void {
     newEnable: true,
   });
   vi.mocked(applyAdminNotes).mockResolvedValue(undefined);
-  vi.mocked(applyPlugin).mockResolvedValue(undefined);
+  vi.mocked(applyPlugin).mockResolvedValue({ addedPluginIds: [], skipped: [] });
   vi.mocked(upsertSeed).mockResolvedValue({
     added: 0,
     updated: 0,
@@ -479,6 +479,7 @@ describe("applyAllForApp", () => {
     });
     vi.mocked(applyPlugin).mockImplementation(async () => {
       callOrder.push("plugin");
+      return { addedPluginIds: [], skipped: [] };
     });
     vi.mocked(upsertSeed).mockImplementation(async () => {
       callOrder.push("seed");

--- a/src/core/application/plugin/__tests__/applyPlugin.test.ts
+++ b/src/core/application/plugin/__tests__/applyPlugin.test.ts
@@ -19,7 +19,7 @@ describe("applyPlugin", () => {
       const container = getContainer();
       container.pluginStorage.setContent(VALID_CONFIG);
 
-      await applyPlugin({ container });
+      const output = await applyPlugin({ container });
 
       expect(container.pluginConfigurator.callLog).toEqual([
         "getPlugins",
@@ -29,6 +29,11 @@ describe("applyPlugin", () => {
         "djmhffjlbkikgmepoociabnpfcfjhdge",
         "abcdefghijklmnopqrstuvwxyz012345",
       ]);
+      expect(output.addedPluginIds).toEqual([
+        "djmhffjlbkikgmepoociabnpfcfjhdge",
+        "abcdefghijklmnopqrstuvwxyz012345",
+      ]);
+      expect(output.skipped).toEqual([]);
     });
 
     it("should not call addPlugins when all plugins already exist", async () => {
@@ -47,10 +52,12 @@ describe("applyPlugin", () => {
         },
       ]);
 
-      await applyPlugin({ container });
+      const output = await applyPlugin({ container });
 
       expect(container.pluginConfigurator.callLog).toEqual(["getPlugins"]);
       expect(container.pluginConfigurator.lastAddPluginsParams).toBeNull();
+      expect(output.addedPluginIds).toEqual([]);
+      expect(output.skipped).toEqual([]);
     });
 
     it("should only add plugins that are missing", async () => {
@@ -64,7 +71,7 @@ describe("applyPlugin", () => {
         },
       ]);
 
-      await applyPlugin({ container });
+      const output = await applyPlugin({ container });
 
       expect(container.pluginConfigurator.callLog).toEqual([
         "getPlugins",
@@ -73,6 +80,141 @@ describe("applyPlugin", () => {
       expect(container.pluginConfigurator.lastAddPluginsParams?.ids).toEqual([
         "abcdefghijklmnopqrstuvwxyz012345",
       ]);
+      expect(output.addedPluginIds).toEqual([
+        "abcdefghijklmnopqrstuvwxyz012345",
+      ]);
+      expect(output.skipped).toEqual([]);
+    });
+  });
+
+  describe("enabled: false handling", () => {
+    it("should not add an enabled:false plugin and surface it as skipped (disabled)", async () => {
+      const container = getContainer();
+      container.pluginStorage.setContent(`
+plugins:
+  - id: djmhffjlbkikgmepoociabnpfcfjhdge
+    name: 条件分岐プラグイン
+    enabled: true
+  - id: abcdefghijklmnopqrstuvwxyz012345
+    name: ルックアッププラグイン
+    enabled: false
+`);
+
+      const output = await applyPlugin({ container });
+
+      expect(container.pluginConfigurator.lastAddPluginsParams?.ids).toEqual([
+        "djmhffjlbkikgmepoociabnpfcfjhdge",
+      ]);
+      expect(output.addedPluginIds).toEqual([
+        "djmhffjlbkikgmepoociabnpfcfjhdge",
+      ]);
+      expect(output.skipped).toEqual([
+        {
+          pluginId: "abcdefghijklmnopqrstuvwxyz012345",
+          reason: "disabled",
+        },
+      ]);
+    });
+
+    it("should not call addPlugins when only enabled:false plugins exist but still report them as skipped", async () => {
+      const container = getContainer();
+      container.pluginStorage.setContent(`
+plugins:
+  - id: abcdefghijklmnopqrstuvwxyz012345
+    name: ルックアッププラグイン
+    enabled: false
+`);
+
+      const output = await applyPlugin({ container });
+
+      expect(container.pluginConfigurator.callLog).toEqual(["getPlugins"]);
+      expect(container.pluginConfigurator.lastAddPluginsParams).toBeNull();
+      expect(output.addedPluginIds).toEqual([]);
+      expect(output.skipped).toEqual([
+        {
+          pluginId: "abcdefghijklmnopqrstuvwxyz012345",
+          reason: "disabled",
+        },
+      ]);
+    });
+
+    it("should NOT warn about an already-added plugin whose remote is already enabled:false (avoid noise)", async () => {
+      const container = getContainer();
+      container.pluginStorage.setContent(`
+plugins:
+  - id: abcdefghijklmnopqrstuvwxyz012345
+    name: ルックアッププラグイン
+    enabled: false
+`);
+      container.pluginConfigurator.setPlugins([
+        {
+          id: "abcdefghijklmnopqrstuvwxyz012345",
+          name: "ルックアッププラグイン",
+          enabled: false,
+        },
+      ]);
+
+      const output = await applyPlugin({ container });
+
+      expect(container.pluginConfigurator.callLog).toEqual(["getPlugins"]);
+      expect(container.pluginConfigurator.lastAddPluginsParams).toBeNull();
+      expect(output.addedPluginIds).toEqual([]);
+      expect(output.skipped).toEqual([]);
+    });
+
+    it("should warn about an already-added plugin whose remote is enabled:true but local is enabled:false (disable intent, API-unsupported)", async () => {
+      const container = getContainer();
+      container.pluginStorage.setContent(`
+plugins:
+  - id: abcdefghijklmnopqrstuvwxyz012345
+    name: ルックアッププラグイン
+    enabled: false
+`);
+      container.pluginConfigurator.setPlugins([
+        {
+          id: "abcdefghijklmnopqrstuvwxyz012345",
+          name: "ルックアッププラグイン",
+          enabled: true,
+        },
+      ]);
+
+      const output = await applyPlugin({ container });
+
+      expect(container.pluginConfigurator.callLog).toEqual(["getPlugins"]);
+      expect(container.pluginConfigurator.lastAddPluginsParams).toBeNull();
+      expect(output.addedPluginIds).toEqual([]);
+      expect(output.skipped).toEqual([
+        {
+          pluginId: "abcdefghijklmnopqrstuvwxyz012345",
+          reason: "disabled",
+        },
+      ]);
+    });
+
+    it("should keep remote-only plugins (merge; never deletes them)", async () => {
+      const container = getContainer();
+      container.pluginStorage.setContent(`
+plugins:
+  - id: djmhffjlbkikgmepoociabnpfcfjhdge
+    name: 条件分岐プラグイン
+`);
+      container.pluginConfigurator.setPlugins([
+        {
+          id: "remoteonlyplugin0000000000000000",
+          name: "リモート専用プラグイン",
+          enabled: true,
+        },
+      ]);
+
+      const output = await applyPlugin({ container });
+
+      expect(container.pluginConfigurator.lastAddPluginsParams?.ids).toEqual([
+        "djmhffjlbkikgmepoociabnpfcfjhdge",
+      ]);
+      expect(output.addedPluginIds).toEqual([
+        "djmhffjlbkikgmepoociabnpfcfjhdge",
+      ]);
+      expect(output.skipped).toEqual([]);
     });
   });
 

--- a/src/core/application/plugin/applyPlugin.ts
+++ b/src/core/application/plugin/applyPlugin.ts
@@ -1,10 +1,30 @@
+import type { PluginConfig } from "@/core/domain/plugin/entity";
 import type { PluginServiceArgs } from "../container/plugin";
 import { ValidationError, ValidationErrorCode } from "../error";
 import { parsePluginConfigText } from "./parseConfig";
 
+/** A plugin that apply cannot bring to its desired `enabled: false` state. */
+export type SkippedPlugin = Readonly<{
+  pluginId: string;
+  /**
+   * `disabled`: the plugin is `enabled: false` locally but the kintone plugin
+   * API cannot express it — there is no way to add a plugin in a disabled state
+   * and no way to disable an already-added plugin. Manual action in the kintone
+   * admin UI is required (MEMORY: plugin-enabled-no-disable-api).
+   */
+  reason: "disabled";
+}>;
+
+export type ApplyPluginOutput = Readonly<{
+  /** Plugin ids actually added to the app. */
+  addedPluginIds: readonly string[];
+  /** `enabled: false` plugins that need manual handling (surfaced as warnings). */
+  skipped: readonly SkippedPlugin[];
+}>;
+
 export async function applyPlugin({
   container,
-}: PluginServiceArgs): Promise<void> {
+}: PluginServiceArgs): Promise<ApplyPluginOutput> {
   const result = await container.pluginStorage.get();
   if (!result.exists) {
     throw new ValidationError(
@@ -16,14 +36,34 @@ export async function applyPlugin({
 
   const current = await container.pluginConfigurator.getPlugins();
 
-  const currentIds = new Set(current.plugins.map((p) => p.id));
-  const desiredIds = config.plugins.map((p) => p.id);
-  const missingIds = desiredIds.filter((id) => !currentIds.has(id));
+  const remoteById = new Map<string, PluginConfig>(
+    current.plugins.map((p) => [p.id, p]),
+  );
 
-  if (missingIds.length > 0) {
+  const idsToAdd: string[] = [];
+  const skipped: SkippedPlugin[] = [];
+  for (const plugin of config.plugins) {
+    const remote = remoteById.get(plugin.id);
+    if (plugin.enabled) {
+      // enabled: true → add when missing on the remote, otherwise idempotent.
+      if (remote === undefined) {
+        idsToAdd.push(plugin.id);
+      }
+    } else {
+      // enabled: false is inexpressible via the plugin API. Warn unless the
+      // remote is already in the intended (disabled) state.
+      if (remote === undefined || remote.enabled) {
+        skipped.push({ pluginId: plugin.id, reason: "disabled" });
+      }
+    }
+  }
+
+  if (idsToAdd.length > 0) {
     await container.pluginConfigurator.addPlugins({
-      ids: missingIds,
+      ids: idsToAdd,
       revision: current.revision,
     });
   }
+
+  return { addedPluginIds: idsToAdd, skipped };
 }

--- a/src/core/application/plugin/applyPlugin.ts
+++ b/src/core/application/plugin/applyPlugin.ts
@@ -10,7 +10,7 @@ export type SkippedPlugin = Readonly<{
    * `disabled`: the plugin is `enabled: false` locally but the kintone plugin
    * API cannot express it — there is no way to add a plugin in a disabled state
    * and no way to disable an already-added plugin. Manual action in the kintone
-   * admin UI is required (MEMORY: plugin-enabled-no-disable-api).
+   * admin UI is required.
    */
   reason: "disabled";
 }>;
@@ -45,7 +45,6 @@ export async function applyPlugin({
   for (const plugin of config.plugins) {
     const remote = remoteById.get(plugin.id);
     if (plugin.enabled) {
-      // enabled: true → add when missing on the remote, otherwise idempotent.
       if (remote === undefined) {
         idsToAdd.push(plugin.id);
       }


### PR DESCRIPTION
## Summary
- `applyPlugin` が設定ファイルの `enabled` を無視し、未追加プラグインを一律 `add-app-plugins` に渡していた（`enabled: false` も追加・有効化されてしまうバグ）を修正
- `enabled: true` かつリモート未追加のプラグインのみを追加対象とし、マージ方式（リモート専用は保持）は維持
- `enabled: false` のプラグインはスキップし、「無効化は kintone API 非対応・管理画面で手動対応が必要」という警告を CLI で出力
- 警告対象は push と一貫した3分岐で判定（未追加→警告 / 既追加×リモート `enabled:true`→警告 / 既追加×リモート `enabled:false`→警告しない＝過剰警告回避）
- `applyPlugin` の戻り値を `void` → `ApplyPluginOutput`（`addedPluginIds` / `skipped`）に変更し、CLI（`onResult`）で警告表示
- `spec/usecases/plugin.md` の出力DTO・処理フローを実装に合わせて更新（spec 正本との乖離を解消）

## Issue
Closes #174

## Implementation Plan
Based on `.issue/174/plan.md`（レビューループ2周で収束）

## Test plan

### デプロイ・動作確認方法
本ツールは kintone へプラグイン設定を反映する CLI。実機確認には実 kintone 環境・認証・対象アプリが必要。

```bash
pnpm dev plugin diff    # 差分プレビュー
pnpm dev plugin apply   # 適用（--yes で確認プロンプト省略）
```

### 確認項目
- `enabled: true` のみ追加され、`enabled: false` は追加・有効化されない（AC-1, AC-2）
- 未追加の `enabled: false` でスキップ警告が出る（AC-3）
- 既追加×リモート `enabled: true` を `enabled: false` にすると警告（AC-3b）
- 既追加×リモート `enabled: false` は警告されない（AC-3a）
- 冪等・マージ（リモート専用保持）（AC-4, AC-5, AC-6）
- 異常系（ファイル無し / 不正YAML）は従来どおり（AC-7）

自動テスト: `applyPlugin.test.ts` 13件 / `apply.test.ts` 7件を含む全テスト pass（`pnpm test`）。`pnpm typecheck` pass。

## Browser Verification
- スキップ（CLIツールであり Web UI を持たない。動作確認は実 kintone 環境での CLI 実行が必要で、ロジックはユニット/CLIテスト計20件で担保。agent-browser によるブラウザ検証は対象外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)