### PR TITLE
fix(customize): pull が既存 customize.yaml の path プレフィックスを剥がす問題を修正 (#205)

### DIFF
--- a/src/cli/commands/customize/__tests__/capture.test.ts
+++ b/src/cli/commands/customize/__tests__/capture.test.ts
@@ -1,5 +1,6 @@
+import { dirname, join, resolve } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { deriveFilePrefix } from "../capture";
+import { computeBasePath, deriveFilePrefix } from "../capture";
 
 vi.mock("@clack/prompts", () => ({
   spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn() })),
@@ -98,6 +99,31 @@ describe("deriveFilePrefix", () => {
   it("ディレクトリ内の .yml ファイルも正しくファイル名を返す", () => {
     expect(deriveFilePrefix("some-dir/my-config.yml")).toBe("my-config");
   });
+});
+
+/**
+ * pull resolves file content against `join(captureBasePath, filePrefix)`, while
+ * push resolves against `computeBasePath(...)`. This invariant pins that the two
+ * bases are structurally identical for the same input, so pull writes exactly
+ * where push uploads from (AC-10).
+ */
+describe("pull/push base path invariant (AC-10)", () => {
+  const paths = [
+    "customize.yaml",
+    "myapp/customize.yaml",
+    "customize/customer.yaml",
+    "/project/apps/myapp/customize.yaml",
+    "some-dir/my-config.yml",
+  ];
+
+  for (const path of paths) {
+    it(`join(captureBasePath, filePrefix) equals computeBasePath for ${path}`, () => {
+      // These mirror how src/cli/commands/customize/pull.ts derives its bases.
+      const captureBasePath = dirname(resolve(path));
+      const filePrefix = deriveFilePrefix(path);
+      expect(join(captureBasePath, filePrefix)).toBe(computeBasePath(path));
+    });
+  }
 });
 
 describe("customize capture command (deprecation)", () => {

--- a/src/cli/commands/customize/__tests__/capture.test.ts
+++ b/src/cli/commands/customize/__tests__/capture.test.ts
@@ -106,7 +106,7 @@ describe("deriveFilePrefix", () => {
  * pull resolves file content against `join(captureBasePath, filePrefix)`, while
  * push resolves against `computeBasePath(...)`. This invariant pins that the two
  * bases are structurally identical for the same input, so pull writes exactly
- * where push uploads from (AC-10).
+ * where push uploads from.
  *
  * The bases come from `derivePullPaths` — the exact function `runPull` uses — so a
  * regression in pull.ts's own `captureBasePath`/`filePrefix` derivation is caught

--- a/src/cli/commands/customize/__tests__/capture.test.ts
+++ b/src/cli/commands/customize/__tests__/capture.test.ts
@@ -1,6 +1,7 @@
-import { dirname, join, resolve } from "node:path";
+import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { computeBasePath, deriveFilePrefix } from "../capture";
+import { derivePullPaths } from "../pull";
 
 vi.mock("@clack/prompts", () => ({
   spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn() })),
@@ -106,6 +107,10 @@ describe("deriveFilePrefix", () => {
  * push resolves against `computeBasePath(...)`. This invariant pins that the two
  * bases are structurally identical for the same input, so pull writes exactly
  * where push uploads from (AC-10).
+ *
+ * The bases come from `derivePullPaths` — the exact function `runPull` uses — so a
+ * regression in pull.ts's own `captureBasePath`/`filePrefix` derivation is caught
+ * here, rather than a hand-mirrored copy that could silently drift from pull.ts.
  */
 describe("pull/push base path invariant (AC-10)", () => {
   const paths = [
@@ -117,11 +122,14 @@ describe("pull/push base path invariant (AC-10)", () => {
   ];
 
   for (const path of paths) {
-    it(`join(captureBasePath, filePrefix) equals computeBasePath for ${path}`, () => {
-      // These mirror how src/cli/commands/customize/pull.ts derives its bases.
-      const captureBasePath = dirname(resolve(path));
-      const filePrefix = deriveFilePrefix(path);
-      expect(join(captureBasePath, filePrefix)).toBe(computeBasePath(path));
+    it(`pull content base equals push computeBasePath for ${path}`, () => {
+      const { basePath, captureBasePath, filePrefix } = derivePullPaths(path);
+      // pull downloads/writes content against join(captureBasePath, filePrefix);
+      // push uploads from basePath. They must resolve to the same location.
+      expect(join(captureBasePath, filePrefix)).toBe(basePath);
+      // basePath must be push's computeBasePath, and filePrefix push's prefix.
+      expect(basePath).toBe(computeBasePath(path));
+      expect(filePrefix).toBe(deriveFilePrefix(path));
     });
   }
 });

--- a/src/cli/commands/customize/pull.ts
+++ b/src/cli/commands/customize/pull.ts
@@ -24,6 +24,30 @@ import { computeBasePath, deriveFilePrefix } from "./capture";
 
 type CustomizeMerged = Extract<PullCustomizationOutput, { mode: "merged" }>;
 
+/**
+ * Derives the path bases `runPull` feeds to the application layer.
+ *
+ * - `basePath` (= push's {@link computeBasePath}) is where merged/downloaded
+ *   content resolves and push uploads from.
+ * - `captureBasePath` + `filePrefix` are passed to the capture-equivalent
+ *   (force / first-time) path.
+ *
+ * AC-10 invariant: `join(captureBasePath, filePrefix) === basePath`, so pull
+ * writes exactly where push uploads from. Exported so the invariant test pins
+ * these exact derivations rather than a hand-mirrored copy.
+ */
+export function derivePullPaths(customizeFilePath: string): {
+  readonly basePath: string;
+  readonly captureBasePath: string;
+  readonly filePrefix: string;
+} {
+  return {
+    basePath: computeBasePath(customizeFilePath),
+    captureBasePath: dirname(resolve(customizeFilePath)),
+    filePrefix: deriveFilePrefix(customizeFilePath),
+  };
+}
+
 type PullOptions = {
   readonly force: boolean;
   readonly ours: boolean;
@@ -65,11 +89,11 @@ async function runPull(
 ): Promise<void> {
   const container: CustomizationContainer =
     createCustomizationCliContainer(containerConfig);
-  // Resource paths in the local config resolve against this base.
-  const basePath = computeBasePath(containerConfig.customizeFilePath);
-  // capture-equivalent paths (basePath = file dir, prefix isolates per app)
-  const captureBasePath = dirname(resolve(containerConfig.customizeFilePath));
-  const filePrefix = deriveFilePrefix(containerConfig.customizeFilePath);
+  // basePath: where local resource paths resolve (push-symmetric).
+  // captureBasePath/filePrefix: capture-equivalent bases (prefix isolates per app).
+  const { basePath, captureBasePath, filePrefix } = derivePullPaths(
+    containerConfig.customizeFilePath,
+  );
 
   const s = p.spinner();
   s.start("Pulling customization from kintone...");

--- a/src/cli/commands/customize/pull.ts
+++ b/src/cli/commands/customize/pull.ts
@@ -32,9 +32,9 @@ type CustomizeMerged = Extract<PullCustomizationOutput, { mode: "merged" }>;
  * - `captureBasePath` + `filePrefix` are passed to the capture-equivalent
  *   (force / first-time) path.
  *
- * AC-10 invariant: `join(captureBasePath, filePrefix) === basePath`, so pull
- * writes exactly where push uploads from. Exported so the invariant test pins
- * these exact derivations rather than a hand-mirrored copy.
+ * Invariant: `join(captureBasePath, filePrefix) === basePath`, so pull writes
+ * exactly where push uploads from. Exported so the invariant test pins these
+ * exact derivations rather than a hand-mirrored copy.
  */
 export function derivePullPaths(customizeFilePath: string): {
   readonly basePath: string;

--- a/src/core/application/customization/__tests__/captureCustomization.test.ts
+++ b/src/core/application/customization/__tests__/captureCustomization.test.ts
@@ -403,6 +403,92 @@ describe("captureCustomization", () => {
     ).rejects.toThrow("getCustomization failed");
   });
 
+  it("should preserve declared paths and resolve downloads against the content base when preservePaths is given", async () => {
+    setup();
+    container.customizationConfigurator.setCustomization({
+      scope: "ALL",
+      desktop: {
+        js: [
+          {
+            type: "FILE",
+            file: {
+              fileKey: "fk-1",
+              name: "app.js",
+              contentType: "text/javascript",
+              size: "100",
+            },
+          },
+        ],
+        css: [],
+      },
+      mobile: { js: [], css: [] },
+      revision: "1",
+    });
+
+    const result = await captureCustomization({
+      container,
+      input: {
+        basePath,
+        filePrefix,
+        preservePaths: new Map([["app.js", "app/desktop/js/app.js"]]),
+      },
+    });
+
+    // Config keeps the declared (nested) path, not the normalized scheme.
+    expect(result.config.desktop.js[0]).toEqual({
+      type: "FILE",
+      path: "app/desktop/js/app.js",
+    });
+    const parsed = parseCustomizationConfigText(configCodec, result.configText);
+    expect(parsed.desktop.js[0]).toEqual({
+      type: "FILE",
+      path: "app/desktop/js/app.js",
+    });
+    // Download target = join(basePath, filePrefix, declaredPath) == the same
+    // location push uploads from (basePath == computeBasePath == content base).
+    expect(
+      container.fileWriter.writtenFiles.has(
+        "/project/customize/myapp/app/desktop/js/app.js",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns the config it wrote and uses the normalized scheme when preservePaths is unset (AC-8)", async () => {
+    setup();
+    container.customizationConfigurator.setCustomization({
+      scope: "ALL",
+      desktop: {
+        js: [
+          {
+            type: "FILE",
+            file: {
+              fileKey: "fk-1",
+              name: "app.js",
+              contentType: "text/javascript",
+              size: "100",
+            },
+          },
+        ],
+        css: [],
+      },
+      mobile: { js: [], css: [] },
+      revision: "1",
+    });
+
+    const result = await captureCustomization({
+      container,
+      input: { basePath, filePrefix },
+    });
+
+    // Unset preservePaths keeps the capture normalization contract.
+    expect(result.config.desktop.js[0]).toEqual({
+      type: "FILE",
+      path: "desktop/js/app.js",
+    });
+    const parsed = parseCustomizationConfigText(configCodec, result.configText);
+    expect(parsed.desktop.js[0]).toEqual(result.config.desktop.js[0]);
+  });
+
   it("should download files directly under basePath when filePrefix is empty", async () => {
     setup();
     container.customizationConfigurator.setCustomization({

--- a/src/core/application/customization/__tests__/captureCustomization.test.ts
+++ b/src/core/application/customization/__tests__/captureCustomization.test.ts
@@ -430,7 +430,9 @@ describe("captureCustomization", () => {
       input: {
         basePath,
         filePrefix,
-        preservePaths: new Map([["app.js", "app/desktop/js/app.js"]]),
+        preservePaths: new Map([
+          ["desktop:js:app.js", "app/desktop/js/app.js"],
+        ]),
       },
     });
 
@@ -451,6 +453,107 @@ describe("captureCustomization", () => {
         "/project/customize/myapp/app/desktop/js/app.js",
       ),
     ).toBe(true);
+  });
+
+  it("matches preservePaths by bucket-qualified key so same-basename files across buckets stay distinct (B-001)", async () => {
+    setup();
+    container.customizationConfigurator.setCustomization({
+      scope: "ALL",
+      desktop: {
+        js: [
+          {
+            type: "FILE",
+            file: {
+              fileKey: "fk-d-main",
+              name: "main.js",
+              contentType: "text/javascript",
+              size: "100",
+            },
+          },
+        ],
+        css: [
+          {
+            type: "FILE",
+            file: {
+              fileKey: "fk-d-style",
+              name: "style.css",
+              contentType: "text/css",
+              size: "10",
+            },
+          },
+        ],
+      },
+      mobile: {
+        js: [
+          {
+            type: "FILE",
+            file: {
+              fileKey: "fk-m-main",
+              name: "main.js",
+              contentType: "text/javascript",
+              size: "100",
+            },
+          },
+        ],
+        css: [
+          {
+            type: "FILE",
+            file: {
+              fileKey: "fk-m-style",
+              name: "style.css",
+              contentType: "text/css",
+              size: "10",
+            },
+          },
+        ],
+      },
+      revision: "1",
+    });
+
+    const result = await captureCustomization({
+      container,
+      input: {
+        basePath,
+        filePrefix,
+        // Same basenames (main.js / style.css) in different buckets map to
+        // different declared paths; a flat basename lookup would cross them.
+        preservePaths: new Map([
+          ["desktop:js:main.js", "app/desktop/js/main.js"],
+          ["desktop:css:style.css", "app/desktop/css/style.css"],
+          ["mobile:js:main.js", "app/mobile/js/main.js"],
+          ["mobile:css:style.css", "app/mobile/css/style.css"],
+        ]),
+      },
+    });
+
+    expect(result.config.desktop.js[0]).toEqual({
+      type: "FILE",
+      path: "app/desktop/js/main.js",
+    });
+    expect(result.config.desktop.css[0]).toEqual({
+      type: "FILE",
+      path: "app/desktop/css/style.css",
+    });
+    expect(result.config.mobile.js[0]).toEqual({
+      type: "FILE",
+      path: "app/mobile/js/main.js",
+    });
+    expect(result.config.mobile.css[0]).toEqual({
+      type: "FILE",
+      path: "app/mobile/css/style.css",
+    });
+
+    // Each body lands at its own bucket's nested location (no collision).
+    const base = "/project/customize/myapp";
+    for (const p of [
+      "app/desktop/js/main.js",
+      "app/desktop/css/style.css",
+      "app/mobile/js/main.js",
+      "app/mobile/css/style.css",
+    ]) {
+      expect(container.fileWriter.writtenFiles.has(`${base}/${p}`)).toBe(true);
+    }
+    expect(container.fileWriter.writtenFiles.size).toBe(4);
   });
 
   it("returns the config it wrote and uses the normalized scheme when preservePaths is unset (AC-8)", async () => {

--- a/src/core/application/customization/__tests__/pullCustomization.test.ts
+++ b/src/core/application/customization/__tests__/pullCustomization.test.ts
@@ -4,15 +4,18 @@ import { setupTestCustomizationContainer } from "@/core/application/__tests__/he
 import type { TestCustomizationContainer } from "@/core/application/__tests__/helpers/customization";
 import type { CustomizationConfig } from "@/core/domain/customization/entity";
 import { CustomizationConfigSerializer } from "@/core/domain/customization/services/configSerializer";
+import { CustomizationStateParser } from "@/core/domain/customization/services/customizationStateParser";
 import { CustomizationStateSerializer } from "@/core/domain/customization/services/customizationStateSerializer";
 import type {
   CustomizationScope,
   RemoteResource,
 } from "@/core/domain/customization/valueObject";
+import { parseCustomizationConfigText } from "../parseConfig";
 import {
   applyPulledCustomizationMerge,
   pullCustomization,
 } from "../pullCustomization";
+import { pushCustomization } from "../pushCustomization";
 
 const BASE = "/app";
 const CAPTURE_BASE = "/app";
@@ -75,6 +78,44 @@ function matchFile(
   const buf = new TextEncoder().encode(body).buffer;
   container.fileContentReader.setFile(`${BASE}/${name}`, buf);
   container.fileDownloader.setFile(`fk-${name}`, buf);
+}
+
+/** A config with a single desktop.js FILE at the given (possibly nested) path. */
+function nestedFile(path: string): CustomizationConfig {
+  return {
+    scope: "ALL",
+    desktop: { js: [{ type: "FILE", path }], css: [] },
+    mobile: { js: [], css: [] },
+  };
+}
+
+/** Sets the local body and remote body for a nested FILE to identical bytes. */
+function matchNested(
+  container: TestCustomizationContainer,
+  path: string,
+  fileKey: string,
+  body: string,
+): void {
+  const buf = new TextEncoder().encode(body).buffer;
+  container.fileContentReader.setFile(`${BASE}/${path}`, buf);
+  container.fileDownloader.setFile(fileKey, buf);
+}
+
+async function readLocal(
+  container: TestCustomizationContainer,
+): Promise<CustomizationConfig> {
+  const result = await container.customizationStorage.get();
+  if (!result.exists) throw new Error("expected local config");
+  return parseCustomizationConfigText(configCodec, result.content);
+}
+
+async function readState(
+  container: TestCustomizationContainer,
+): Promise<CustomizationConfig> {
+  const result = await container.customizationStateStorage.get();
+  if (!result.exists) throw new Error("expected state");
+  return CustomizationStateParser.parse(configCodec.parse(result.content))
+    .config;
 }
 
 const input = {
@@ -197,5 +238,218 @@ describe("pullCustomization", () => {
 
     // Resolved to remote → a.js is (re)downloaded with the remote body.
     expect(container.fileWriter.writtenFiles.has(`${BASE}/a.js`)).toBe(true);
+  });
+});
+
+describe("pullCustomization — path preservation (Issue #205)", () => {
+  const getContainer = setupTestCustomizationContainer();
+  const NESTED = "app/desktop/js/a.js";
+  const NESTED_ABS = `${BASE}/${NESTED}`;
+
+  it("force keeps the local declared path, downloads to it, and saves state with it (AC-1/2/3)", async () => {
+    const container = getContainer();
+    const local = nestedFile(NESTED);
+    setState(container, local, "1");
+    setLocal(container, local);
+    setRemote(container, [remoteFile("a.js")], "2");
+
+    const result = await pullCustomization({
+      container,
+      input: { ...input, force: true },
+    });
+    expect(result.mode).toBe("force");
+
+    // Local config path is unchanged (not stripped to basename).
+    const localAfter = await readLocal(container);
+    expect(localAfter.desktop.js[0]).toEqual({ type: "FILE", path: NESTED });
+    // Body downloaded to the nested (double-nest) location, not basename root.
+    expect(container.fileWriter.writtenFiles.has(NESTED_ABS)).toBe(true);
+    expect(container.fileWriter.writtenFiles.has(`${BASE}/a.js`)).toBe(false);
+    // State path matches local (base == local).
+    const state = await readState(container);
+    expect(state.desktop.js[0]).toEqual({ type: "FILE", path: NESTED });
+  });
+
+  it("recovers path from local when state is missing (AC-9)", async () => {
+    const container = getContainer();
+    const local = nestedFile(NESTED);
+    // No state; local exists → firstTime branch with path preservation.
+    setLocal(container, local);
+    setRemote(container, [remoteFile("a.js")], "5");
+
+    const result = await pullCustomization({ container, input });
+    expect(result.mode).toBe("firstTime");
+
+    const localAfter = await readLocal(container);
+    expect(localAfter.desktop.js[0]).toEqual({ type: "FILE", path: NESTED });
+    expect(container.fileWriter.writtenFiles.has(NESTED_ABS)).toBe(true);
+    const state = await readState(container);
+    expect(state.desktop.js[0]).toEqual({ type: "FILE", path: NESTED });
+  });
+
+  it("merge keeps the local path for an unchanged entry and sets state == local (AC-4)", async () => {
+    const container = getContainer();
+    const local = nestedFile(NESTED);
+    setState(container, local, "1");
+    setLocal(container, local);
+    setRemote(container, [remoteFile("a.js")], "1");
+    matchNested(container, NESTED, "fk-a.js", "same-body");
+
+    const pull = await pullCustomization({ container, input });
+    if (pull.mode !== "merged") throw new Error("expected merged");
+    expect(pull.merge.hasConflict).toBe(false);
+
+    await applyPulledCustomizationMerge({
+      container,
+      input: {
+        basePath: BASE,
+        merge: pull.merge,
+        resolution: new Map(),
+        local: pull.local,
+        remote: pull.remote,
+        remoteConfig: pull.remoteConfig,
+        remoteRevision: pull.remoteRevision,
+      },
+    });
+
+    const localAfter = await readLocal(container);
+    expect(localAfter.desktop.js[0]).toEqual({ type: "FILE", path: NESTED });
+    const state = await readState(container);
+    expect(state.desktop.js[0]).toEqual({ type: "FILE", path: NESTED });
+  });
+
+  it("conflict→remote keeps the local path and downloads the remote body to it (AC-5)", async () => {
+    const container = getContainer();
+    const local = nestedFile(NESTED);
+    setState(container, local, "1");
+    setLocal(container, local);
+    setRemote(container, [remoteFile("a.js")], "2");
+    // diverging content → conflict.
+    container.fileContentReader.setFile(
+      NESTED_ABS,
+      new TextEncoder().encode("local").buffer,
+    );
+    container.fileDownloader.setFile(
+      "fk-a.js",
+      new TextEncoder().encode("remote").buffer,
+    );
+
+    const pull = await pullCustomization({ container, input });
+    if (pull.mode !== "merged") throw new Error("expected merged");
+    expect(pull.merge.hasConflict).toBe(true);
+
+    await applyPulledCustomizationMerge({
+      container,
+      input: {
+        basePath: BASE,
+        merge: pull.merge,
+        resolution: new Map([["desktop:js:a.js", "remote"]]),
+        local: pull.local,
+        remote: pull.remote,
+        remoteConfig: pull.remoteConfig,
+        remoteRevision: pull.remoteRevision,
+      },
+    });
+
+    // Remote body written to the local declared path (not basename root).
+    expect(container.fileWriter.writtenFiles.has(NESTED_ABS)).toBe(true);
+    expect(container.fileWriter.writtenFiles.has(`${BASE}/a.js`)).toBe(false);
+    const localAfter = await readLocal(container);
+    expect(localAfter.desktop.js[0]).toEqual({ type: "FILE", path: NESTED });
+    const state = await readState(container);
+    expect(state.desktop.js[0]).toEqual({ type: "FILE", path: NESTED });
+  });
+
+  it("is idempotent across pull → pull for the merge path (AC-7)", async () => {
+    const container = getContainer();
+    const local = nestedFile(NESTED);
+    setState(container, local, "1");
+    setLocal(container, local);
+    setRemote(container, [remoteFile("a.js")], "1");
+    matchNested(container, NESTED, "fk-a.js", "same-body");
+
+    const applyMerge = async () => {
+      const pull = await pullCustomization({ container, input });
+      if (pull.mode !== "merged") throw new Error("expected merged");
+      await applyPulledCustomizationMerge({
+        container,
+        input: {
+          basePath: BASE,
+          merge: pull.merge,
+          resolution: new Map(),
+          local: pull.local,
+          remote: pull.remote,
+          remoteConfig: pull.remoteConfig,
+          remoteRevision: pull.remoteRevision,
+        },
+      });
+    };
+
+    await applyMerge();
+    const firstLocal = await readLocal(container);
+    await applyMerge();
+    const secondLocal = await readLocal(container);
+
+    expect(secondLocal.desktop.js[0]).toEqual({ type: "FILE", path: NESTED });
+    expect(secondLocal).toEqual(firstLocal);
+    const state = await readState(container);
+    expect(state.desktop.js[0]).toEqual({ type: "FILE", path: NESTED });
+  });
+
+  it("pull --force then push detects no drift and only advances revision (AC-6)", async () => {
+    const container = getContainer();
+    const local = nestedFile(NESTED);
+    setState(container, local, "1");
+    setLocal(container, local);
+    setRemote(container, [remoteFile("a.js")], "2");
+    matchNested(container, NESTED, "fk-a.js", "body");
+
+    await pullCustomization({ container, input: { ...input, force: true } });
+
+    // Feed the post-pull state/local into the real push drift-detection path.
+    const push = await pushCustomization({
+      container,
+      input: { basePath: BASE },
+    });
+    // No drift thrown → mode "push"; revision advances 2 → 3.
+    expect(push.mode).toBe("push");
+    expect(push.revision).toBe("3");
+    // Path stays intact through the round trip.
+    const state = await readState(container);
+    expect(state.desktop.js[0]).toEqual({ type: "FILE", path: NESTED });
+    const localAfter = await readLocal(container);
+    expect(localAfter.desktop.js[0]).toEqual({ type: "FILE", path: NESTED });
+  });
+
+  it("pull (merge) then push detects no drift (AC-6)", async () => {
+    const container = getContainer();
+    const local = nestedFile(NESTED);
+    setState(container, local, "1");
+    setLocal(container, local);
+    setRemote(container, [remoteFile("a.js")], "1");
+    matchNested(container, NESTED, "fk-a.js", "body");
+
+    const pull = await pullCustomization({ container, input });
+    if (pull.mode !== "merged") throw new Error("expected merged");
+    await applyPulledCustomizationMerge({
+      container,
+      input: {
+        basePath: BASE,
+        merge: pull.merge,
+        resolution: new Map(),
+        local: pull.local,
+        remote: pull.remote,
+        remoteConfig: pull.remoteConfig,
+        remoteRevision: pull.remoteRevision,
+      },
+    });
+
+    const push = await pushCustomization({
+      container,
+      input: { basePath: BASE },
+    });
+    expect(push.mode).toBe("push");
+    const state = await readState(container);
+    expect(state.desktop.js[0]).toEqual({ type: "FILE", path: NESTED });
   });
 });

--- a/src/core/application/customization/__tests__/pullCustomization.test.ts
+++ b/src/core/application/customization/__tests__/pullCustomization.test.ts
@@ -453,3 +453,89 @@ describe("pullCustomization — path preservation (Issue #205)", () => {
     expect(state.desktop.js[0]).toEqual({ type: "FILE", path: NESTED });
   });
 });
+
+describe("pullCustomization — cross-bucket path preservation (Issue #205, B-001)", () => {
+  const getContainer = setupTestCustomizationContainer();
+
+  // desktop and mobile ship same-basename files (main.js / style.css) — a common
+  // layout. Each bucket's declared path must survive independently; a flat
+  // basename map would let one bucket's path clobber the other's (last-wins).
+  const D_JS = "app/desktop/js/main.js";
+  const D_CSS = "app/desktop/css/style.css";
+  const M_JS = "app/mobile/js/main.js";
+  const M_CSS = "app/mobile/css/style.css";
+
+  function crossBucketLocal(): CustomizationConfig {
+    return {
+      scope: "ALL",
+      desktop: {
+        js: [{ type: "FILE", path: D_JS }],
+        css: [{ type: "FILE", path: D_CSS }],
+      },
+      mobile: {
+        js: [{ type: "FILE", path: M_JS }],
+        css: [{ type: "FILE", path: M_CSS }],
+      },
+    };
+  }
+
+  function setCrossBucketRemote(
+    container: TestCustomizationContainer,
+    revision: string,
+  ): void {
+    container.customizationConfigurator.setCustomization({
+      scope: "ALL",
+      desktop: {
+        js: [remoteFile("main.js", "fk-d-main")],
+        css: [remoteFile("style.css", "fk-d-style")],
+      },
+      mobile: {
+        js: [remoteFile("main.js", "fk-m-main")],
+        css: [remoteFile("style.css", "fk-m-style")],
+      },
+      revision,
+    });
+    for (const key of ["fk-d-main", "fk-d-style", "fk-m-main", "fk-m-style"]) {
+      container.fileDownloader.setFile(
+        key,
+        new TextEncoder().encode(`body-${key}`).buffer,
+      );
+    }
+  }
+
+  it("force keeps each bucket's declared path without cross-bucket collision (AC-1/2/3)", async () => {
+    const container = getContainer();
+    const local = crossBucketLocal();
+    setState(container, local, "1");
+    setLocal(container, local);
+    setCrossBucketRemote(container, "2");
+
+    const result = await pullCustomization({
+      container,
+      input: { ...input, force: true },
+    });
+    expect(result.mode).toBe("force");
+
+    // Every bucket keeps its own declared path (not last-wins from another).
+    const localAfter = await readLocal(container);
+    expect(localAfter.desktop.js[0]).toEqual({ type: "FILE", path: D_JS });
+    expect(localAfter.desktop.css[0]).toEqual({ type: "FILE", path: D_CSS });
+    expect(localAfter.mobile.js[0]).toEqual({ type: "FILE", path: M_JS });
+    expect(localAfter.mobile.css[0]).toEqual({ type: "FILE", path: M_CSS });
+
+    // Bodies land at four distinct nested locations — no two downloads collide.
+    for (const path of [D_JS, D_CSS, M_JS, M_CSS]) {
+      expect(container.fileWriter.writtenFiles.has(`${BASE}/${path}`)).toBe(
+        true,
+      );
+    }
+    expect(container.fileWriter.writtenFiles.size).toBe(4);
+
+    // State mirrors local for every bucket (base == local).
+    const state = await readState(container);
+    expect(state.desktop.js[0]).toEqual({ type: "FILE", path: D_JS });
+    expect(state.desktop.css[0]).toEqual({ type: "FILE", path: D_CSS });
+    expect(state.mobile.js[0]).toEqual({ type: "FILE", path: M_JS });
+    expect(state.mobile.css[0]).toEqual({ type: "FILE", path: M_CSS });
+  });
+});

--- a/src/core/application/customization/captureCustomization.ts
+++ b/src/core/application/customization/captureCustomization.ts
@@ -17,10 +17,20 @@ import { stringifyConfig } from "../stringifyConfig";
 export type CaptureCustomizationInput = {
   readonly basePath: string;
   readonly filePrefix: string;
+  /**
+   * Opt-in path preservation for `pull`. Keyed by FILE basename (as produced by
+   * `remoteResourceName`), value is the existing local declared relative path.
+   * When a remote FILE's basename is present, its config path and download
+   * target adopt the declared path instead of the capture-normalized scheme.
+   * Unset (the `capture` command) keeps the current normalization (AC-8).
+   */
+  readonly preservePaths?: ReadonlyMap<string, string>;
 };
 
 export type CaptureCustomizationOutput = {
   readonly configText: string;
+  /** The config that was written, for callers that persist it as the new base. */
+  readonly config: CustomizationConfig;
   readonly hasExistingConfig: boolean;
   readonly fileResourceCount: number;
 };
@@ -97,6 +107,8 @@ function planResources(
   platformDir: string,
   resourceType: "js" | "css",
   relativeBaseDir: string,
+  contentBase: string,
+  preservePaths: ReadonlyMap<string, string> | undefined,
 ): PlanResult {
   const planned: CustomizationResource[] = [];
   const filesToDownload: PlannedFile[] = [];
@@ -111,14 +123,27 @@ function planResources(
         sanitizeFileName(resource.file.name),
         usedNames,
       );
-      const absolutePath = join(dir, fileName);
-      const relativePath = join(relativeBaseDir, resourceType, fileName);
-      planned.push({ type: "FILE", path: relativePath });
-      filesToDownload.push({
-        fileName,
-        fileKey: resource.file.fileKey,
-        absolutePath,
-      });
+      const declaredPath = preservePaths?.get(resource.file.name);
+      if (declaredPath !== undefined) {
+        // Preserve the existing local declared path: path is a local-owned
+        // concern, so keep it and resolve the download target against the same
+        // content base push uploads from (`join(basePath, filePrefix)`).
+        planned.push({ type: "FILE", path: declaredPath });
+        filesToDownload.push({
+          fileName,
+          fileKey: resource.file.fileKey,
+          absolutePath: join(contentBase, declaredPath),
+        });
+      } else {
+        const absolutePath = join(dir, fileName);
+        const relativePath = join(relativeBaseDir, resourceType, fileName);
+        planned.push({ type: "FILE", path: relativePath });
+        filesToDownload.push({
+          fileName,
+          fileKey: resource.file.fileKey,
+          absolutePath,
+        });
+      }
     }
   }
 
@@ -130,12 +155,14 @@ function planPlatform(
   platformName: string,
   basePath: string,
   filePrefix: string,
+  preservePaths: ReadonlyMap<string, string> | undefined,
 ): {
   platform: CustomizationPlatform;
   filesToDownload: readonly PlannedFile[];
   fileCount: number;
 } {
-  const platformDir = join(basePath, filePrefix, platformName);
+  const contentBase = join(basePath, filePrefix);
+  const platformDir = join(contentBase, platformName);
   const platformPrefix = platformName;
 
   const jsPlan = planResources(
@@ -143,12 +170,16 @@ function planPlatform(
     platformDir,
     "js",
     platformPrefix,
+    contentBase,
+    preservePaths,
   );
   const cssPlan = planResources(
     remotePlatform.css,
     platformDir,
     "css",
     platformPrefix,
+    contentBase,
+    preservePaths,
   );
 
   const fileCount =
@@ -198,12 +229,14 @@ export async function captureCustomization({
     "desktop",
     input.basePath,
     input.filePrefix,
+    input.preservePaths,
   );
   const mobilePlan = planPlatform(
     mobile,
     "mobile",
     input.basePath,
     input.filePrefix,
+    input.preservePaths,
   );
 
   const config: CustomizationConfig = {
@@ -226,6 +259,7 @@ export async function captureCustomization({
 
   return {
     configText,
+    config,
     hasExistingConfig: existing.exists,
     fileResourceCount: desktopPlan.fileCount + mobilePlan.fileCount,
   };

--- a/src/core/application/customization/captureCustomization.ts
+++ b/src/core/application/customization/captureCustomization.ts
@@ -26,7 +26,7 @@ export type CaptureCustomizationInput = {
    * `remoteResourceName`); the value is the existing local declared relative
    * path. When a remote FILE's key is present, its config path and download
    * target adopt the declared path instead of the capture-normalized scheme.
-   * Unset (the `capture` command) keeps the current normalization (AC-8).
+   * Unset (the `capture` command) keeps the current normalization.
    */
   readonly preservePaths?: ReadonlyMap<string, string>;
 };

--- a/src/core/application/customization/captureCustomization.ts
+++ b/src/core/application/customization/captureCustomization.ts
@@ -1,6 +1,7 @@
 import { basename, extname, join } from "node:path";
 import type { CustomizationConfig } from "@/core/domain/customization/entity";
 import { CustomizationConfigSerializer } from "@/core/domain/customization/services/configSerializer";
+import { resourceKey } from "@/core/domain/customization/services/customizationMerge";
 import type {
   CustomizationPlatform,
   CustomizationResource,
@@ -18,9 +19,12 @@ export type CaptureCustomizationInput = {
   readonly basePath: string;
   readonly filePrefix: string;
   /**
-   * Opt-in path preservation for `pull`. Keyed by FILE basename (as produced by
-   * `remoteResourceName`), value is the existing local declared relative path.
-   * When a remote FILE's basename is present, its config path and download
+   * Opt-in path preservation for `pull`. Keyed by the bucket-qualified identity
+   * `resourceKey(platform, category, FILE basename)` — the same identity the
+   * 3-way merge uses, so cross-bucket same-basename files stay distinct. The
+   * basename component is the remote FILE's `file.name` (as produced by
+   * `remoteResourceName`); the value is the existing local declared relative
+   * path. When a remote FILE's key is present, its config path and download
    * target adopt the declared path instead of the capture-normalized scheme.
    * Unset (the `capture` command) keeps the current normalization (AC-8).
    */
@@ -104,6 +108,7 @@ type PlanResult = {
 
 function planResources(
   resources: readonly RemoteResource[],
+  platformName: string,
   platformDir: string,
   resourceType: "js" | "css",
   relativeBaseDir: string,
@@ -123,7 +128,11 @@ function planResources(
         sanitizeFileName(resource.file.name),
         usedNames,
       );
-      const declaredPath = preservePaths?.get(resource.file.name);
+      // Match on the bucket-qualified identity so a remote FILE only adopts a
+      // preserved path from the same (platform, category) bucket.
+      const declaredPath = preservePaths?.get(
+        resourceKey(platformName, resourceType, resource.file.name),
+      );
       if (declaredPath !== undefined) {
         // Preserve the existing local declared path: path is a local-owned
         // concern, so keep it and resolve the download target against the same
@@ -167,6 +176,7 @@ function planPlatform(
 
   const jsPlan = planResources(
     remotePlatform.js,
+    platformName,
     platformDir,
     "js",
     platformPrefix,
@@ -175,6 +185,7 @@ function planPlatform(
   );
   const cssPlan = planResources(
     remotePlatform.css,
+    platformName,
     platformDir,
     "css",
     platformPrefix,

--- a/src/core/application/customization/pullCustomization.ts
+++ b/src/core/application/customization/pullCustomization.ts
@@ -12,6 +12,7 @@ import {
   resourceName,
 } from "@/core/domain/customization/services/diffDetector";
 import type {
+  CustomizationResource,
   LocalFileResource,
   RemoteCustomization,
 } from "@/core/domain/customization/valueObject";
@@ -69,14 +70,24 @@ export async function pullCustomization({
 
   if (input.force || state === undefined || local === undefined) {
     // Capture-equivalent: download remote file bodies, write config + files.
+    // When a local config exists (force, or state-loss recovery), preserve its
+    // declared FILE paths so `path` (a local-owned concern) survives the pull.
+    const preservePaths =
+      local !== undefined ? buildPreservePaths(local) : undefined;
     const captured = await captureCustomization({
       container,
-      input: { basePath: input.captureBasePath, filePrefix: input.filePrefix },
+      input: {
+        basePath: input.captureBasePath,
+        filePrefix: input.filePrefix,
+        preservePaths,
+      },
     });
     await container.customizationStorage.update(captured.configText);
+    // Persist the config we actually wrote as the new base (base == local),
+    // keeping pull symmetric with push instead of the basename-only remote view.
     await saveCustomizationSnapshotAndRevision(
       container,
-      remote.config,
+      captured.config,
       remote.revision,
     );
     return { mode: input.force ? "force" : "firstTime" };
@@ -183,11 +194,35 @@ export async function applyPulledCustomizationMerge({
     CustomizationConfigSerializer.serialize(merged),
   );
   await container.customizationStorage.update(configText);
+  // Base == the config we just wrote locally (declared paths), so a subsequent
+  // push sees no drift and `git diff` stays clean (push-symmetric).
   await saveCustomizationSnapshotAndRevision(
     container,
-    input.remoteConfig,
+    merged,
     input.remoteRevision,
   );
+}
+
+/**
+ * Builds the path-preservation map for `captureCustomization`: FILE basename →
+ * declared local relative path. Only FILE resources carry a path.
+ */
+function buildPreservePaths(
+  config: CustomizationConfig,
+): ReadonlyMap<string, string> {
+  const map = new Map<string, string>();
+  const add = (resources: readonly CustomizationResource[]) => {
+    for (const resource of resources) {
+      if (resource.type === "FILE") {
+        map.set(resourceName(resource), resource.path);
+      }
+    }
+  };
+  add(config.desktop.js);
+  add(config.desktop.css);
+  add(config.mobile.js);
+  add(config.mobile.css);
+  return map;
 }
 
 function allFileResources(config: CustomizationConfig): LocalFileResource[] {

--- a/src/core/application/customization/pullCustomization.ts
+++ b/src/core/application/customization/pullCustomization.ts
@@ -6,6 +6,7 @@ import {
   type CustomizationThreeWayMerge,
   computeCustomizationThreeWayMerge,
   resolveCustomizationMerge,
+  resourceKey,
 } from "@/core/domain/customization/services/customizationMerge";
 import {
   remoteResourceName,
@@ -204,24 +205,35 @@ export async function applyPulledCustomizationMerge({
 }
 
 /**
- * Builds the path-preservation map for `captureCustomization`: FILE basename →
- * declared local relative path. Only FILE resources carry a path.
+ * Builds the path-preservation map for `captureCustomization`: bucket-qualified
+ * key (`resourceKey(platform, category, FILE basename)`) → declared local
+ * relative path. The composite key matches the merge identity so cross-bucket
+ * same-basename files (e.g. `app/desktop/js/main.js` vs `app/mobile/js/main.js`)
+ * stay distinct instead of colliding under a flat basename map. Only FILE
+ * resources carry a path.
  */
 function buildPreservePaths(
   config: CustomizationConfig,
 ): ReadonlyMap<string, string> {
   const map = new Map<string, string>();
-  const add = (resources: readonly CustomizationResource[]) => {
+  const add = (
+    platform: string,
+    category: string,
+    resources: readonly CustomizationResource[],
+  ) => {
     for (const resource of resources) {
       if (resource.type === "FILE") {
-        map.set(resourceName(resource), resource.path);
+        map.set(
+          resourceKey(platform, category, resourceName(resource)),
+          resource.path,
+        );
       }
     }
   };
-  add(config.desktop.js);
-  add(config.desktop.css);
-  add(config.mobile.js);
-  add(config.mobile.css);
+  add("desktop", "js", config.desktop.js);
+  add("desktop", "css", config.desktop.css);
+  add("mobile", "js", config.mobile.js);
+  add("mobile", "css", config.mobile.css);
   return map;
 }
 

--- a/src/core/application/pullAll/__tests__/pullAllForApp.test.ts
+++ b/src/core/application/pullAll/__tests__/pullAllForApp.test.ts
@@ -298,3 +298,25 @@ describe("pullAllForApp — 早期スキップの安全性（W-app-002）", () =
     ).toBe(false);
   });
 });
+
+/**
+ * `pullCustomization` is fully mocked here, so this layer cannot observe the
+ * Fix B state (base == local) — that behavior is verified in pullCustomization's
+ * own usecase tests. Here we only pin the wiring: customize delegates with
+ * `force: false` (so only Fix A/B, never the force-only Fix C, apply via pullAll).
+ */
+describe("pullAllForApp — customize 配線（Issue #205）", () => {
+  it("customize は force:false で pullCustomization に委譲する", async () => {
+    vi.mocked(getCurrentRemoteRevision).mockResolvedValue("101");
+    vi.mocked(loadAppRevision).mockResolvedValue({ revision: "100" });
+    mockAllPullsForce();
+
+    await pullAllForApp(makeArgs());
+
+    expect(pullCustomization).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({ force: false }),
+      }),
+    );
+  });
+});

--- a/src/core/application/pullAll/__tests__/pullAllForApp.test.ts
+++ b/src/core/application/pullAll/__tests__/pullAllForApp.test.ts
@@ -301,9 +301,8 @@ describe("pullAllForApp — 早期スキップの安全性（W-app-002）", () =
 
 /**
  * `pullCustomization` is fully mocked here, so this layer cannot observe the
- * Fix B state (base == local) — that behavior is verified in pullCustomization's
- * own usecase tests. Here we only pin the wiring: customize delegates with
- * `force: false` (so only Fix A/B, never the force-only Fix C, apply via pullAll).
+ * base == local behavior — that is verified in pullCustomization's own usecase
+ * tests. Here we only pin the wiring: customize delegates with `force: false`.
  */
 describe("pullAllForApp — customize 配線（Issue #205）", () => {
   it("customize は force:false で pullCustomization に委譲する", async () => {

--- a/src/core/domain/customization/services/__tests__/customizationMerge.test.ts
+++ b/src/core/domain/customization/services/__tests__/customizationMerge.test.ts
@@ -10,6 +10,10 @@ function file(name: string): CustomizationResource {
   return { type: "FILE", path: name };
 }
 
+function fileAt(path: string): CustomizationResource {
+  return { type: "FILE", path };
+}
+
 function pathOf(r: CustomizationResource): string {
   return r.type === "FILE" ? r.path : r.url;
 }
@@ -171,5 +175,59 @@ describe("resolveCustomizationMerge", () => {
     expect(() =>
       resolveCustomizationMerge(merge, new Map(), local, remote),
     ).toThrow();
+  });
+
+  it("keeps the local declared path for an unchanged entry (path is local-owned)", () => {
+    // base/remote carry the basename path (state/remote view); local declares a
+    // nested build-output path with the same basename.
+    const base = cfg([file("a.js")]);
+    const local = cfg([fileAt("app/desktop/js/a.js")]);
+    const remote = cfg([file("a.js")]);
+    const merge = computeCustomizationThreeWayMerge(
+      base,
+      local,
+      remote,
+      NO_MODIFIED,
+    );
+    const result = resolveCustomizationMerge(merge, new Map(), local, remote);
+    expect(result.desktop.js.map(pathOf)).toEqual(["app/desktop/js/a.js"]);
+  });
+
+  it("keeps the local declared path even when a conflict is resolved to remote", () => {
+    const base = cfg([file("a.js")]);
+    const local = cfg([fileAt("app/desktop/js/a.js")]);
+    const remote = cfg([file("a.js")]);
+    const merge = computeCustomizationThreeWayMerge(
+      base,
+      local,
+      remote,
+      new Set(["a.js"]),
+    );
+    const result = resolveCustomizationMerge(
+      merge,
+      new Map([["desktop:js:a.js", "remote"]]),
+      local,
+      remote,
+    );
+    // content-source is remote, but path stays the local declared path.
+    expect(result.desktop.js.map(pathOf)).toEqual(["app/desktop/js/a.js"]);
+  });
+
+  it("uses the remote basename path only for a remote-only entry", () => {
+    const base = cfg([file("a.js")]);
+    const local = cfg([fileAt("app/desktop/js/a.js")]);
+    const remote = cfg([file("a.js"), file("c.js")]);
+    const merge = computeCustomizationThreeWayMerge(
+      base,
+      local,
+      remote,
+      NO_MODIFIED,
+    );
+    const result = resolveCustomizationMerge(merge, new Map(), local, remote);
+    // existing entry keeps its nested path; new remote-only file uses basename.
+    expect(result.desktop.js.map(pathOf)).toEqual([
+      "app/desktop/js/a.js",
+      "c.js",
+    ]);
   });
 });

--- a/src/core/domain/customization/services/customizationMerge.ts
+++ b/src/core/domain/customization/services/customizationMerge.ts
@@ -183,6 +183,11 @@ export function resolveCustomizationMerge(
  * Rebuilds the config from the chosen resource keys, ordering each bucket by the
  * resource's position in local first, then any remote-only resources, so the
  * resulting list is stable and matches the user's local ordering intent.
+ *
+ * `path` is a local-owned concern (the build-output location) that is orthogonal
+ * to which content wins the merge: whenever a key exists locally, the local
+ * resource (its declared path) is kept regardless of the chosen content side.
+ * Only remote-only keys fall back to the chosen (remote/basename) resource.
  */
 function rebuild(
   chosen: Map<string, CustomizationResource>,
@@ -196,13 +201,20 @@ function rebuild(
   ): CustomizationResource[] {
     const seen = new Set<string>();
     const out: CustomizationResource[] = [];
+    const localByKey = new Map<string, CustomizationResource>();
+    for (const resource of platformList(local, platform, category)) {
+      localByKey.set(
+        resourceKey(platform, category, resourceName(resource)),
+        resource,
+      );
+    }
     const append = (resources: readonly CustomizationResource[]) => {
       for (const resource of resources) {
         const key = resourceKey(platform, category, resourceName(resource));
         if (seen.has(key)) continue;
         const picked = chosen.get(key);
         if (picked !== undefined) {
-          out.push(picked);
+          out.push(localByKey.get(key) ?? picked);
           seen.add(key);
         }
       }

--- a/src/core/domain/customization/services/customizationMerge.ts
+++ b/src/core/domain/customization/services/customizationMerge.ts
@@ -57,9 +57,14 @@ const PLATFORMS: readonly Platform[] = ["desktop", "mobile"];
 const CATEGORIES: readonly Category[] = ["js", "css"];
 const SCOPE_KEY = "config:scope";
 
-function resourceKey(
-  platform: Platform,
-  category: Category,
+/**
+ * Bucket-qualified resource identity: `platform:category:name`. Shared with the
+ * force/firstTime pull path (`preservePaths`) so path preservation matches the
+ * merge on the same identity and cross-bucket same-basename files stay distinct.
+ */
+export function resourceKey(
+  platform: string,
+  category: string,
   name: string,
 ): string {
   return `${platform}:${category}:${name}`;


### PR DESCRIPTION
## Summary
- `customize pull`（`--force` 含む）が既存 customize.yaml エントリの `path:` プレフィックス（`<アプリ名>/`）を剥がして single-nest 化してしまう問題を修正
- path（配置先＝local 固有の関心事）と content-source（local 据え置き / remote 再ダウンロード）を直交概念として分離し、path の source of truth を local に固定
- **Fix A**（domain）: `customizationMerge.rebuild` を「選択キーが local に存在すれば local の宣言 path を採用、remoteOnly のみ chosen」に是正
- **Fix B**（usecase）: pull の state 保存を local と一致させる（`applyPulledCustomizationMerge` は `merged`、force 経路は `captured.config`）→ base==local
- **Fix C**（usecase）: `captureCustomization` に opt-in の `preservePaths` を追加し、force 経路で既存 path を保持しつつ content を double-nest 位置へ download。`config` オブジェクトも返却
- レビュー B-001 対応: `preservePaths` の照合キーを `resourceKey(platform, category, name)` の複合キーに揃え、desktop/mobile 同名 basename の cross-bucket 衝突を解消
- これにより push とパス解決が一致し、`pull → push` / `pull → pull` が path について冪等になる

## Issue
Closes #205

## Implementation Plan
Based on `.issue/205/plan.md`（2視点並列レビュー3周で収束）。設計判断は `.issue/205/adr.md`（ADR-001〜004）。

## Test plan

### デプロイ・動作確認方法
CLI ツール（Web UI なし）。中核は自動テストで担保。

```bash
pnpm typecheck
pnpm lint:fix
pnpm format
pnpm test
```

end-to-end（kintone 認証情報が設定済みのプロジェクトでのみ）:

```bash
pnpm dev customize pull --app "<アプリ名>" --force   # force 経路
pnpm dev customize pull --app "<アプリ名>"            # 3-way merge 経路
```

### 確認項目
- force pull で local / state customize.yaml の `path:` が保持され、content が double-nest 位置へ落ちる（AC-1〜3）
- 非 force pull（unchanged / conflict→remote）で既存エントリの path が保持される（AC-4, AC-5）
- `pull → push` で drift 非発火・path 無傷、`pull → pull` 冪等（AC-6, AC-7）
- state 喪失からの復旧ケースで path 保持（AC-9）
- capture コマンド単体の path 正規化は不変（AC-8）
- pull/push のパス解決基底一致の不変条件（AC-10）
- cross-bucket 同名 basename（desktop/mobile の main.js/style.css）の force pull で path 衝突なし（レビュー B-001 リグレッション）

新規/更新テスト全緑（customize 関連 165 tests passed、全体 2861 tests passed）。

## Browser Verification
スキップ理由: CLI ツールで Web UI が存在しない（UI ファイル `*.html/*.tsx/*.jsx/*.vue/*.svelte` 不在、UI フレームワーク依存なし、`package.json` の dev/start は CLI 実行、testing.md に画面操作項目ゼロ を確認）。動作確認は自動テスト（Vitest 2861 件緑）＋ Test plan の CLI 手順で担保。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
