### PR TITLE
fix(push): push-all が pushPlugin の add-disabled 警告を破棄する問題を修正 (#196)

### DIFF
--- a/src/cli/__tests__/pushAllOutput.test.ts
+++ b/src/cli/__tests__/pushAllOutput.test.ts
@@ -31,10 +31,13 @@ describe("printPushAllResults", () => {
   it("ヘッダーに 'Push Results:' とフェーズ名を表示すること", () => {
     const output: PushAllForAppOutput = {
       phases: [
-        { phase: "Schema", results: [{ domain: "schema", success: true }] },
+        {
+          phase: "Schema",
+          results: [{ domain: "schema", success: true, warnings: [] }],
+        },
         {
           phase: "Views & Customization",
-          results: [{ domain: "view", success: true }],
+          results: [{ domain: "view", success: true, warnings: [] }],
         },
       ],
       deployed: true,
@@ -55,7 +58,10 @@ describe("printPushAllResults", () => {
   it("deployed が true のとき 'Deployed to production.' を表示すること", () => {
     printPushAllResults({
       phases: [
-        { phase: "Schema", results: [{ domain: "schema", success: true }] },
+        {
+          phase: "Schema",
+          results: [{ domain: "schema", success: true, warnings: [] }],
+        },
       ],
       deployed: true,
     });
@@ -66,7 +72,10 @@ describe("printPushAllResults", () => {
   it("deployError があるとき deploy 失敗を error 表示すること", () => {
     printPushAllResults({
       phases: [
-        { phase: "Schema", results: [{ domain: "schema", success: true }] },
+        {
+          phase: "Schema",
+          results: [{ domain: "schema", success: true, warnings: [] }],
+        },
       ],
       deployed: false,
       deployError: new Error("Deploy API timeout"),
@@ -127,6 +136,42 @@ describe("printPushAllResults", () => {
     expect(logError).toHaveBeenCalledTimes(1);
   });
 
+  it("plugin の warning を当該ドメイン行直後に warn 表示し、成否/exit を変えないこと（AC-6/AC-7）", () => {
+    const output: PushAllForAppOutput = {
+      phases: [
+        {
+          phase: "Settings & Others",
+          results: [
+            {
+              domain: "plugin",
+              success: true,
+              warnings: [
+                {
+                  domain: "plugin",
+                  message:
+                    "Cannot add plugins in a disabled state via the kintone API (add-only; adding would force-enable them); not added — set enabled: false manually in the kintone admin UI: plugA",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      deployed: true,
+    };
+
+    printPushAllResults(output);
+
+    const warnCalls = vi
+      .mocked(p.log.warn)
+      .mock.calls.map((call) => call[0] as string);
+    expect(warnCalls).toContain(
+      "Cannot add plugins in a disabled state via the kintone API (add-only; adding would force-enable them); not added — set enabled: false manually in the kintone admin UI: plugA",
+    );
+    // Warning does not produce a logError and does not flip the exit verdict.
+    expect(logError).not.toHaveBeenCalled();
+    expect(pushAllHasFailure(output)).toBe(false);
+  });
+
   it("空 phases でもクラッシュしないこと", () => {
     expect(() =>
       printPushAllResults({ phases: [], deployed: false }),
@@ -139,7 +184,10 @@ describe("pushAllHasFailure", () => {
     expect(
       pushAllHasFailure({
         phases: [
-          { phase: "Schema", results: [{ domain: "schema", success: true }] },
+          {
+            phase: "Schema",
+            results: [{ domain: "schema", success: true, warnings: [] }],
+          },
         ],
         deployed: true,
       }),
@@ -219,7 +267,10 @@ describe("pushAllHasFailure", () => {
     expect(
       pushAllHasFailure({
         phases: [
-          { phase: "Schema", results: [{ domain: "schema", success: true }] },
+          {
+            phase: "Schema",
+            results: [{ domain: "schema", success: true, warnings: [] }],
+          },
         ],
         deployed: false,
         deployError: new Error("deploy failed"),

--- a/src/cli/__tests__/pushAllOutput.test.ts
+++ b/src/cli/__tests__/pushAllOutput.test.ts
@@ -136,7 +136,7 @@ describe("printPushAllResults", () => {
     expect(logError).toHaveBeenCalledTimes(1);
   });
 
-  it("plugin の warning を当該ドメイン行直後に warn 表示し、成否/exit を変えないこと（AC-6/AC-7）", () => {
+  it("plugin の warning を当該ドメイン行直後に warn 表示し、成否/exit を変えないこと", () => {
     const output: PushAllForAppOutput = {
       phases: [
         {

--- a/src/cli/pushAllOutput.ts
+++ b/src/cli/pushAllOutput.ts
@@ -48,6 +48,14 @@ function printPhaseResult(phaseResult: PushPhaseResult): void {
     if (!result.success && result.skipped === false) {
       logError(result.error);
     }
+    // Surface advisory warnings right after their domain row so it is clear
+    // which domain they belong to. Warnings are not errors and do not affect
+    // the summary counts or the exit verdict.
+    if (result.success) {
+      for (const warning of result.warnings) {
+        p.log.warn(warning.message);
+      }
+    }
   }
 }
 

--- a/src/core/application/pushAll/__tests__/pushAllForApp.test.ts
+++ b/src/core/application/pushAll/__tests__/pushAllForApp.test.ts
@@ -341,7 +341,7 @@ describe("pushAllForApp", () => {
       .find((r) => r.domain === "plugin");
   }
 
-  it("plugin の add-disabled スキップが plugin success 結果の warnings に載る（AC-1/AC-5）", async () => {
+  it("plugin の add-disabled スキップが plugin success 結果の warnings に載る", async () => {
     mockAllPushesSucceed();
     vi.mocked(pushPlugin).mockResolvedValue({
       mode: "push",
@@ -368,7 +368,7 @@ describe("pushAllForApp", () => {
     }
   });
 
-  it("plugin の delete スキップが warnings に載る（AC-5）", async () => {
+  it("plugin の delete スキップが warnings に載る", async () => {
     mockAllPushesSucceed();
     vi.mocked(pushPlugin).mockResolvedValue({
       mode: "push",
@@ -393,7 +393,7 @@ describe("pushAllForApp", () => {
     }
   });
 
-  it("plugin の modify スキップが warnings に載る（AC-5）", async () => {
+  it("plugin の modify スキップが warnings に載る", async () => {
     mockAllPushesSucceed();
     vi.mocked(pushPlugin).mockResolvedValue({
       mode: "push",
@@ -418,7 +418,7 @@ describe("pushAllForApp", () => {
     }
   });
 
-  it("plugin の skipped が delete/modify/add-disabled 混在のとき3種すべての warning を順に載せる（AC-5）", async () => {
+  it("plugin の skipped が delete/modify/add-disabled 混在のとき3種すべての warning を順に載せる", async () => {
     mockAllPushesSucceed();
     vi.mocked(pushPlugin).mockResolvedValue({
       mode: "push",
@@ -445,7 +445,7 @@ describe("pushAllForApp", () => {
     }
   });
 
-  it("plugin の skipped が空のとき warnings は空（AC-8）", async () => {
+  it("plugin の skipped が空のとき warnings は空", async () => {
     mockAllPushesSucceed();
 
     const output = await pushAllForApp(makeArgs());
@@ -458,13 +458,11 @@ describe("pushAllForApp", () => {
     }
   });
 
-  it("push-all が生成する3種の warning 文言が plugin push 単体コマンドの文言と1文字単位で一致する（W-002 回帰防止）", async () => {
-    // Regression net for the intentionally-duplicated warning wording. Per #194
-    // ADR-002 (do not over-generalize) the strings are hardcoded independently
-    // in both pushAllForApp.ts and src/cli/commands/plugin/push.ts L43/48/53 —
-    // there is NO shared constant. These expected literals are kept in sync with
-    // commands/plugin/push.ts BY HAND (no shared-constant extraction per
-    // ADR-002). If either side changes, this test fails to flag the drift.
+  it("push-all が生成する3種の warning 文言が plugin push 単体コマンドの文言と1文字単位で一致する", async () => {
+    // The warning wording is intentionally duplicated (not extracted into a
+    // shared constant) per the do-not-over-generalize decision, so these literals
+    // are kept in sync with src/cli/commands/plugin/push.ts by hand. This test
+    // fails if either side drifts.
     mockAllPushesSucceed();
     vi.mocked(pushPlugin).mockResolvedValue({
       mode: "push",
@@ -481,15 +479,12 @@ describe("pushAllForApp", () => {
 
     const plugin = findPlugin(output);
     if (plugin?.success) {
-      // delete (matches commands/plugin/push.ts L43)
       expect(plugin.warnings[0].message).toBe(
         "Cannot remove plugins via the kintone API (add-only); left on the app: plugDel",
       );
-      // modify (matches commands/plugin/push.ts L48)
       expect(plugin.warnings[1].message).toBe(
         "Cannot modify existing plugins (name/enabled) via the kintone API (add-only); unchanged: plugMod",
       );
-      // add-disabled (matches commands/plugin/push.ts L53)
       expect(plugin.warnings[2].message).toBe(
         "Cannot add plugins in a disabled state via the kintone API (add-only; adding would force-enable them); not added — set enabled: false manually in the kintone admin UI: plugDis",
       );
@@ -498,7 +493,7 @@ describe("pushAllForApp", () => {
     }
   });
 
-  it("schema phase の success 結果も warnings:[] を持つ（AC-3/AC-4）", async () => {
+  it("schema phase の success 結果も warnings:[] を持つ", async () => {
     mockAllPushesSucceed();
 
     const output = await pushAllForApp(makeArgs());
@@ -511,17 +506,14 @@ describe("pushAllForApp", () => {
     }
   });
 
-  it("plugin の success+warning と、別ドメインの実失敗（skipped:false）が同一出力に共存する（W-001 / apply S-004 相当）", async () => {
+  it("plugin の success+warning と、別ドメインの実失敗（skipped:false）が同一出力に共存する", async () => {
     mockAllPushesSucceed();
     // plugin (last domain of the Settings & Others phase) succeeds with a
     // warning. notification (an earlier domain of the same phase) fails with a
-    // non-fatal error, which records a genuine `skipped:false` failure without
-    // aborting the rest. This pins that a warning-bearing success and a real
-    // failure coexist in the same run, and that the failure variant carries no
-    // `warnings` field (only the success variant does). A non-fatal failure is
-    // used because push-all has no post-Settings phase (apply's S-004 fails the
-    // later seed phase); the only way plugin can still run-and-warn alongside a
-    // recorded failure is a non-fatal failure that does not abort.
+    // non-fatal error, recording a genuine `skipped:false` failure without
+    // aborting the rest. A non-fatal failure is required: push-all has no
+    // post-plugin phase, so it is the only way plugin can still run-and-warn
+    // alongside a recorded failure.
     vi.mocked(pushPlugin).mockResolvedValue({
       mode: "push",
       revision: "2",
@@ -564,7 +556,7 @@ describe("pushAllForApp", () => {
     );
   });
 
-  it("plugin 自身が drift skip したとき success バリアントでないため warning を持たない（W-001 push 固有）", async () => {
+  it("plugin 自身が drift skip したとき success バリアントでないため warning を持たない", async () => {
     mockAllPushesSucceed();
     // plugin itself drifts: ConfigDrift → skipped:"drift" failure variant. The
     // would-be add-only warnings are never reachable because the task did not
@@ -582,7 +574,7 @@ describe("pushAllForApp", () => {
     }
   });
 
-  it("plugin が not-found skip したとき warning を持たない（W-001）", async () => {
+  it("plugin が not-found skip したとき warning を持たない", async () => {
     mockAllPushesSucceed();
 
     const output = await pushAllForApp(
@@ -597,7 +589,7 @@ describe("pushAllForApp", () => {
     }
   });
 
-  it("warning があっても全体は success 扱いで deploy され、base revision 再同期も走る（AC-7/AC-9）", async () => {
+  it("warning があっても全体は success 扱いで deploy され、base revision 再同期も走る", async () => {
     mockAllPushesSucceed();
     vi.mocked(pushPlugin).mockResolvedValue({
       mode: "push",

--- a/src/core/application/pushAll/__tests__/pushAllForApp.test.ts
+++ b/src/core/application/pushAll/__tests__/pushAllForApp.test.ts
@@ -205,6 +205,11 @@ describe("pushAllForApp", () => {
     expect(allResults).toHaveLength(13);
     for (const r of allResults) {
       expect(r.success).toBe(true);
+      // Unified run signature: every success result carries `warnings`,
+      // empty when the task emitted none.
+      if (r.success) {
+        expect(r.warnings).toEqual([]);
+      }
     }
 
     // Schema deploy happens after the schema task, plus a single deploy after
@@ -326,5 +331,168 @@ describe("pushAllForApp", () => {
     );
 
     expect(sync.savedRevision).toBeUndefined();
+  });
+
+  function findPlugin(output: Awaited<ReturnType<typeof pushAllForApp>>) {
+    return output.phases
+      .flatMap((p) => p.results)
+      .find((r) => r.domain === "plugin");
+  }
+
+  it("plugin の add-disabled スキップが plugin success 結果の warnings に載る（AC-1/AC-5）", async () => {
+    mockAllPushesSucceed();
+    vi.mocked(pushPlugin).mockResolvedValue({
+      mode: "push",
+      revision: "2",
+      addedPluginIds: [],
+      skipped: [
+        { pluginId: "plugA", reason: "add-disabled" },
+        { pluginId: "plugB", reason: "add-disabled" },
+      ],
+    });
+
+    const output = await pushAllForApp(makeArgs());
+
+    const plugin = findPlugin(output);
+    expect(plugin?.success).toBe(true);
+    if (plugin?.success) {
+      expect(plugin.warnings).toEqual([
+        {
+          domain: "plugin",
+          message:
+            "Cannot add plugins in a disabled state via the kintone API (add-only; adding would force-enable them); not added — set enabled: false manually in the kintone admin UI: plugA, plugB",
+        },
+      ]);
+    }
+  });
+
+  it("plugin の delete スキップが warnings に載る（AC-5）", async () => {
+    mockAllPushesSucceed();
+    vi.mocked(pushPlugin).mockResolvedValue({
+      mode: "push",
+      revision: "2",
+      addedPluginIds: [],
+      skipped: [{ pluginId: "plugDel", reason: "delete" }],
+    });
+
+    const output = await pushAllForApp(makeArgs());
+
+    const plugin = findPlugin(output);
+    if (plugin?.success) {
+      expect(plugin.warnings).toEqual([
+        {
+          domain: "plugin",
+          message:
+            "Cannot remove plugins via the kintone API (add-only); left on the app: plugDel",
+        },
+      ]);
+    } else {
+      throw new Error("plugin should have succeeded");
+    }
+  });
+
+  it("plugin の modify スキップが warnings に載る（AC-5）", async () => {
+    mockAllPushesSucceed();
+    vi.mocked(pushPlugin).mockResolvedValue({
+      mode: "push",
+      revision: "2",
+      addedPluginIds: [],
+      skipped: [{ pluginId: "plugMod", reason: "modify" }],
+    });
+
+    const output = await pushAllForApp(makeArgs());
+
+    const plugin = findPlugin(output);
+    if (plugin?.success) {
+      expect(plugin.warnings).toEqual([
+        {
+          domain: "plugin",
+          message:
+            "Cannot modify existing plugins (name/enabled) via the kintone API (add-only); unchanged: plugMod",
+        },
+      ]);
+    } else {
+      throw new Error("plugin should have succeeded");
+    }
+  });
+
+  it("plugin の skipped が delete/modify/add-disabled 混在のとき3種すべての warning を順に載せる（AC-5）", async () => {
+    mockAllPushesSucceed();
+    vi.mocked(pushPlugin).mockResolvedValue({
+      mode: "push",
+      revision: "2",
+      addedPluginIds: [],
+      skipped: [
+        { pluginId: "plugDel", reason: "delete" },
+        { pluginId: "plugMod", reason: "modify" },
+        { pluginId: "plugDis", reason: "add-disabled" },
+      ],
+    });
+
+    const output = await pushAllForApp(makeArgs());
+
+    const plugin = findPlugin(output);
+    if (plugin?.success) {
+      expect(plugin.warnings.map((w) => w.message)).toEqual([
+        "Cannot remove plugins via the kintone API (add-only); left on the app: plugDel",
+        "Cannot modify existing plugins (name/enabled) via the kintone API (add-only); unchanged: plugMod",
+        "Cannot add plugins in a disabled state via the kintone API (add-only; adding would force-enable them); not added — set enabled: false manually in the kintone admin UI: plugDis",
+      ]);
+    } else {
+      throw new Error("plugin should have succeeded");
+    }
+  });
+
+  it("plugin の skipped が空のとき warnings は空（AC-8）", async () => {
+    mockAllPushesSucceed();
+
+    const output = await pushAllForApp(makeArgs());
+
+    const plugin = findPlugin(output);
+    if (plugin?.success) {
+      expect(plugin.warnings).toEqual([]);
+    } else {
+      throw new Error("plugin should have succeeded");
+    }
+  });
+
+  it("schema phase の success 結果も warnings:[] を持つ（AC-3/AC-4）", async () => {
+    mockAllPushesSucceed();
+
+    const output = await pushAllForApp(makeArgs());
+
+    const schema = output.phases[0].results[0];
+    expect(schema.domain).toBe("schema");
+    expect(schema.success).toBe(true);
+    if (schema.success) {
+      expect(schema.warnings).toEqual([]);
+    }
+  });
+
+  it("warning があっても全体は success 扱いで deploy され、base revision 再同期も走る（AC-7/AC-9）", async () => {
+    mockAllPushesSucceed();
+    vi.mocked(pushPlugin).mockResolvedValue({
+      mode: "push",
+      revision: "2",
+      addedPluginIds: [],
+      skipped: [{ pluginId: "plugDis", reason: "add-disabled" }],
+    });
+    const sync: RevisionSync = {
+      remoteRevision: "9",
+      savedRevision: undefined,
+    };
+
+    const output = await pushAllForApp(makeArgs({ sync }));
+
+    // All 13 domains still succeed; warning does not flip success/skip/error.
+    const allResults = output.phases.flatMap((p) => p.results);
+    expect(allResults).toHaveLength(13);
+    for (const r of allResults) {
+      expect(r.success).toBe(true);
+    }
+    // anyPushed/needsDeploy verdicts look only at r.success, so deploy and the
+    // post-deploy base re-sync run exactly as in the warning-free case.
+    expect(output.deployed).toBe(true);
+    expect(sync.savedRevision).toBe("9");
   });
 });

--- a/src/core/application/pushAll/__tests__/pushAllForApp.test.ts
+++ b/src/core/application/pushAll/__tests__/pushAllForApp.test.ts
@@ -5,6 +5,8 @@ import {
   ConflictErrorCode,
   UnauthenticatedError,
   UnauthenticatedErrorCode,
+  ValidationError,
+  ValidationErrorCode,
 } from "@/core/application/error";
 import {
   type PushAllForAppInput,
@@ -456,6 +458,46 @@ describe("pushAllForApp", () => {
     }
   });
 
+  it("push-all が生成する3種の warning 文言が plugin push 単体コマンドの文言と1文字単位で一致する（W-002 回帰防止）", async () => {
+    // Regression net for the intentionally-duplicated warning wording. Per #194
+    // ADR-002 (do not over-generalize) the strings are hardcoded independently
+    // in both pushAllForApp.ts and src/cli/commands/plugin/push.ts L43/48/53 —
+    // there is NO shared constant. These expected literals are kept in sync with
+    // commands/plugin/push.ts BY HAND (no shared-constant extraction per
+    // ADR-002). If either side changes, this test fails to flag the drift.
+    mockAllPushesSucceed();
+    vi.mocked(pushPlugin).mockResolvedValue({
+      mode: "push",
+      revision: "2",
+      addedPluginIds: [],
+      skipped: [
+        { pluginId: "plugDel", reason: "delete" },
+        { pluginId: "plugMod", reason: "modify" },
+        { pluginId: "plugDis", reason: "add-disabled" },
+      ],
+    });
+
+    const output = await pushAllForApp(makeArgs());
+
+    const plugin = findPlugin(output);
+    if (plugin?.success) {
+      // delete (matches commands/plugin/push.ts L43)
+      expect(plugin.warnings[0].message).toBe(
+        "Cannot remove plugins via the kintone API (add-only); left on the app: plugDel",
+      );
+      // modify (matches commands/plugin/push.ts L48)
+      expect(plugin.warnings[1].message).toBe(
+        "Cannot modify existing plugins (name/enabled) via the kintone API (add-only); unchanged: plugMod",
+      );
+      // add-disabled (matches commands/plugin/push.ts L53)
+      expect(plugin.warnings[2].message).toBe(
+        "Cannot add plugins in a disabled state via the kintone API (add-only; adding would force-enable them); not added — set enabled: false manually in the kintone admin UI: plugDis",
+      );
+    } else {
+      throw new Error("plugin should have succeeded");
+    }
+  });
+
   it("schema phase の success 結果も warnings:[] を持つ（AC-3/AC-4）", async () => {
     mockAllPushesSucceed();
 
@@ -466,6 +508,92 @@ describe("pushAllForApp", () => {
     expect(schema.success).toBe(true);
     if (schema.success) {
       expect(schema.warnings).toEqual([]);
+    }
+  });
+
+  it("plugin の success+warning と、別ドメインの実失敗（skipped:false）が同一出力に共存する（W-001 / apply S-004 相当）", async () => {
+    mockAllPushesSucceed();
+    // plugin (last domain of the Settings & Others phase) succeeds with a
+    // warning. notification (an earlier domain of the same phase) fails with a
+    // non-fatal error, which records a genuine `skipped:false` failure without
+    // aborting the rest. This pins that a warning-bearing success and a real
+    // failure coexist in the same run, and that the failure variant carries no
+    // `warnings` field (only the success variant does). A non-fatal failure is
+    // used because push-all has no post-Settings phase (apply's S-004 fails the
+    // later seed phase); the only way plugin can still run-and-warn alongside a
+    // recorded failure is a non-fatal failure that does not abort.
+    vi.mocked(pushPlugin).mockResolvedValue({
+      mode: "push",
+      revision: "2",
+      addedPluginIds: [],
+      skipped: [{ pluginId: "plugDis", reason: "add-disabled" }],
+    });
+    vi.mocked(pushNotification).mockRejectedValue(
+      new ValidationError(ValidationErrorCode.InvalidInput, "invalid"),
+    );
+
+    const output = await pushAllForApp(makeArgs());
+
+    const allResults = output.phases.flatMap((p) => p.results);
+
+    // plugin's success+warning survives in the same output as the failure.
+    const plugin = allResults.find((r) => r.domain === "plugin");
+    expect(plugin?.success).toBe(true);
+    if (plugin?.success) {
+      expect(plugin.warnings).toHaveLength(1);
+      expect(plugin.warnings[0].domain).toBe("plugin");
+    }
+
+    // A genuine failure was recorded (skipped:false), so the coexistence is
+    // real and not a tautology.
+    const notification = allResults.find((r) => r.domain === "notification");
+    expect(notification?.success).toBe(false);
+    if (notification && !notification.success) {
+      expect(notification.skipped).toBe(false);
+      // The failure variant has no `warnings` field at all — only success
+      // results carry warnings.
+      expect("warnings" in notification).toBe(false);
+    }
+
+    // Both the warning and the failure coexist in the final output.
+    expect(allResults.some((r) => r.success && r.warnings.length > 0)).toBe(
+      true,
+    );
+    expect(allResults.some((r) => !r.success && r.skipped === false)).toBe(
+      true,
+    );
+  });
+
+  it("plugin 自身が drift skip したとき success バリアントでないため warning を持たない（W-001 push 固有）", async () => {
+    mockAllPushesSucceed();
+    // plugin itself drifts: ConfigDrift → skipped:"drift" failure variant. The
+    // would-be add-only warnings are never reachable because the task did not
+    // succeed; the drift failure result carries no `warnings` field.
+    vi.mocked(pushPlugin).mockRejectedValue(
+      new ConflictError(ConflictErrorCode.ConfigDrift, "drift"),
+    );
+
+    const output = await pushAllForApp(makeArgs());
+
+    const plugin = findPlugin(output);
+    expect(plugin).toMatchObject({ success: false, skipped: "drift" });
+    if (plugin && !plugin.success) {
+      expect("warnings" in plugin).toBe(false);
+    }
+  });
+
+  it("plugin が not-found skip したとき warning を持たない（W-001）", async () => {
+    mockAllPushesSucceed();
+
+    const output = await pushAllForApp(
+      makeArgs({ missing: new Set(["plugin"]) }),
+    );
+
+    const plugin = findPlugin(output);
+    expect(plugin).toMatchObject({ success: false, skipped: "not-found" });
+    expect(pushPlugin).not.toHaveBeenCalled();
+    if (plugin && !plugin.success) {
+      expect("warnings" in plugin).toBe(false);
     }
   });
 

--- a/src/core/application/pushAll/pushAllForApp.ts
+++ b/src/core/application/pushAll/pushAllForApp.ts
@@ -58,8 +58,24 @@ export type PushPhaseName =
   | "Permissions"
   | "Settings & Others";
 
+/**
+ * A non-fatal advisory surfaced by a push task. Unlike a failure or a skip,
+ * a warning does not affect success/failed/skipped aggregation, fail-fast,
+ * `state.aborted`, or the exit verdict (`pushAllHasFailure`). The message is a
+ * finished, display-ready string built in the application layer (the CLI layer
+ * only renders it). Currently only the plugin task emits warnings, but any
+ * domain can return them via the same channel. Push-specific (`domain` is
+ * `PushDomain`); kept separate from apply-all's `ApplyWarning` per the push/apply
+ * type split.
+ */
+export type PushWarning = Readonly<{ domain: PushDomain; message: string }>;
+
 export type PushTaskResult =
-  | Readonly<{ domain: PushDomain; success: true }>
+  | Readonly<{
+      domain: PushDomain;
+      success: true;
+      warnings: readonly PushWarning[];
+    }>
   | Readonly<{ domain: PushDomain; success: false; skipped: "not-found" }>
   | Readonly<{
       domain: PushDomain;
@@ -100,7 +116,12 @@ export type PushAllForAppInput = Readonly<{
 type PushTask = {
   readonly domain: PushDomain;
   readonly storageExists: () => Promise<boolean>;
-  readonly run: () => Promise<void>;
+  // Returns the warnings the task wants surfaced (empty when none). The plugin
+  // task builds them from pushPlugin's `skipped`; all other tasks return [].
+  // Unified across all tasks intentionally: an optional field or a side channel
+  // would diverge from apply-all's established pattern, so every task returns
+  // `Promise<readonly PushWarning[]>` even when it never emits a warning.
+  readonly run: () => Promise<readonly PushWarning[]>;
 };
 
 type PhaseDefinition = {
@@ -122,6 +143,7 @@ function buildPhases(args: PushAllForAppInput): readonly PhaseDefinition[] {
             (await c.schema.schemaStorage.get()).exists,
           run: async () => {
             await pushSchema({ container: c.schema, input: { force } });
+            return [];
           },
         },
       ],
@@ -138,6 +160,7 @@ function buildPhases(args: PushAllForAppInput): readonly PhaseDefinition[] {
               container: c.customization,
               input: { basePath: args.customizeBasePath, force },
             });
+            return [];
           },
         },
         {
@@ -145,6 +168,7 @@ function buildPhases(args: PushAllForAppInput): readonly PhaseDefinition[] {
           storageExists: async () => (await c.view.viewStorage.get()).exists,
           run: async () => {
             await pushView({ container: c.view, input: { force } });
+            return [];
           },
         },
       ],
@@ -161,6 +185,7 @@ function buildPhases(args: PushAllForAppInput): readonly PhaseDefinition[] {
               container: c.fieldPermission,
               input: { force },
             });
+            return [];
           },
         },
         {
@@ -172,6 +197,7 @@ function buildPhases(args: PushAllForAppInput): readonly PhaseDefinition[] {
               container: c.appPermission,
               input: { force },
             });
+            return [];
           },
         },
         {
@@ -183,6 +209,7 @@ function buildPhases(args: PushAllForAppInput): readonly PhaseDefinition[] {
               container: c.recordPermission,
               input: { force },
             });
+            return [];
           },
         },
       ],
@@ -199,6 +226,7 @@ function buildPhases(args: PushAllForAppInput): readonly PhaseDefinition[] {
               container: c.settings,
               input: { force },
             });
+            return [];
           },
         },
         {
@@ -210,6 +238,7 @@ function buildPhases(args: PushAllForAppInput): readonly PhaseDefinition[] {
               container: c.notification,
               input: { force },
             });
+            return [];
           },
         },
         {
@@ -218,6 +247,7 @@ function buildPhases(args: PushAllForAppInput): readonly PhaseDefinition[] {
             (await c.report.reportStorage.get()).exists,
           run: async () => {
             await pushReport({ container: c.report, input: { force } });
+            return [];
           },
         },
         {
@@ -226,6 +256,7 @@ function buildPhases(args: PushAllForAppInput): readonly PhaseDefinition[] {
             (await c.action.actionStorage.get()).exists,
           run: async () => {
             await pushAction({ container: c.action, input: { force } });
+            return [];
           },
         },
         {
@@ -237,6 +268,7 @@ function buildPhases(args: PushAllForAppInput): readonly PhaseDefinition[] {
               container: c.process,
               input: { force },
             });
+            return [];
           },
         },
         {
@@ -245,6 +277,7 @@ function buildPhases(args: PushAllForAppInput): readonly PhaseDefinition[] {
             (await c.adminNotes.adminNotesStorage.get()).exists,
           run: async () => {
             await pushAdminNotes({ container: c.adminNotes, input: { force } });
+            return [];
           },
         },
         {
@@ -252,7 +285,41 @@ function buildPhases(args: PushAllForAppInput): readonly PhaseDefinition[] {
           storageExists: async () =>
             (await c.plugin.pluginStorage.get()).exists,
           run: async () => {
-            await pushPlugin({ container: c.plugin, input: { force } });
+            const result = await pushPlugin({
+              container: c.plugin,
+              input: { force },
+            });
+            // Add-only API: surface every operation that `addPlugins` could not
+            // express (mirrors the standalone `plugin push` command's wording).
+            const warnings: PushWarning[] = [];
+            const deletions = result.skipped
+              .filter((o) => o.reason === "delete")
+              .map((o) => o.pluginId);
+            const modifications = result.skipped
+              .filter((o) => o.reason === "modify")
+              .map((o) => o.pluginId);
+            const addDisabled = result.skipped
+              .filter((o) => o.reason === "add-disabled")
+              .map((o) => o.pluginId);
+            if (deletions.length > 0) {
+              warnings.push({
+                domain: "plugin",
+                message: `Cannot remove plugins via the kintone API (add-only); left on the app: ${deletions.join(", ")}`,
+              });
+            }
+            if (modifications.length > 0) {
+              warnings.push({
+                domain: "plugin",
+                message: `Cannot modify existing plugins (name/enabled) via the kintone API (add-only); unchanged: ${modifications.join(", ")}`,
+              });
+            }
+            if (addDisabled.length > 0) {
+              warnings.push({
+                domain: "plugin",
+                message: `Cannot add plugins in a disabled state via the kintone API (add-only; adding would force-enable them); not added — set enabled: false manually in the kintone admin UI: ${addDisabled.join(", ")}`,
+              });
+            }
+            return warnings;
           },
         },
       ],
@@ -320,9 +387,9 @@ async function executeSchemaPhase(
     }
 
     try {
-      await task.run();
+      const warnings = await task.run();
       await deployApp({ container: containers.schema });
-      results.push({ domain: task.domain, success: true });
+      results.push({ domain: task.domain, success: true, warnings });
     } catch (error) {
       const err = toError(error);
       // A drifted schema is skippable but still aborts the rest: subsequent
@@ -378,8 +445,8 @@ async function executeStandardPhase(
     }
 
     try {
-      await task.run();
-      results.push({ domain: task.domain, success: true });
+      const warnings = await task.run();
+      results.push({ domain: task.domain, success: true, warnings });
     } catch (error) {
       const err = toError(error);
       if (isDrift(err)) {

--- a/src/core/application/pushAll/pushAllForApp.ts
+++ b/src/core/application/pushAll/pushAllForApp.ts
@@ -63,10 +63,9 @@ export type PushPhaseName =
  * a warning does not affect success/failed/skipped aggregation, fail-fast,
  * `state.aborted`, or the exit verdict (`pushAllHasFailure`). The message is a
  * finished, display-ready string built in the application layer (the CLI layer
- * only renders it). Currently only the plugin task emits warnings, but any
- * domain can return them via the same channel. Push-specific (`domain` is
- * `PushDomain`); kept separate from apply-all's `ApplyWarning` per the push/apply
- * type split.
+ * only renders it). Any domain can return warnings via the same channel.
+ * Push-specific (`domain` is `PushDomain`); kept separate from apply-all's
+ * `ApplyWarning` per the push/apply type split.
  */
 export type PushWarning = Readonly<{ domain: PushDomain; message: string }>;
 
@@ -116,11 +115,9 @@ export type PushAllForAppInput = Readonly<{
 type PushTask = {
   readonly domain: PushDomain;
   readonly storageExists: () => Promise<boolean>;
-  // Returns the warnings the task wants surfaced (empty when none). The plugin
-  // task builds them from pushPlugin's `skipped`; all other tasks return [].
-  // Unified across all tasks intentionally: an optional field or a side channel
-  // would diverge from apply-all's established pattern, so every task returns
-  // `Promise<readonly PushWarning[]>` even when it never emits a warning.
+  // Returns the warnings the task wants surfaced (empty when none). Every task
+  // returns `Promise<readonly PushWarning[]>` even when it never warns: an
+  // optional field or side channel would diverge from apply-all's pattern.
   readonly run: () => Promise<readonly PushWarning[]>;
 };
 


### PR DESCRIPTION
## Summary
- push-all 集約（`pushAllForApp`）の plugin タスクが `pushPlugin` の戻り値（`skipped`）を破棄しており、`enabled: false` の未追加プラグインのスキップ警告が `push`（集約）経由で表示されなかった問題を修正
- #194 で apply-all に導入した `ApplyWarning` 集約と同型の **push 専用 `PushWarning`** 機構を `pushAllForApp.ts` に展開（`ApplyWarning` は共有せず push/apply の型分離を維持）
- `PushTask.run` を `() => Promise<readonly PushWarning[]>` に全タスク統一変更、`PushTaskResult` の success に `warnings` を追加。plugin タスクのみ `skipped` から warning を生成
- delete / modify / add-disabled の **3種すべて**を、`plugin push` 単体コマンドと1文字単位で一致する文言で表示（同根の穴の完全閉塞）
- CLI 層（`pushAllOutput.ts`）が各ドメイン行の直後に `p.log.warn` で表示（文言生成=アプリ層、表示=CLI 層の責務分離を踏襲）
- warning は success 集計・fail-fast・exit code（`pushAllHasFailure`）・deploy 可否に影響させない

## Issue
Closes #196

## Implementation Plan
Based on `.issue/196/plan.md`（設計判断は `.issue/196/adr.md`）

## Test plan

### デプロイ・動作確認方法
- 自動テスト: `pnpm test`（`vitest run`） / `pnpm typecheck` / `pnpm lint`
- push 集約の実機確認: `pnpm dev:push-all`（= `tsx src/cli/index.ts push`）。`KINTONE_DOMAIN` + 認証情報（API Token or username/password）と `kintone-migrator.yaml` が前提

### 確認項目
- `enabled: false` の未追加プラグインを含む状態で push 集約を実行 → Plugin 行の直後に add-disabled 警告が表示される
- delete / modify の skip も同様に警告表示される
- 警告が success 集計・exit code・deploy 可否に影響しない
- plugin の `skipped` が空のとき警告が出ない

## Browser Verification
- スキップ理由: Web UI なしの CLI ツール（`dev`/`start` は CLI エントリポイントを起動、UIファイル不在、`bin` は CLI バイナリ）。動作はユニットテスト2837件（新規テスト含む）で担保

🤖 Generated with [Claude Code](https://claude.com/claude-code)